### PR TITLE
Add @ORM\Table by default

### DIFF
--- a/src/Resources/skeleton/doctrine/Entity.php.txt
+++ b/src/Resources/skeleton/doctrine/Entity.php.txt
@@ -6,6 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\{{ repository_class_name }}")
+ * @ORM\Table()
  */
 class {{ entity_class_name }}
 {


### PR DESCRIPTION
I think having it is better. When a user later needs to add indexes, or (for some reason) wants to control the table name, it's there waiting for them.