### PR TITLE
Add maker command for form type extensions

### DIFF
--- a/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
+++ b/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Form\Extension\Core\CoreExtension;
 
 class MakeCommandRegistrationPass implements CompilerPassInterface
 {
@@ -25,6 +26,8 @@ class MakeCommandRegistrationPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
+        $this->processFormTypeExtensionMaker($container);
+
         foreach ($container->findTaggedServiceIds(self::MAKER_TAG) as $id => $tags) {
             $def = $container->getDefinition($id);
             $class = $container->getParameterBag()->resolveValue($def->getClass());
@@ -40,5 +43,41 @@ class MakeCommandRegistrationPass implements CompilerPassInterface
                 new Reference('maker.file_manager'),
             ])->addTag('console.command', ['command' => $class::getCommandName()]);
         }
+    }
+
+    private function processFormTypeExtensionMaker(ContainerBuilder $container)
+    {
+        if (!class_exists(CoreExtension::class)) {
+            return;
+        }
+
+        $typesMap = [];
+        // add core form types
+        $coreExtension = new CoreExtension();
+        $loadTypesRefMethod = (new \ReflectionObject($coreExtension))->getMethod('loadTypes');
+        $loadTypesRefMethod->setAccessible(true);
+        $coreTypes = $loadTypesRefMethod->invoke($coreExtension);
+        foreach ($coreTypes as $type) {
+            $fqcn = \get_class($type);
+            $cn = \array_slice(explode('\\', $fqcn), -1)[0];
+            $typesMap[$cn] = $fqcn;
+        }
+
+        // add form type services
+        foreach ($container->findTaggedServiceIds('form.type', true) as $serviceId => $tag) {
+            $fqcn = $container->getDefinition($serviceId)->getClass();
+            $cn = \array_slice(explode('\\', $fqcn), -1)[0];
+            if (isset($typesMap[$cn])) {
+                if (!\in_array($fqcn, (array) $typesMap[$cn], true)) {
+                    // preparing for ambiguous question
+                    $typesMap[$cn] = array_merge((array) $typesMap[$cn], [$fqcn]);
+                }
+            } else {
+                $typesMap[$cn] = $fqcn;
+            }
+        }
+
+        $maker = $container->getDefinition('maker.maker.make_form_type_extension');
+        $maker->setArgument(0, $typesMap);
     }
 }

