### PR TITLE
Fixing MakeCommandCommand dependency configuration.

### DIFF
--- a/src/Command/MakeCommandCommand.php
+++ b/src/Command/MakeCommandCommand.php
@@ -64,8 +64,9 @@ final class MakeCommandCommand extends AbstractCommand
 
     protected function configureDependencies(DependencyBuilder $dependencies)
     {
-        $dependencies->addClassDependency(Command::class, [
-            'console'
-        ]);
+        $dependencies->addClassDependency(
+          Command::class,
+          'console'
+        );
     }
 }


### PR DESCRIPTION
In `src/Command/MakeCommandCommand.php` second argument for class dependency is passed as array what causes an error when dependency is missing in `src/Command/AbstractCommand.php:87`.

This PR should fix that in `src/Command/MakeCommandCommand.php`.