### PR TITLE
make:entity: Removing overridden __construct in repository

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.php.txt
+++ b/src/Resources/skeleton/doctrine/Repository.php.txt
@@ -4,16 +4,9 @@ namespace App\Repository;
 
 use App\Entity\{{ entity_class_name }};
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Query;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 
 class {{ repository_class_name }} extends ServiceEntityRepository
 {
-    public function __construct(RegistryInterface $registry)
-    {
-        parent::__construct($registry, {{ entity_class_name }}::class);
-    }
-
     /*
     public function findBySomething($value)
     {


### PR DESCRIPTION
You don't need this. You will only need to override the constructor if you need to add dependencies. And while showing parent::__construct() is useful for that situation, we should actually recommend against doing this (you shouldn't normally need extra deps in your repository class)