### PR TITLE
Fix undefined class GuardAuthenticator

### DIFF
--- a/src/Resources/skeleton/authenticator/Empty.tpl.php
+++ b/src/Resources/skeleton/authenticator/Empty.tpl.php
@@ -7,9 +7,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Guard\GuardAuthenticator;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 
-class <?= $class_name ?> extends GuardAuthenticator
+class <?= $class_name ?> extends AbstractGuardAuthenticator
 {
     public function supports(Request $request)
     {


### PR DESCRIPTION
Class `Symfony\Component\Security\Guard\GuardAuthenticator;` does not exist.

# How to test

- [ ] `./bin/console make:auth`
- [ ]  Open your `Authenticator`