### PR TITLE
Extending from AbstractController in controller skeletons

### DIFF
--- a/src/Resources/skeleton/controller/Controller.php.txt
+++ b/src/Resources/skeleton/controller/Controller.php.txt
@@ -3,10 +3,10 @@
 namespace App\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 
-class {{ controller_class_name }} extends Controller
+class {{ controller_class_name }} extends AbstractController
 {
     /**
      * @Route("{{ route_path }}", name="{{ route_name }}")

--- a/src/Resources/skeleton/controller/ControllerWithTwig.php.txt
+++ b/src/Resources/skeleton/controller/ControllerWithTwig.php.txt
@@ -3,10 +3,10 @@
 namespace App\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 
-class {{ controller_class_name }} extends Controller
+class {{ controller_class_name }} extends AbstractController
 {
     /**
      * @Route("{{ route_path }}", name="{{ route_name }}")


### PR DESCRIPTION
> https://symfony.com/doc/master/best_practices/controllers.html#controllers
> [Best Practice] Make your controller extend the `AbstractController` base controller provided by Symfony and use annotations to configure routing, caching and security whenever possible.

> https://symfony.com/doc/master/best_practices/controllers.html#fetching-services
> [Best Practice] Don't use `$this->get()` or `$this->container->get()` to fetch services from the container. Instead, use dependency injection.