### PR TITLE
Docs ammends for example class

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -46,84 +46,9 @@ Creating your Own Makers
 
 In case your applications need to generate custom boilerplate code, you can
 create your own ``make:...`` command reusing the tools provided by this bundle.
-Imagine that you need to create a ``make:report`` command. First, create a
-class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
-
-    // src/Maker/ReportMaker.php
-    namespace App\Maker;
-
-    use Symfony\Bundle\MakerBundle\ConsoleStyle;
-    use Symfony\Bundle\MakerBundle\DependencyBuilder;
-    use Symfony\Bundle\MakerBundle\InputConfiguration;
-    use Symfony\Bundle\MakerBundle\MakerInterface;
-    use Symfony\Bundle\MakerBundle\Str;
-    use Symfony\Bundle\MakerBundle\Validator;
-    use Symfony\Component\Console\Command\Command;
-    use Symfony\Component\Console\Input\InputArgument;
-    use Symfony\Component\Console\Input\InputInterface;
-
-    class ReportMaker implements MakerInterface
-    {
-        public static function getCommandName(): string
-        {
-            return 'make:report';
-        }
-
-        public function configureCommand(Command $command, InputConfiguration $inputConf)
-        {
-            $command
-                ->setDescription('Creates a new report')
-                ->addArgument('name', InputArgument::OPTIONAL, 'Choose a class name for your report (e.g. <fg=yellow>PdfReport</>).')
-                ->addArgument('format', InputArgument::OPTIONAL, 'Choose the report format', 'pdf')
-            ;
-        }
-
-        public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-        {
-        }
-
-        public function getParameters(InputInterface $input): array
-        {
-            $reportClassName = Str::asClassName($input->getArgument('name'), 'Report');
-            Validator::validateClassName($reportClassName);
-            $format = $input->getArgument('format');
-            
-            return [
-                'report_class_name' => $reportClassName,
-                'format' => $format,
-            ];
-        }
-
-        public function getFiles(array $params): array
-        {
-            return [
-                __DIR__.'/../Resources/skeleton/report/Report.tpl.php' => 'src/Report/'.$params['report_class_name'].'.php',
-            ];
-        }
-
-        public function writeNextStepsMessage(array $params, ConsoleStyle $io)
-        {
-            $io->text([
-                'Next: Open your new report and start customizing it.',
-            ]);
-        }
-
-        public function configureDependencies(DependencyBuilder $dependencies)
-        {
-        }
-    }
-
-Second, create your template that will be filled with data from your command::
-
-    // src/Resources/skeleton/report/Report.tpl.php
-    <?= "<?php\n" ?>
-
-    namespace App\Report;
-    
-    class <?= $report_class_name ?>
-    {
-        public const FORMAT = '<?= $format ?>';
-    }
+To do that, you should create a class that implements
+:class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`:: in your `src/Maker`
+directory. And this is really it!
 
 For examples of how to complete your new maker command, see the `core maker commands`_.
 Make sure your class is registered as a service and tagged with ``maker.command``.

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -47,7 +47,7 @@ Creating your Own Makers
 In case your applications need to generate custom boilerplate code, you can
 create your own ``make:...`` command reusing the tools provided by this bundle.
 To do that, you should create a class that implements
-:class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`:: in your `src/Maker`
+:class:`Symfony\\Bundle\\MakerBundle\\MakerInterface` in your ``src/Maker/``
 directory. And this is really it!
 
 For examples of how to complete your new maker command, see the `core maker commands`_.

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -73,7 +73,8 @@ class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
         {
             $command
                 ->setDescription('Creates a new report')
-                ->addArgument('name', InputArgument::OPTIONAL, 'Choose the report format', 'pdf')
+                ->addArgument('name', InputArgument::OPTIONAL, 'Choose a class name for your report (e.g. <fg=yellow>PdfReport</>).')
+                ->addArgument('format', InputArgument::OPTIONAL, 'Choose the report format', 'pdf')
             ;
         }
 
@@ -83,16 +84,28 @@ class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
 
         public function getParameters(InputInterface $input): array
         {
-            return [];
+            $reportClassName = Str::asClassName($input->getArgument('name'), 'Report');
+            Validator::validateClassName($reportClassName);
+            $format = $input->getArgument('format');
+            
+            return [
+                'report_class_name' => $reportClassName,
+                'format' => $format,
+            ];
         }
 
         public function getFiles(array $params): array
         {
-            return [];
+            return [
+                __DIR__.'/../Resources/skeleton/report/Report.tpl.php' => 'src/Report/'.$params['report_class_name'].'.php',
+            ];
         }
 
         public function writeNextStepsMessage(array $params, ConsoleStyle $io): void
         {
+            $io->text([
+                'Next: Open your new report and start customizing it.',
+            ]);
         }
 
         public function configureDependencies(DependencyBuilder $dependencies): void
@@ -100,7 +113,19 @@ class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
         }
     }
 
-For examples of how to complete this class, see the `core maker commands`_.
+Second, create your template that will be filled with data from your command::
+
+    // src/Resources/skeleton/report/Report.tpl.php
+    <?= "<?php\n" ?>
+
+    namespace App\Report;
+    
+    class <?= $report_class_name ?>
+    {
+        public const FORMAT = '<?= $format ?>';
+    }
+
+For examples of how to complete your new maker command, see the `core maker commands`_.
 Make sure your class is registered as a service and tagged with ``maker.command``.
 If you're using the standard Symfony ``services.yaml`` configuration, this
 will be done automatically.

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -69,7 +69,7 @@ class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
             return 'make:report';
         }
 
-        public function configureCommand(Command $command, InputConfiguration $inputConf): void
+        public function configureCommand(Command $command, InputConfiguration $inputConf)
         {
             $command
                 ->setDescription('Creates a new report')
@@ -78,7 +78,7 @@ class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
             ;
         }
 
-        public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+        public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
         {
         }
 
@@ -101,14 +101,14 @@ class that implements :class:`Symfony\\Bundle\\MakerBundle\\MakerInterface`::
             ];
         }
 
-        public function writeNextStepsMessage(array $params, ConsoleStyle $io): void
+        public function writeNextStepsMessage(array $params, ConsoleStyle $io)
         {
             $io->text([
                 'Next: Open your new report and start customizing it.',
             ]);
         }
 
-        public function configureDependencies(DependencyBuilder $dependencies): void
+        public function configureDependencies(DependencyBuilder $dependencies)
         {
         }
     }


### PR DESCRIPTION
Guys, 
I've decided to share with you my thoughts on maker-bundle docs over this PR instead of raising the new issue to be more clear. 

Current version of `Creating your Own Makers` consists of one stub class than can be used for creating new maker command. I know that the last paragraph explain everything ("For examples of how to complete this class, see the core maker commands") but at this point for me, the user of this bundle, is not really clear even for easy stuff I will have to check core command to see how methods are filled. 

Also I can see the following inconsistencies throughout the class: 
1. `use Symfony\Bundle\MakerBundle\Str;` and `use Symfony\Bundle\MakerBundle\Validator;` are not used within this example
2. `name` feels for me more as class name than format.
3. We are missing php skeleton files - why should I create such command without code that it may generate?

I've decided to address those in the following PR. 

Looking forward to see your thoughts!