### PR TITLE
If value fails validation, ask again!

### DIFF
--- a/src/Exception/RuntimeCommandException.php
+++ b/src/Exception/RuntimeCommandException.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Bundle\MakerBundle\Exception;
 
-use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Exception\ExceptionInterface;
 
 /**
  * An exception whose output is displayed as a clean error.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
-final class RuntimeCommandException extends RuntimeException
+final class RuntimeCommandException extends \RuntimeException implements ExceptionInterface
 {
 }


### PR DESCRIPTION
@weaverryan Look like throwing a `Symfony\Component\Console\Exception\RuntimeException` into validator function breaks the [loop](https://github.com/symfony/symfony/blob/784186b2498303343a684a6a6f71eca1f7fa2bf2/src/Symfony/Component/Console/Helper/QuestionHelper.php#L364-L365).

But still we need a nice error message without line trace, so implementing `ExceptionInterface` should be enough.

Fix #90.