### PR TITLE
Improving error message style on invalid class name

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle;
 
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
@@ -22,7 +24,7 @@ class Validator
         if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $className)) {
             $errorMessage = $errorMessage ?: sprintf('"%s" is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores)', $className);
 
-            throw new \RuntimeException($errorMessage);
+            throw new RuntimeCommandException($errorMessage);
         }
     }
 }


### PR DESCRIPTION
**before**
![invalid-class-name-bad](https://user-images.githubusercontent.com/2028198/33103664-a044d53c-cef1-11e7-985c-33e36e0d28a7.png)

**after**
![valid-class-name-good](https://user-images.githubusercontent.com/2028198/33103682-b87b10ee-cef1-11e7-9bfc-4c0b51889f1c.png)

