### PR TITLE
make:doctrine:entities command

### DIFF
--- a/src/Command/GenerateEntitiesCommand.php
+++ b/src/Command/GenerateEntitiesCommand.php
@@ -21,7 +21,7 @@ class GenerateEntitiesCommand extends ContainerAwareCommand
             ->setDescription('Generates entity classes and method stubs from your mapping information for flex based project')
             ->addArgument('name', InputArgument::OPTIONAL, 'An entity name')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path where to generate entities when it cannot be guessed')
-            ->addOption('no-backup', null, InputOption::VALUE_NONE, 'Do not backup existing entities files.')
+            ->addOption('backup', null, InputOption::VALUE_NONE, 'Backup existing entities files.')
         ;
     }
 
@@ -46,7 +46,7 @@ class GenerateEntitiesCommand extends ContainerAwareCommand
 
         $generator = $this->getEntityGenerator();
 
-        $backupExisting = !$input->getOption('no-backup');
+        $backupExisting = $input->getOption('backup');
         $generator->setBackupExisting($backupExisting);
 
         $repoGenerator = new EntityRepositoryGenerator();

--- a/src/Command/GenerateEntitiesCommand.php
+++ b/src/Command/GenerateEntitiesCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\ORM\Tools\EntityRepositoryGenerator;
+use Symfony\Bundle\MakerBundle\Doctrine\EntityGenerator;
+use Symfony\Bundle\MakerBundle\Doctrine\DisconnectedMetadataFactory;
+
+class GenerateEntitiesCommand extends ContainerAwareCommand
+{
+    protected static $defaultName = 'make:doctrine:entities';
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Generates entity classes and method stubs from your mapping information for flex based project')
+            ->addArgument('name', InputArgument::OPTIONAL, 'An entity name')
+            ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path where to generate entities when it cannot be guessed')
+            ->addOption('no-backup', null, InputOption::VALUE_NONE, 'Do not backup existing entities files.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $manager = new DisconnectedMetadataFactory($this->getContainer()->get('doctrine'));
+
+        $name = strtr($input->getArgument('name'), '/', '\\');
+        $name = $name ? 'App:'.$name : 'App';
+
+        if (false !== $pos = strpos($name, ':')) {
+            $name = $this->getContainer()->get('doctrine')->getAliasNamespace(substr($name, 0, $pos)).'\\'.substr($name, $pos + 1);
+        }
+
+        if (class_exists($name)) {
+            $output->writeln(sprintf('Generating entity "<info>%s</info>"', $name));
+            $metadata = $manager->getClassMetadata($name, $input->getOption('path'));
+        } else {
+            $output->writeln(sprintf('Generating entities for namespace "<info>%s</info>"', $name));
+            $metadata = $manager->getNamespaceMetadata($name, $input->getOption('path'));
+        }
+
+        $generator = $this->getEntityGenerator();
+
+        $backupExisting = !$input->getOption('no-backup');
+        $generator->setBackupExisting($backupExisting);
+
+        $repoGenerator = new EntityRepositoryGenerator();
+        foreach ($metadata->getMetadata() as $m) {
+            if ($backupExisting) {
+                $basename = substr($m->name, strrpos($m->name, '\\') + 1);
+                $output->writeln(sprintf('  > backing up <comment>%s.php</comment> to <comment>%s.php~</comment>', $basename, $basename));
+            }
+            // Getting the metadata for the entity class once more to get the correct path if the namespace has multiple occurrences
+            try {
+                $entityMetadata = $manager->getClassMetadata($m->getName(), $input->getOption('path'));
+            } catch (\RuntimeException $e) {
+                // fall back to the bundle metadata when no entity class could be found
+                $entityMetadata = $metadata;
+            }
+
+            $output->writeln(sprintf('  > generating <comment>%s</comment>', $m->name));
+
+            $generator->generate(array($m), $entityMetadata->getPath());
+
+            if ($m->customRepositoryClassName && false !== strpos($m->customRepositoryClassName, $metadata->getNamespace())) {
+                $repoGenerator->writeEntityRepositoryClass($m->customRepositoryClassName, $metadata->getPath());
+            }
+        }
+    }
+
+    private function getEntityGenerator()
+    {
+        $entityGenerator = new EntityGenerator();
+        $entityGenerator->setGenerateAnnotations(false);
+        $entityGenerator->setGenerateStubMethods(true);
+        $entityGenerator->setRegenerateEntityIfExists(false);
+        $entityGenerator->setUpdateEntityIfExists(true);
+        $entityGenerator->setNumSpaces(4);
+        $entityGenerator->setAnnotationPrefix('ORM\\');
+
+        return $entityGenerator;
+    }
+}

