### PR TITLE
New make:migration command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 phpunit.xml
 vendor/
 tests/tmp/*
+.php_cs.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+1.1
+===
+
+* [BC BREAK] The MakerInterface changed: `writeNextStepsMessage`
+  was renamed to `writeSuccessMessage`. You should now extend
+  `AbstractMaker` instead of implementing the interface directly,
+  and use `parent::writeSuccessMessage()` to get the normal success
+  message after the command.

--- a/src/ApplicationAwareMakerInterface.php
+++ b/src/ApplicationAwareMakerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle;
+
+use Symfony\Component\Console\Application;
+
+/**
+ * Implement this interface if your Maker needs access to the Application.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+interface ApplicationAwareMakerInterface
+{
+    /**
+     * @param Application $application
+     */
+    public function setApplication(Application $application);
+}

--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -11,13 +11,16 @@
 
 namespace Symfony\Bundle\MakerBundle\Command;
 
+use Symfony\Bundle\MakerBundle\ApplicationAwareMakerInterface;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\ExtraGenerationMakerInterface;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -92,13 +95,24 @@ final class MakerCommand extends Command
         $params = $this->maker->getParameters($input);
         $this->generator->generate($params, $this->maker->getFiles($params));
 
-        $this->io->newLine();
-        $this->io->writeln(' <bg=green;fg=white>          </>');
-        $this->io->writeln(' <bg=green;fg=white> Success! </>');
-        $this->io->writeln(' <bg=green;fg=white>          </>');
-        $this->io->newLine();
+        if ($this->maker instanceof ExtraGenerationMakerInterface) {
+            $this->maker->afterGenerate($this->io, $params);
+        }
 
-        $this->maker->writeNextStepsMessage($params, $this->io);
+        $this->maker->writeSuccessMessage($params, $this->io);
+    }
+
+    public function setApplication(Application $application = null)
+    {
+        parent::setApplication($application);
+
+        if ($this->maker instanceof ApplicationAwareMakerInterface) {
+            if (null === $application) {
+                throw new \RuntimeException('Application cannot be null.');
+            }
+
+            $this->maker->setApplication($application);
+        }
     }
 
     /**

--- a/src/ExtraGenerationMakerInterface.php
+++ b/src/ExtraGenerationMakerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle;
+
+/**
+ * Interface to do extra code generation in a maker.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+interface ExtraGenerationMakerInterface
+{
+    /**
+     * Called after normal code generation.
+     */
+    public function afterGenerate(ConsoleStyle $io, array $params);
+}

