### PR TITLE
Invocation paramter type are not compatible with declared

### DIFF
--- a/src/Command/MakeCommandCommand.php
+++ b/src/Command/MakeCommandCommand.php
@@ -64,8 +64,9 @@ final class MakeCommandCommand extends AbstractCommand
 
     protected function configureDependencies(DependencyBuilder $dependencies)
     {
-        $dependencies->addClassDependency(Command::class, [
+        $dependencies->addClassDependency(
+            Command::class,
             'console'
-        ]);
+        );
     }
 }


### PR DESCRIPTION
> Expected string, got array.