### PR TITLE
[EntityGenerator] add the support of ApiPlatform

### DIFF
--- a/src/Command/MakeEntityCommand.php
+++ b/src/Command/MakeEntityCommand.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -31,6 +32,7 @@ final class MakeEntityCommand extends AbstractCommand
         $this
             ->setDescription('Creates a new Doctrine entity class')
             ->addArgument('entity-class', InputArgument::OPTIONAL, sprintf('The class name of the entity to create (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addOption('with-api', 'api', InputOption::VALUE_OPTIONAL, sprintf('The class will be used in ApiPlatform.'), false)
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeEntity.txt'))
         ;
     }
@@ -46,13 +48,14 @@ final class MakeEntityCommand extends AbstractCommand
             'entity_class_name' => $entityClassName,
             'entity_alias' => $entityAlias,
             'repository_class_name' => $repositoryClassName,
+            'api_platform' => $this->input->hasOption('with-api') ? 'Api' : ''
         ];
     }
 
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/doctrine/Entity.php.txt' => 'src/Entity/'.$params['entity_class_name'].'.php',
+            __DIR__.'/../Resources/skeleton/doctrine/Entity'.$params['api_platform'].'.php.txt' => 'src/Entity/'.$params['entity_class_name'].'.php',
             __DIR__.'/../Resources/skeleton/doctrine/Repository.php.txt' => 'src/Repository/'.$params['repository_class_name'].'.php',
         ];
     }
@@ -72,6 +75,12 @@ final class MakeEntityCommand extends AbstractCommand
 
     protected function configureDependencies(DependencyBuilder $dependencies)
     {
+        if ($this->input->hasOption('with-api') && true === $this->input->getOption('with-api')) {
+           $dependencies->addClassDependency(
+               'ApiPlatform\Core\Annotation\ApiResource',
+               'api'
+           );
+        }
         $dependencies->addClassDependency(
             Column::class,
             'orm'

--- a/src/Resources/skeleton/doctrine/EntityApi.php.txt
+++ b/src/Resources/skeleton/doctrine/EntityApi.php.txt
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource
+ * @ORM\Entity(repositoryClass="App\Repository\{{ repository_class_name }}")
+ */
+class {{ entity_class_name }}
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    // add your own fields
+}


### PR DESCRIPTION
I would like to add the support of ApiPlatform in maker, since api-platform is already in the recipes of flex.
![dsc_0003](https://user-images.githubusercontent.com/3451634/33113583-5bcb8316-cf59-11e7-8a25-946a8a829048.JPG)
(PRception)
