### PR TITLE
[RFC] Generate UnitTest from file path instead of class name?

### DIFF
--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\DependencyInjection;
 
+use Symfony\Bundle\MakerBundle\Command\MakeUnitTestCommand;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -30,5 +31,7 @@ class MakerExtension extends Extension
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        $container->getDefinition(MakeUnitTestCommand::class)->setArgument('$projectDir', $container->getParameter('kernel.project_dir'));
     }
 }

--- a/src/Resources/skeleton/test/Unit.php.txt
+++ b/src/Resources/skeleton/test/Unit.php.txt
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests;
+namespace {{ test_namespace }};
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Command/FunctionalTest.php
+++ b/tests/Command/FunctionalTest.php
@@ -160,10 +160,18 @@ class FunctionalTest extends TestCase
         ];
 
         $commands['unit_test'] = [
-            new MakeUnitTestCommand($generator),
+            new MakeUnitTestCommand($generator, __DIR__.'/../Fixtures'),
             [
                 // class name
                 'FooBar'
+            ]
+        ];
+
+        $commands['unit_test_filename'] = [
+            new MakeUnitTestCommand($generator, __DIR__.'/../Fixtures'),
+            [
+                // relative path to the file
+                'src/Security/Voter/FooVoter.php'
             ]
         ];
 

--- a/tests/Fixtures/src/Security/Voter/FooVoter.php
+++ b/tests/Fixtures/src/Security/Voter/FooVoter.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Security\Voter;
+
+class FooVoter
+{
+}


### PR DESCRIPTION
Most of the time (almost always I think) running `make:unit-test <class-name>` would require to move the generated test file to the right directory and change its namespace according to the best practice:
> By convention, the `tests/` directory should replicate the directory of your bundle for unit tests. So, if you're testing a class in the `src/Util/` directory, put the test in the `tests/Util/` directory.

My proposal (with shell auto-completation <3):
```bash
./bin/console make:unit-test src/Security/Voter/FooVoter.php
```
This would generate the file in `tests/Security/Voter/FooVoterTest.php` with namespace `App\Tests\Security\Voter`.

For now, it's optional and still one can to pass the class name, but probably the proposed one should be the only way IMHO.

What do you think?
