### PR TITLE
Fix extends on ControllerWithTwig template

### DIFF
--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -3,15 +3,15 @@
 namespace App\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
-class <?= $controller_class_name ?> extends AbstractController
+class <?= $controller_class_name ?> extends Controller
 {
     /**
      * @Route("<?= $route_path ?>", name="<?= $route_name ?>")
      */
-    public function index()
+    public function index(): Response
     {
         return new Response('Welcome to your new controller!');
     }

--- a/src/Resources/skeleton/controller/ControllerWithTwig.tpl.php
+++ b/src/Resources/skeleton/controller/ControllerWithTwig.tpl.php
@@ -3,15 +3,15 @@
 namespace App\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
-class <?= $controller_class_name ?> extends AbstractController
+class <?= $controller_class_name ?> extends Controller
 {
     /**
      * @Route("<?= $route_path ?>", name="<?= $route_name ?>")
      */
-    public function index()
+    public function index(): Response
     {
         // replace this line with your own code!
         return $this->render('@Maker/demoPage.html.twig', [ 'path' => str_replace($this->getParameter('kernel.project_dir').'/', '', __FILE__) ]);


### PR DESCRIPTION
`Symfony\Bundle\FrameworkBundle\Controller\AbstractController` doesn't implement `getParameter` method. I replaced it by `Symfony\Bundle\FrameworkBundle\Controller\Controller`

# How to test

- `bin/console make:controller HomeController`
- Open `/home`