--- a/src/Maker/AbstractMaker.php
+++ b/src/Maker/AbstractMaker.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\MakerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Convenient abstract class for makers.
+ */
+abstract class AbstractMaker implements MakerInterface
+{
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    {
+    }
+
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
+    {
+        $io->newLine();
+        $io->writeln(' <bg=green;fg=white>          </>');
+        $io->writeln(' <bg=green;fg=white> Success! </>');
+        $io->writeln(' <bg=green;fg=white>          </>');
+        $io->newLine();
+    }
+}

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -25,7 +24,7 @@ use Symfony\Component\Console\Input\InputInterface;
 /**
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
-final class MakeAuthenticator implements MakerInterface
+final class MakeAuthenticator extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -39,10 +38,6 @@ final class MakeAuthenticator implements MakerInterface
             ->addArgument('authenticator-class', InputArgument::OPTIONAL, 'The class name of the authenticator to create (e.g. <fg=yellow>AppCustomAuthenticator</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeAuth.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -62,8 +57,10 @@ final class MakeAuthenticator implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Customize your new authenticator.',
             'Then, configure the "guard" key on your firewall to use it.',

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -25,7 +24,7 @@ use Symfony\Component\Console\Input\InputInterface;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeCommand implements MakerInterface
+final class MakeCommand extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -39,10 +38,6 @@ final class MakeCommand implements MakerInterface
             ->addArgument('name', InputArgument::OPTIONAL, sprintf('Choose a command name (e.g. <fg=yellow>app:%s</>)', Str::asCommand(Str::getRandomTerm())))
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCommand.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -64,8 +59,10 @@ final class MakeCommand implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: open your new command class and customize it!',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/console.html</>',

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -15,7 +15,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -28,7 +27,7 @@ use Symfony\Component\Routing\RouterInterface;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeController implements MakerInterface
+final class MakeController extends AbstractMaker
 {
     private $router;
 
@@ -49,10 +48,6 @@ final class MakeController implements MakerInterface
             ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeController.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -76,8 +71,10 @@ final class MakeController implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         if (!count($this->router->getRouteCollection())) {
             $io->text('<error> Warning! </> No routes configuration defined yet.');
             $io->text('           You should probably uncomment the annotation routes in <comment>config/routes.yaml</>');

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping\Column;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +25,7 @@ use Symfony\Component\Console\Input\InputInterface;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeEntity implements MakerInterface
+final class MakeEntity extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -40,10 +39,6 @@ final class MakeEntity implements MakerInterface
             ->addArgument('entity-class', InputArgument::OPTIONAL, sprintf('The class name of the entity to create (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeEntity.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -68,8 +63,10 @@ final class MakeEntity implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Add more fields to your entity and start using it.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/doctrine.html#creating-an-entity-class</>',

--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -27,7 +26,7 @@ use Symfony\Component\Validator\Validation;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeForm implements MakerInterface
+final class MakeForm extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -41,10 +40,6 @@ final class MakeForm implements MakerInterface
             ->addArgument('name', InputArgument::OPTIONAL, sprintf('The name of the form class (e.g. <fg=yellow>%sType</>)', Str::asClassName(Str::getRandomTerm())))
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeForm.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -66,8 +61,10 @@ final class MakeForm implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Add fields to your form and start using it.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/forms.html</>',

--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\BrowserKit\Client;
@@ -27,7 +26,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-class MakeFunctionalTest implements MakerInterface
+class MakeFunctionalTest extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -41,10 +40,6 @@ class MakeFunctionalTest implements MakerInterface
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the functional test class (e.g. <fg=yellow>DefaultControllerTest</>).')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeFunctionalTest.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -64,8 +59,10 @@ class MakeFunctionalTest implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Open your new test class and start customizing it.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/testing.html#functional-tests</>',

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Doctrine\Bundle\MigrationsBundle\Command\DoctrineCommand;
+use Symfony\Bundle\MakerBundle\ApplicationAwareMakerInterface;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\ExtraGenerationMakerInterface;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @author Amrouche Hamza <hamza.simperfit@gmail.com>
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+final class MakeMigration extends AbstractMaker implements ApplicationAwareMakerInterface, ExtraGenerationMakerInterface
+{
+    private $projectDir;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    /**
+     * @var string
+     */
+    private $migrationOutput;
+
+    public function __construct(string $projectDir)
+    {
+        $this->projectDir = $projectDir;
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:migration';
+    }
+
+    public function setApplication(Application $application)
+    {
+        $this->application = $application;
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConf)
+    {
+        $command
+            ->setDescription('Creates a new migration based on database changes.')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection name.')
+            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager name')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection name.')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeMigration.txt'))
+        ;
+    }
+
+    public function getParameters(InputInterface $input): array
+    {
+        return [
+            'options' => [
+                'db' => $input->getOption('db'),
+                'em' => $input->getOption('em'),
+                'shard' => $input->getOption('shard'),
+            ],
+        ];
+    }
+
+    public function getFiles(array $params): array
+    {
+        return [];
+    }
+
+    public function afterGenerate(ConsoleStyle $io, array $params)
+    {
+        $options = $params['options'];
+
+        $options['command'] = 'doctrine:migrations:diff';
+        $generateMigrationCommand = $this->application->find('doctrine:migrations:diff');
+
+        $commandOutput = new BufferedOutput($io->getVerbosity());
+        $generateMigrationCommand->run(new ArgvInput($options), $commandOutput);
+        $this->migrationOutput = $commandOutput->fetch();
+    }
+
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
+    {
+        if (false !== strpos($this->migrationOutput, 'No changes detected')) {
+            $io->warning([
+                'No database changes were detected.',
+            ]);
+            $io->text([
+                'The database schema was compared with your mapping information and they are already in sync: no migration was generated.',
+                '',
+            ]);
+
+            return;
+        }
+
+        parent::writeSuccessMessage($params, $io);
+
+        $migrationName = $this->getGeneratedMigrationFilename($this->migrationOutput);
+
+        $io->text([
+            sprintf('Next: Review the new migration <info>%s</info>', $migrationName),
+            'Then: Run the migration with <info>php bin/console doctrine:migrations:migrate</info>',
+            'See <fg=yellow>https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html</>',
+        ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(
+            DoctrineCommand::class,
+            'migrations'
+        );
+    }
+
+    private function getGeneratedMigrationFilename(string $migrationOutput): string
+    {
+        preg_match('#"(.*?)"#', $migrationOutput, $matches);
+
+        if (!isset($matches[0])) {
+            throw new \Exception('Your migration generated successfully, but an error occurred printing the summary of what occurred.');
+        }
+
+        return str_replace($this->projectDir.'/', '', $matches[0]);
+    }
+}

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -103,7 +103,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
                 'No database changes were detected.',
             ]);
             $io->text([
-                'The database schema was compared with your mapping information and they are already in sync: no migration was generated.',
+                'The database schema and the application mapping information are already in sync.',
                 '',
             ]);
 

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -25,7 +24,7 @@ use Symfony\Component\Serializer\Serializer;
 /**
  * @author Piotr Grabski-Gradzinski <piotr.gradzinski@gmail.com>
  */
