### PR TITLE
(make:unit-test) Generate test class from file path

### DIFF
--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -46,6 +46,7 @@
             </service>
 
             <service id="maker.maker.make_unit_test" class="Symfony\Bundle\MakerBundle\Maker\MakeUnitTest">
+                <argument>%kernel.project_dir%</argument>
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/skeleton/test/Unit.tpl.php
+++ b/src/Resources/skeleton/test/Unit.tpl.php
@@ -1,6 +1,6 @@
 <?= "<?php\n" ?>
 
-namespace App\Tests;
+namespace <?= $test_namespace ?>;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Command/FunctionalTest.php
+++ b/tests/Command/FunctionalTest.php
@@ -177,10 +177,18 @@ class FunctionalTest extends TestCase
         );
 
         yield 'unit_test' => array(
-            new MakeUnitTest(),
+            new MakeUnitTest(__DIR__.'/../Fixtures'),
             array(
                 // class name
                 'FooBar',
+            ),
+        );
+
+        yield 'unit_test_from_file_path' => array(
+            new MakeUnitTest(__DIR__.'/../Fixtures'),
+            array(
+                // file path
+                'src/Security/Voter/FooVoter.php',
             ),
         );
 

--- a/tests/Fixtures/src/Security/Voter/FooVoter.php
+++ b/tests/Fixtures/src/Security/Voter/FooVoter.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Security\Voter;
+
+class FooVoter
+{
+}


### PR DESCRIPTION
> By convention, the `tests/` directory should replicate the directory of your bundle for unit tests. So, if you're testing a class in the `src/Util/` directory, put the test in the `tests/Util/` directory.

Following this convention, I'd like to offer another way to generate unit tests to accomplish this statement.

I think by passing the source file path with the benefits of shell autocompletion, we can easily derive the test path, the namespace and the final class. e.g:
```bash
$ bin/console make:unit-test src/Security/Voter/FooVoter.php
```
Generating this:
```php
// tests/Security/Voter/FooVoterTest.php
namespace App\Tests\Security\Voter;

// ...
```
Wdyt?