### PR TITLE
Docs syntax consistency fix.

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -83,12 +83,12 @@ class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
 
         public function getParameters(InputInterface $input): array
         {
-            return array();
+            return [];
         }
 
         public function getFiles(array $params): array
         {
-            return array();
+            return [];
         }
 
         public function writeNextStepsMessage(array $params, ConsoleStyle $io): void


### PR DESCRIPTION
Referencing #72 for syntax consistency between docs and code.