### PR TITLE
Add supports to override skeleton templates

### DIFF
--- a/src/Command/MakeCommandCommand.php
+++ b/src/Command/MakeCommandCommand.php
@@ -50,7 +50,7 @@ final class MakeCommandCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/command/Command.php.txt' => 'src/Command/'.$params['command_class_name'].'.php',
+            'command/Command.php.txt' => 'src/Command/'.$params['command_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeControllerCommand.php
+++ b/src/Command/MakeControllerCommand.php
@@ -64,7 +64,7 @@ final class MakeControllerCommand extends AbstractCommand
         $skeletonFile = $this->isTwigInstalled() ? 'ControllerWithTwig.php.txt' : 'Controller.php.txt';
 
         return [
-            __DIR__.'/../Resources/skeleton/controller/'.$skeletonFile => 'src/Controller/'.$params['controller_class_name'].'.php',
+            'controller/'.$skeletonFile => 'src/Controller/'.$params['controller_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeEntityCommand.php
+++ b/src/Command/MakeEntityCommand.php
@@ -52,8 +52,8 @@ final class MakeEntityCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/doctrine/Entity.php.txt' => 'src/Entity/'.$params['entity_class_name'].'.php',
-            __DIR__.'/../Resources/skeleton/doctrine/Repository.php.txt' => 'src/Repository/'.$params['repository_class_name'].'.php',
+            'doctrine/Entity.php.txt' => 'src/Entity/'.$params['entity_class_name'].'.php',
+            'doctrine/Repository.php.txt' => 'src/Repository/'.$params['repository_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeFormCommand.php
+++ b/src/Command/MakeFormCommand.php
@@ -51,7 +51,7 @@ final class MakeFormCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/form/Type.php.txt' => 'src/Form/'.$params['form_class_name'].'.php',
+            'form/Type.php.txt' => 'src/Form/'.$params['form_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeFunctionalTestCommand.php
+++ b/src/Command/MakeFunctionalTestCommand.php
@@ -47,7 +47,7 @@ class MakeFunctionalTestCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/test/Functional.php.txt' => 'tests/'.$params['test_class_name'].'.php',
+            'test/Functional.php.txt' => 'tests/'.$params['test_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeSubscriberCommand.php
+++ b/src/Command/MakeSubscriberCommand.php
@@ -91,7 +91,7 @@ final class MakeSubscriberCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/event/Subscriber.php.txt' => 'src/EventSubscriber/'.$params['subscriber_class_name'].'.php',
+            'event/Subscriber.php.txt' => 'src/EventSubscriber/'.$params['subscriber_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeTwigExtensionCommand.php
+++ b/src/Command/MakeTwigExtensionCommand.php
@@ -48,7 +48,7 @@ final class MakeTwigExtensionCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/twig/Extension.php.txt' => 'src/Twig/'.$params['extension_class_name'].'.php',
+            'twig/Extension.php.txt' => 'src/Twig/'.$params['extension_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeUnitTestCommand.php
+++ b/src/Command/MakeUnitTestCommand.php
@@ -47,7 +47,7 @@ final class MakeUnitTestCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/test/Unit.php.txt' => 'tests/'.$params['test_class_name'].'.php',
+            'test/Unit.php.txt' => 'tests/'.$params['test_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeValidatorCommand.php
+++ b/src/Command/MakeValidatorCommand.php
@@ -50,8 +50,8 @@ final class MakeValidatorCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/validator/Validator.php.txt' => 'src/Validator/Constraints/'.$params['validator_class_name'].'.php',
-            __DIR__.'/../Resources/skeleton/validator/Constraint.php.txt' => 'src/Validator/Constraints/'.$params['constraint_class_name'].'.php',
+            'validator/Validator.php.txt' => 'src/Validator/Constraints/'.$params['validator_class_name'].'.php',
+            'validator/Constraint.php.txt' => 'src/Validator/Constraints/'.$params['constraint_class_name'].'.php',
         ];
     }
 

--- a/src/Command/MakeVoterCommand.php
+++ b/src/Command/MakeVoterCommand.php
@@ -48,7 +48,7 @@ final class MakeVoterCommand extends AbstractCommand
     protected function getFiles(array $params): array
     {
         return [
-            __DIR__.'/../Resources/skeleton/security/Voter.php.txt' => 'src/Security/Voter/'.$params['voter_class_name'].'.php',
+            'security/Voter.php.txt' => 'src/Security/Voter/'.$params['voter_class_name'].'.php',
         ];
     }
 

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\DependencyInjection;
 
+use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -30,5 +31,7 @@ class MakerExtension extends Extension
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        $container->getDefinition(FileManager::class)->replaceArgument(1, $container->getParameter('kernel.root_dir'));
     }
 }

--- a/tests/Fixtures/src/Resources/MakerBundle/skeleton/controller/Controller.php.txt
+++ b/tests/Fixtures/src/Resources/MakerBundle/skeleton/controller/Controller.php.txt
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Route("{{ route_path }}", name="{{ route_name }}")
+ */
+class {{ controller_class_name }}
+{
+    public function __invoke()
+    {
+        return new Response('Welcome to your new controller!');
+    }
+}


### PR DESCRIPTION
This allows us to load skeleton templates relative to:
* <del>`%kernel.project_dir%/config/maker/skeleton/`<del>
* `%kernel.root_dir%/Resources/MakerBundle/skeleton/` (overriding dir convention)
* `Resources/skeleton/` (from MakerBundle)

Thus we would have a simple mechanism to override all or one template without create/override the whole command and vice versa, this allows us to reuse the MakerBundle skeletons in our custom commands by passing the relative template name.

Fixes #33 

What do you think?