-final class MakeSerializerEncoder implements MakerInterface
+final class MakeSerializerEncoder extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -40,10 +39,6 @@ final class MakeSerializerEncoder implements MakerInterface
             ->addArgument('format', InputArgument::OPTIONAL, 'Pick your format name (e.g. <fg=yellow>yaml</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeSerializerEncoder.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -65,8 +60,10 @@ final class MakeSerializerEncoder implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Open your new serializer encoder class and start customizing it.',
             'Find the documentation at <fg=yellow>http://symfony.com/doc/current/serializer/custom_encoders.html</>',

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\EventRegistry;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -27,7 +26,7 @@ use Symfony\Component\Console\Question\Question;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeSubscriber implements MakerInterface
+final class MakeSubscriber extends AbstractMaker
 {
     private $eventRegistry;
 
@@ -96,8 +95,10 @@ final class MakeSubscriber implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Open your new subscriber class and start customizing it.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber</>',

--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +25,7 @@ use Twig\Extension\AbstractExtension;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeTwigExtension implements MakerInterface
+final class MakeTwigExtension extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -40,10 +39,6 @@ final class MakeTwigExtension implements MakerInterface
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the Twig extension class (e.g. <fg=yellow>AppExtension</>).', 'AppExtension')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeTwigExtension.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -63,8 +58,10 @@ final class MakeTwigExtension implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Open your new extension class and start customizing it.',
             'Find the documentation at <fg=yellow>http://symfony.com/doc/current/templating/twig_extension.html</>',

--- a/src/Maker/MakeUnitTest.php
+++ b/src/Maker/MakeUnitTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -25,7 +24,7 @@ use Symfony\Component\Console\Input\InputInterface;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeUnitTest implements MakerInterface
+final class MakeUnitTest extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -39,10 +38,6 @@ final class MakeUnitTest implements MakerInterface
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the unit test class (e.g. <fg=yellow>UtilTest</>).')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeUnitTest.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -62,8 +57,10 @@ final class MakeUnitTest implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Open your new test class and start customizing it.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/testing.html#unit-tests</>',

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +25,7 @@ use Symfony\Component\Validator\Validation;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeValidator implements MakerInterface
+final class MakeValidator extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -40,10 +39,6 @@ final class MakeValidator implements MakerInterface
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the validator class (e.g. <fg=yellow>EnabledValidator</>).')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeValidator.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -66,8 +61,10 @@ final class MakeValidator implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Open your new constraint & validators and add your logic.',
             'Find the documentation at <fg=yellow>http://symfony.com/doc/current/validation/custom_constraint.html</>',

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -26,7 +25,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */
-final class MakeVoter implements MakerInterface
+final class MakeVoter extends AbstractMaker
 {
     public static function getCommandName(): string
     {
@@ -40,10 +39,6 @@ final class MakeVoter implements MakerInterface
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the security voter class (e.g. <fg=yellow>BlogPostVoter</>).')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeVoter.txt'))
         ;
-    }
-
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
-    {
     }
 
     public function getParameters(InputInterface $input): array
@@ -63,8 +58,10 @@ final class MakeVoter implements MakerInterface
         ];
     }
 
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io)
+    public function writeSuccessMessage(array $params, ConsoleStyle $io)
     {
+        parent::writeSuccessMessage($params, $io);
+
         $io->text([
             'Next: Open your voter and add your logic.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/security/voters.html</>',

--- a/src/MakerInterface.php
+++ b/src/MakerInterface.php
@@ -88,5 +88,5 @@ interface MakerInterface
      * @param array        $params
      * @param ConsoleStyle $io
      */
-    public function writeNextStepsMessage(array $params, ConsoleStyle $io);
+    public function writeSuccessMessage(array $params, ConsoleStyle $io);
 }

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -56,5 +56,10 @@
             <service id="maker.maker.make_voter" class="Symfony\Bundle\MakerBundle\Maker\MakeVoter">
                 <tag name="maker.command" />
             </service>
+
+            <service id="maker.maker.make_migration" class="Symfony\Bundle\MakerBundle\Maker\MakeMigration">
+                <argument>%kernel.project_dir%</argument>
+                <tag name="maker.command" />
+            </service>
         </services>
 </container>

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -46,8 +46,8 @@ Creating your Own Makers
 
 In case your applications need to generate custom boilerplate code, you can
 create your own ``make:...`` command reusing the tools provided by this bundle.
-To do that, you should create a class that implements
-:class:`Symfony\\Bundle\\MakerBundle\\MakerInterface` in your ``src/Maker/``
+To do that, you should create a class that extends
+:class:`Symfony\\Bundle\\MakerBundle\\Maker\\AbstractMaker` in your ``src/Maker/``
 directory. And this is really it!
 
 For examples of how to complete your new maker command, see the `core maker commands`_.

--- a/src/Resources/help/MakeMigration.txt
+++ b/src/Resources/help/MakeMigration.txt
@@ -1,0 +1,3 @@
+The <info>%command.name%</info> command generates a new migration:
+
+<info>php %command.full_name%</info>

--- a/src/Resources/skeleton/test/Functional.tpl.php
+++ b/src/Resources/skeleton/test/Functional.tpl.php
@@ -12,6 +12,6 @@ class <?= $test_class_name ?> extends WebTestCase
         $crawler = $client->request('GET', '/');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertSame(0, $crawler->filter('html:contains("Hello World")')->count());
+        $this->assertSame(1, $crawler->filter('h1:contains("Hello World")')->count());
     }
 }

