### PR TITLE
add --dev option with composer

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -13,7 +13,7 @@ Run this command to install and enable this bundle in your application:
 
 .. code-block:: terminal
 
-    $ composer require maker
+    $ composer require maker --dev
 
 Usage
 -----


### PR DESCRIPTION
I suggest to add --dev option to the composer require command in the docs because the maker bundle shouldn't be needed in production environment, in fact flex already registers it automatically to be used only in dev...