### PR TITLE
Validating empty arguments

### DIFF
--- a/src/Command/MakeCommandCommand.php
+++ b/src/Command/MakeCommandCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -38,6 +39,10 @@ final class MakeCommandCommand extends AbstractCommand
     protected function getParameters(): array
     {
         $commandName = trim($this->input->getArgument('name'));
+        if(empty($commandName)) {
+            throw new RuntimeCommandException("You must provide the name of the command you want to create");
+        }
+
         $commandClassName = Str::asClassName($commandName, 'Command');
         Validator::validateClassName($commandClassName, sprintf('The "%s" command name is not valid because it would be implemented by "%s" class, which is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores).', $commandName, $commandClassName));
 

--- a/src/Command/MakeControllerCommand.php
+++ b/src/Command/MakeControllerCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
@@ -49,7 +50,12 @@ final class MakeControllerCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $controllerClassName = Str::asClassName($this->input->getArgument('controller-class'), 'Controller');
+        $controllerName = $this->input->getArgument('controller-class');
+        if(empty($controllerName)) {
+            throw new RuntimeCommandException("You must provide the name of the controller you want to create");
+        }
+
+        $controllerClassName = Str::asClassName($controllerName, 'Controller');
         Validator::validateClassName($controllerClassName);
 
         return [

--- a/src/Command/MakeEntityCommand.php
+++ b/src/Command/MakeEntityCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -37,7 +38,12 @@ final class MakeEntityCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $entityClassName = Str::asClassName($this->input->getArgument('entity-class'));
+        $entityName = $this->input->getArgument('entity-class');
+        if(empty($entityName)) {
+            throw new RuntimeCommandException("You must provide the name of the entity you want to create");
+        }
+
+        $entityClassName = Str::asClassName($entityName);
         Validator::validateClassName($entityClassName);
         $entityAlias = strtolower($entityClassName[0]);
         $repositoryClassName = Str::addSuffix($entityClassName, 'Repository');

--- a/src/Command/MakeFormCommand.php
+++ b/src/Command/MakeFormCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -38,7 +39,12 @@ final class MakeFormCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $formClassName = Str::asClassName($this->input->getArgument('name'), 'Type');
+        $formName = $this->input->getArgument('name');
+        if(empty($formName)) {
+            throw new RuntimeCommandException("You must provide the name of the form you want to create");
+        }
+
+        $formClassName = Str::asClassName($formName, 'Type');
         Validator::validateClassName($formClassName);
         $entityClassName = Str::removeSuffix($formClassName, 'Type');
 

--- a/src/Command/MakeFunctionalTestCommand.php
+++ b/src/Command/MakeFunctionalTestCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -36,7 +37,12 @@ class MakeFunctionalTestCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $testClassName = Str::asClassName($this->input->getArgument('name'), 'Test');
+        $testName = $this->input->getArgument('name');
+        if(empty($testName)) {
+            throw new RuntimeCommandException("You must provide the name of the test you want to create");
+        }
+
+        $testClassName = Str::asClassName($testName, 'Test');
         Validator::validateClassName($testClassName);
 
         return [

--- a/src/Command/MakeSubscriberCommand.php
+++ b/src/Command/MakeSubscriberCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\EventRegistry;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
@@ -69,9 +70,20 @@ final class MakeSubscriberCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $subscriberClassName = Str::asClassName($this->input->getArgument('name'), 'Subscriber');
+        $subscriberName = $this->input->getArgument('name');
+
+        if(empty($subscriberName)) {
+            throw new RuntimeCommandException("You must provide the name of the subscriber you want to create");
+        }
+
+        $subscriberClassName = Str::asClassName($subscriberName, 'Subscriber');
         Validator::validateClassName($subscriberClassName);
+
         $event = $this->input->getArgument('event');
+        if(empty($event)) {
+            throw new RuntimeCommandException("You must provide the name of the event you want to subscribe to");
+        }
+
         $eventClass = $this->eventRegistry->getEventClassName($event);
         $eventShortName = null;
         if ($eventClass) {

--- a/src/Command/MakeUnitTestCommand.php
+++ b/src/Command/MakeUnitTestCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -36,7 +37,12 @@ final class MakeUnitTestCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $testClassName = Str::asClassName($this->input->getArgument('name'), 'Test');
+        $name = $this->input->getArgument('name');
+        if(empty($name)) {
+            throw new RuntimeCommandException("You must provide the name of the unit test you want to create");
+        }
+
+        $testClassName = Str::asClassName($name, 'Test');
         Validator::validateClassName($testClassName);
 
         return [

--- a/src/Command/MakeValidatorCommand.php
+++ b/src/Command/MakeValidatorCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -37,7 +38,12 @@ final class MakeValidatorCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $validatorClassName = Str::asClassName($this->input->getArgument('name'), 'Validator');
+        $name = $this->input->getArgument('name');
+        if(empty($name)) {
+            throw new RuntimeCommandException("You must provide the name of the validator you want to create");
+        }
+
+        $validatorClassName = Str::asClassName($name, 'Validator');
         Validator::validateClassName($validatorClassName);
         $constraintClassName = Str::removeSuffix($validatorClassName, 'Validator');
 

--- a/src/Command/MakeVoterCommand.php
+++ b/src/Command/MakeVoterCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -37,7 +38,12 @@ final class MakeVoterCommand extends AbstractCommand
 
     protected function getParameters(): array
     {
-        $voterClassName = Str::asClassName($this->input->getArgument('name'), 'Voter');
+        $name = $this->input->getArgument('name');
+        if(empty($name)) {
+            throw new RuntimeCommandException("You must provide the name of the voter you want to create");
+        }
+
+        $voterClassName = Str::asClassName($name, 'Voter');
         Validator::validateClassName($voterClassName);
 
         return [


### PR DESCRIPTION
Right now almost all commands are throwing errors if the `name` argument is empty.
This small PR adds validation to every command to check for empty values.

(#SymfonyConHackday2017)