--- a/tests/fixtures/MakeFunctional/config/routes.yaml
+++ b/tests/fixtures/MakeFunctional/config/routes.yaml
@@ -1,0 +1,3 @@
+homepage:
+    path: /
+    controller: App\Controller\MainController::homepage

--- a/tests/fixtures/MakeFunctional/src/Controller/MainController.php
+++ b/tests/fixtures/MakeFunctional/src/Controller/MainController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class MainController
+{
+    public function homepage()
+    {
+        // create a controller that will make the functional test pass
+        return new Response('<html><body><h1>Hello World</h1></body></html>');
+    }
+}

--- a/tests/fixtures/MakeMigration/src/Entity/SpicyFood.php
+++ b/tests/fixtures/MakeMigration/src/Entity/SpicyFood.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class SpicyFood
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+}


### PR DESCRIPTION
This replaces #10.

There are 2 cases:

(A) When there ARE schema changes:

<img width="1053" alt="screen shot 2017-12-29 at 11 07 47 pm" src="https://user-images.githubusercontent.com/121003/34451290-9b0c9bb0-ecef-11e7-9a1d-41ba78c84638.png">

(B) When there are NOT schema changes:

<img width="1269" alt="screen shot 2017-12-29 at 11 07 14 pm" src="https://user-images.githubusercontent.com/121003/34451291-a617113e-ecef-11e7-979f-c30f2cc3e91e.png">

This includes a BC break on `MakerInterface`, but it will only affect people who have created custom makers (and they'll get a clear error).