--- a/src/Command/GenerateEntitiesCommand.php
+++ b/src/Command/GenerateEntitiesCommand.php
@@ -22,6 +22,16 @@ class GenerateEntitiesCommand extends ContainerAwareCommand
             ->addArgument('name', InputArgument::OPTIONAL, 'An entity name')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The path where to generate entities when it cannot be guessed')
             ->addOption('backup', null, InputOption::VALUE_NONE, 'Backup existing entities files.')
+            ->setHelp(<<<EOT
+This command is port of "doctrine:generate:entities" for symfony flex based projects.
+There is some differences from original command:
+
+    * Without argument generate all entities.
+    * With argument generate one entity specified by argument.
+    * No backups by default. To do backups, use <info>--backup</info> option.
+
+EOT
+)
         ;
     }
 

--- a/src/Doctrine/DisconnectedMetadataFactory.php
+++ b/src/Doctrine/DisconnectedMetadataFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Doctrine;
+
+use Doctrine\Bundle\DoctrineBundle\Mapping\DisconnectedMetadataFactory as BaseClass;
+use Doctrine\Bundle\DoctrineBundle\Mapping\ClassMetadataCollection;
+
+class DisconnectedMetadataFactory extends BaseClass
+{
+    public function findNamespaceAndPathForMetadata(ClassMetadataCollection $metadata, $path = null)
+    {
+        $all = $metadata->getMetadata();
+        if (class_exists($all[0]->name)) {
+            $r = new \ReflectionClass($all[0]->name);
+            $path = dirname($r->getFilename());
+            $ns = $r->getNamespaceName();
+        } elseif ($path) {
+            // Get namespace by removing the last component of the FQCN
+            $nsParts = explode('\\', $all[0]->name);
+            array_pop($nsParts);
+            $ns = implode('\\', $nsParts);
+        } else {
+            throw new \RuntimeException(sprintf('Unable to determine where to save the "%s" class (use the --path option).', $all[0]->name));
+        }
+
+        $metadata->setPath($path);
+        $metadata->setNamespace($ns);
+    }
+}

--- a/src/Doctrine/EntityGenerator.php
+++ b/src/Doctrine/EntityGenerator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Doctrine;
+
+use Doctrine\ORM\Tools\EntityGenerator as BaseClass;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+class EntityGenerator extends BaseClass
+{
+    public function writeEntityClass(ClassMetadataInfo $metadata, $outputDirectory)
+    {
+        $path = $outputDirectory.'/'.substr($metadata->name, strrpos($metadata->name, '\\') + 1).$this->extension;
+        $dir = dirname($path);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        $this->isNew = !file_exists($path) || (file_exists($path) && $this->regenerateEntityIfExists);
+
+        if (!$this->isNew) {
+            $this->parseTokensInEntityFile(file_get_contents($path));
+        } else {
+            $this->staticReflection[$metadata->name] = array('properties' => array(), 'methods' => array());
+        }
+
+        if ($this->backupExisting && file_exists($path)) {
+            $backupPath = dirname($path).DIRECTORY_SEPARATOR.basename($path).'~';
+            if (!copy($path, $backupPath)) {
+                throw new \RuntimeException('Attempt to backup overwritten entity file but copy operation failed.');
+            }
+        }
+
+        // If entity doesn't exist or we're re-generating the entities entirely
+        if ($this->isNew) {
+            file_put_contents($path, $this->generateEntityClass($metadata));
+            // If entity exists and we're allowed to update the entity class
+        } elseif (!$this->isNew && $this->updateEntityIfExists) {
+            file_put_contents($path, $this->generateUpdatedEntityClass($metadata, $path));
+        }
+        chmod($path, 0664);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -23,5 +23,9 @@
             <service id="maker.console_error_listener" class="Symfony\Bundle\MakerBundle\Event\ConsoleErrorSubscriber">
                 <tag name="kernel.event_subscriber" />
             </service>
+
+            <service id="maker.command.entities" class="Symfony\Bundle\MakerBundle\Command\GenerateEntitiesCommand">
+                <tag name="console.command" command="make:doctrine:entities" />
+            </service>
         </services>
 </container>


### PR DESCRIPTION
It is port for `doctrine:generate:entities` command from DoctrineBundle for flex based apps.
Namespaced with "doctrine" intentionally to not conflict with "entity" so you don't have to write full command like in SensioGeneratorBundle

May be not so elegant, but this command really needed