--- a/src/Maker/MakeFormTypeExtension.php
+++ b/src/Maker/MakeFormTypeExtension.php
@@ -43,8 +43,8 @@ final class MakeFormTypeExtension extends AbstractMaker
     {
         $command
             ->setDescription('Creates a new form type extension class')
-            ->addArgument('name', InputArgument::OPTIONAL, sprintf('The name of the form type extension class (e.g. <fg=yellow>%sTypeExtension</>)', Str::asClassName(Str::getRandomTerm())))
-            ->addArgument('extended_type', InputArgument::OPTIONAL, 'The name of the extended type class (e.g. <fg=yellow>FormType</>)')
+            ->addArgument('name', InputArgument::OPTIONAL, sprintf('The class name of the form type extension (e.g. <fg=yellow>%sTypeExtension</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addArgument('extended_type', InputArgument::OPTIONAL, 'The class name of the extended form type (e.g. <fg=yellow>DateType</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeFormTypeExtension.txt'))
         ;
 
@@ -67,7 +67,7 @@ final class MakeFormTypeExtension extends AbstractMaker
             $extendedType = $io->askQuestion($question);
             if (!class_exists($extendedType)) {
                 if (\is_array($this->types[$extendedType])) {
-                    $extendedType = $io->choice(sprintf("The type \"%s\" is ambiguous.\n\nSelect one of the following form types:", $extendedType), $this->types[$extendedType], $this->types[$extendedType][0]);
+                    $extendedType = $io->choice(sprintf("The class name \"%s\" is ambiguous.\n\nSelect one of the following form types:", $extendedType), $this->types[$extendedType], $this->types[$extendedType][0]);
                 } else {
                     $extendedType = $this->types[$extendedType];
                 }

--- a/src/Maker/MakeFormTypeExtension.php
+++ b/src/Maker/MakeFormTypeExtension.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\MakerInterface;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Form\AbstractTypeExtension;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+final class MakeFormTypeExtension implements MakerInterface
+{
+    public static function getCommandName(): string
+    {
+        return 'make:form:type-extension';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConf)
+    {
+        $command
+            ->setDescription('Creates a new form type extension class')
+            ->addArgument('name', InputArgument::OPTIONAL, sprintf('The name of the form type extension class (e.g. <fg=yellow>%sTypeExtension</>)', Str::asClassName(Str::getRandomTerm())))
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeFormTypeExtension.txt'))
+        ;
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    {
+    }
+
+    public function getParameters(InputInterface $input): array
+    {
+        $typeExtensionClassName = Str::asClassName($input->getArgument('name'), 'TypeExtension');
+        Validator::validateClassName($typeExtensionClassName);
+
+        return [
+            'type_extension_class_name' => $typeExtensionClassName,
+        ];
+    }
+
+    public function getFiles(array $params): array
+    {
+        return [
+            __DIR__.'/../Resources/skeleton/form/TypeExtension.tpl.php' => 'src/Form/Extension/'.$params['type_extension_class_name'].'.php',
+        ];
+    }
+
+    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    {
+        $io->text([
+            'Next: Make Symfony aware of your form type extension by registering it as a service.',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/form/create_form_type_extension.html</>',
+        ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(
+            AbstractTypeExtension::class,
+            'form'
+        );
+    }
+}

--- a/src/Maker/MakeFormTypeExtension.php
+++ b/src/Maker/MakeFormTypeExtension.php
@@ -36,6 +36,7 @@ final class MakeFormTypeExtension extends AbstractMaker
         $command
             ->setDescription('Creates a new form type extension class')
             ->addArgument('name', InputArgument::OPTIONAL, sprintf('The name of the form type extension class (e.g. <fg=yellow>%sTypeExtension</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addArgument('extended_type', InputArgument::OPTIONAL, 'The name of the extended type class (e.g. <fg=yellow>FormType</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeFormTypeExtension.txt'))
         ;
     }
@@ -48,9 +49,12 @@ final class MakeFormTypeExtension extends AbstractMaker
     {
         $typeExtensionClassName = Str::asClassName($input->getArgument('name'), 'TypeExtension');
         Validator::validateClassName($typeExtensionClassName);
+        $extendedTypeClassName = $input->getArgument('extended_type');
+        Validator::validateClassName($extendedTypeClassName);
 
         return [
             'type_extension_class_name' => $typeExtensionClassName,
+            'extended_type_class_name' => $extendedTypeClassName,
         ];
     }
 

--- a/src/Maker/MakeFormTypeExtension.php
+++ b/src/Maker/MakeFormTypeExtension.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -25,7 +24,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
-final class MakeFormTypeExtension implements MakerInterface
+final class MakeFormTypeExtension extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -62,8 +61,10 @@ final class MakeFormTypeExtension implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Make Symfony aware of your form type extension by registering it as a service.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/form/create_form_type_extension.html</>',

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -32,6 +32,10 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_form_type_extension" class="Symfony\Bundle\MakerBundle\Maker\MakeFormTypeExtension">
+                <tag name="maker.command" />
+            </service>
+
             <service id="maker.maker.make_functional_test" class="Symfony\Bundle\MakerBundle\Maker\MakeFunctionalTest">
                 <tag name="maker.command" />
             </service>

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -34,6 +34,7 @@
 
             <service id="maker.maker.make_form_type_extension" class="Symfony\Bundle\MakerBundle\Maker\MakeFormTypeExtension">
                 <tag name="maker.command" />
+                <argument type="collection" />
             </service>
 
             <service id="maker.maker.make_functional_test" class="Symfony\Bundle\MakerBundle\Maker\MakeFunctionalTest">

--- a/src/Resources/help/MakeFormTypeExtension.txt
+++ b/src/Resources/help/MakeFormTypeExtension.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new form type extension class.
+
+<info>php %command.full_name% FormTypeExtension</info>
+
+If the argument is missing, the command will ask for the form type extension class interactively.

--- a/src/Resources/skeleton/form/TypeExtension.tpl.php
+++ b/src/Resources/skeleton/form/TypeExtension.tpl.php
@@ -18,6 +18,6 @@ class <?= $type_extension_class_name ?> extends AbstractTypeExtension
     public function getExtendedType()
     {
         // returns the FQCN of the type being extended.
-        return FormType::class;
+        return <?= $extended_type_class_name ?>;
     }
 }

--- a/src/Resources/skeleton/form/TypeExtension.tpl.php
+++ b/src/Resources/skeleton/form/TypeExtension.tpl.php
@@ -3,8 +3,8 @@
 namespace App\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use <?= $extended_type_class ?>;
 
 class <?= $type_extension_class_name ?> extends AbstractTypeExtension
 {
@@ -17,7 +17,6 @@ class <?= $type_extension_class_name ?> extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        // returns the FQCN of the type being extended.
-        return <?= $extended_type_class_name ?>;
+        return <?= $extended_type_class_name ?>::class;
     }
 }

--- a/src/Resources/skeleton/form/TypeExtension.tpl.php
+++ b/src/Resources/skeleton/form/TypeExtension.tpl.php
@@ -1,0 +1,23 @@
+<?= "<?php\n" ?>
+
+namespace App\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class <?= $type_extension_class_name ?> extends AbstractTypeExtension
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'option_name' => null,
+        ]);
+    }
+
+    public function getExtendedType()
+    {
+        // returns the FQCN of the type being extended.
+        return FormType::class;
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -46,4 +46,13 @@ final class Validator
 
         return $value;
     }
+
+    public static function validateClassExists(string $class): string
+    {
+        if (!class_exists($class)) {
+            throw new RuntimeCommandException(sprintf('Could not find class "%s"', $class));
+        }
+
+        return $class;
+    }
 }

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -173,6 +173,8 @@ class FunctionalTest extends MakerTestCase
             [
                 // form name
                 'FooBar',
+                // extended type
+                'FormType'
             ])
         ];
 

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -14,6 +14,7 @@ use Symfony\Bundle\MakerBundle\Maker\MakeController;
 use Symfony\Bundle\MakerBundle\Maker\MakeEntity;
 use Symfony\Bundle\MakerBundle\Maker\MakeFixtures;
 use Symfony\Bundle\MakerBundle\Maker\MakeForm;
+use Symfony\Bundle\MakerBundle\Maker\MakeFormTypeExtension;
 use Symfony\Bundle\MakerBundle\Maker\MakeFunctionalTest;
 use Symfony\Bundle\MakerBundle\Maker\MakeMigration;
 use Symfony\Bundle\MakerBundle\Maker\MakeSerializerEncoder;
@@ -169,6 +170,14 @@ class FunctionalTest extends MakerTestCase
 
         yield 'form' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeForm::class),
+            [
+                // form name
+                'FooBar',
+            ])
+        ];
+
+        yield 'form_type_extension' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeFormTypeExtension::class),
             [
                 // form name
                 'FooBar',

--- a/tests/fixtures/MakeEntity/tests/GeneratedEntityTest.php
+++ b/tests/fixtures/MakeEntity/tests/GeneratedEntityTest.php
@@ -29,6 +29,6 @@ class GeneratedEntityTest extends KernelTestCase
         $actualFood = $em->getRepository(TastyFood::class)
             ->findAll();
 
-        $this->assertcount(1, $actualFood);
+        $this->assertCount(1, $actualFood);
     }
 }


### PR DESCRIPTION
I've two versions of this command:
1. This asks only for the class name of the form type extension and the extended type is always the `FormType::class`. Then, the user is responsible for changing it if necessary (with IDE autocompletion this task is very fast).
2. (The current one) Ask also for the FQCN of the extended type + class exists validation, but it could be a boring task considering that most of the time this form type comes from a vendor with a long namespace. To improve it, I thought about injecting all available form types and allowing the input of the class name only, something similar to what was done with the command `debug:form <FormType>` argument.

![form-type-extension](https://user-images.githubusercontent.com/2028198/34854762-91b1c990-f709-11e7-8cf8-5a0e9bb0547d.gif)

closes #78 