### PR TITLE
Changing configureDependencies() to be static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@
   `AbstractMaker` instead of implementing the interface directly,
   and use `parent::writeSuccessMessage()` to get the normal success
   message after the command.
+
+* [BC BREAK] The MakerInterface changed: `configureDependencies()`
+  was changed to be static.

--- a/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
+++ b/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\MakerBundle\Command\MakerCommand;
 use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
@@ -27,7 +28,10 @@ class MakeCommandRegistrationPass implements CompilerPassInterface
                 sprintf('maker.auto_command.%s', Str::asTwigVariable($class::getCommandName())),
                 MakerCommand::class
             )->setArguments([
-                new Reference($id),
+                ServiceLocatorTagPass::register($container, [
+                    'maker' => new Reference($id),
+                ]),
+                $class,
                 new Reference('maker.generator'),
             ])->addTag('console.command', ['command' => $class::getCommandName()]);
         }

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -67,7 +67,7 @@ final class MakeAuthenticator extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             SecurityBundle::class,

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -69,7 +69,7 @@ final class MakeCommand extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             Command::class,

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -83,7 +83,7 @@ final class MakeController extends AbstractMaker
         $io->text('Next: Open your new controller class and add some pages!');
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             Route::class,

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -73,7 +73,7 @@ final class MakeEntity extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             Column::class,

--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -71,7 +71,7 @@ final class MakeForm extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             AbstractType::class,

--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -69,7 +69,7 @@ class MakeFunctionalTest extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             Client::class,

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -121,7 +121,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             DoctrineCommand::class,

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -70,7 +70,7 @@ final class MakeSerializerEncoder extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             Serializer::class,

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -105,7 +105,7 @@ final class MakeSubscriber extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
     }
 }

--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -68,7 +68,7 @@ final class MakeTwigExtension extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             AbstractExtension::class,

--- a/src/Maker/MakeUnitTest.php
+++ b/src/Maker/MakeUnitTest.php
@@ -67,7 +67,7 @@ final class MakeUnitTest extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
     }
 }

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -71,7 +71,7 @@ final class MakeValidator extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             Validation::class,

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -68,7 +68,7 @@ final class MakeVoter extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public static function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
             Voter::class,

--- a/src/MakerInterface.php
+++ b/src/MakerInterface.php
@@ -44,7 +44,7 @@ interface MakerInterface
      *
      * @param DependencyBuilder $dependencies
      */
-    public function configureDependencies(DependencyBuilder $dependencies);
+    public static function configureDependencies(DependencyBuilder $dependencies);
 
     /**
      * If necessary, you can use this method to interactively ask the user for input.

--- a/src/Test/MakerTestCase.php
+++ b/src/Test/MakerTestCase.php
@@ -53,7 +53,7 @@ class MakerTestCase extends TestCase
         $executableFinder = new PhpExecutableFinder();
         $phpPath = $executableFinder->find(false);
         $makerProcess = $this->createProcess(
-            sprintf('%s bin/console %s', $phpPath, ($testDetails->getMaker())::getCommandName()),
+            sprintf('%s bin/console %s', $phpPath, call_user_func([$testDetails->getMakerClass(), 'getCommandName'])),
             self::$currentRootDir
         );
         $makerProcess->setTimeout(10);

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -12,11 +12,10 @@
 namespace Symfony\Bundle\MakerBundle\Test;
 
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
-use Symfony\Bundle\MakerBundle\MakerInterface;
 
 final class MakerTestDetails
 {
-    private $maker;
+    private $makerClass;
 
     private $inputs;
 
@@ -33,20 +32,20 @@ final class MakerTestDetails
     private $extraDependencies = [];
 
     /**
-     * @param MakerInterface $maker
-     * @param array          $inputs
+     * @param string $makerClass
+     * @param array  $inputs
      *
      * @return static
      */
-    public static function createTest(MakerInterface $maker, array $inputs)
+    public static function createTest(string $makerClass, array $inputs)
     {
-        return new static($maker, $inputs);
+        return new static($makerClass, $inputs);
     }
 
-    private function __construct(MakerInterface $maker, array $inputs)
+    private function __construct(string $makerClass, array $inputs)
     {
         $this->inputs = $inputs;
-        $this->maker = $maker;
+        $this->makerClass = $makerClass;
     }
 
     public function setFixtureFilesPath(string $fixtureFilesPath): self
@@ -121,7 +120,7 @@ final class MakerTestDetails
     {
         // create a unique directory name for this project
         // but one that will be the same each time the tests are run
-        return (new \ReflectionObject($this->maker))->getShortName().'_'.($this->fixtureFilesPath ? basename($this->fixtureFilesPath) : 'default').'_'.md5(serialize($this->extraDependencies));
+        return (new \ReflectionClass($this->makerClass))->getShortName().'_'.($this->fixtureFilesPath ? basename($this->fixtureFilesPath) : 'default').'_'.md5(serialize($this->extraDependencies));
     }
 
     public function getPreMakeCommands(): array
@@ -139,9 +138,9 @@ final class MakerTestDetails
         return $this->replacements;
     }
 
-    public function getMaker(): MakerInterface
+    public function getMakerClass(): string
     {
-        return $this->maker;
+        return $this->makerClass;
     }
 
     /**
@@ -155,7 +154,7 @@ final class MakerTestDetails
     public function getDependencies()
     {
         $depBuilder = new DependencyBuilder();
-        $this->maker->configureDependencies($depBuilder);
+        call_user_func([$this->makerClass, 'configureDependencies'], $depBuilder);
 
         return array_merge($depBuilder->getMissingDependencies(), $this->extraDependencies);
     }

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -51,7 +51,7 @@ class FunctionalTest extends MakerTestCase
     public function getCommandTests()
     {
         yield 'command' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeCommand::class),
+            MakeCommand::class,
             [
                 // command name
                 'app:foo',
@@ -60,7 +60,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'controller' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeController::class),
+            MakeController::class,
             [
                 // controller class name
                 'FooBar',
@@ -69,7 +69,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'entity' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeEntity::class),
+            MakeEntity::class,
             [
                 // entity class name
                 'TastyFood',
@@ -91,7 +91,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'form' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeForm::class),
+            MakeForm::class,
             [
                 // form name
                 'FooBar',
@@ -99,7 +99,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'functional' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeFunctionalTest::class),
+            MakeFunctionalTest::class,
             [
                 // functional test class name
                 'FooBar',
@@ -108,7 +108,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'subscriber' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeSubscriber::class),
+            MakeSubscriber::class,
             [
                 // subscriber name
                 'FooBar',
@@ -118,7 +118,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'subscriber_unknown_event_class' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeSubscriber::class),
+            MakeSubscriber::class,
             [
                 // subscriber name
                 'FooBar',
@@ -128,7 +128,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'serializer_encoder' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeSerializerEncoder::class),
+            MakeSerializerEncoder::class,
             [
                 // encoder class name
                 'FooBarEncoder',
@@ -138,7 +138,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'twig_extension' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeTwigExtension::class),
+            MakeTwigExtension::class,
             [
                 // extension class name
                 'FooBar',
@@ -146,7 +146,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'unit_test' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeUnitTest::class),
+            MakeUnitTest::class,
             [
                 // class name
                 'FooBar',
@@ -154,7 +154,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'validator' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeValidator::class),
+            MakeValidator::class,
             [
                 // validator name
                 'FooBar',
@@ -162,7 +162,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'voter' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeVoter::class),
+            MakeVoter::class,
             [
                 // voter class name
                 'FooBar',
@@ -170,7 +170,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'auth_empty' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeAuthenticator::class),
+            MakeAuthenticator::class,
             [
                 // class name
                 'AppCustomAuthenticator',
@@ -178,7 +178,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'migration_with_changes' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeMigration::class),
+            MakeMigration::class,
             [/* no input */])
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMigration')
             ->addReplacement(
@@ -206,7 +206,7 @@ class FunctionalTest extends MakerTestCase
         ];
 
         yield 'migration_no_changes' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeMigration::class),
+            MakeMigration::class,
             [/* no input */])
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMigration')
             ->addReplacement(
@@ -251,22 +251,9 @@ class FunctionalTest extends MakerTestCase
             $this->assertInstanceOf(MakerCommand::class, $command);
         }
     }
-
-    private function getMakerInstance(string $makerClass): MakerInterface
-    {
-        if (null === $this->kernel) {
-            $this->kernel = new FunctionalTestKernel('dev', true);
-            $this->kernel->boot();
-        }
-
-        // a cheap way to guess the service id
-        $serviceId = $serviceId ?? sprintf('maker.maker.%s', Str::asRouteName((new \ReflectionClass($makerClass))->getShortName()));
-
-        return $this->kernel->getContainer()->get($serviceId);
-    }
 }
 
-class FunctionalTestKernel extends Kernel implements CompilerPassInterface
+class FunctionalTestKernel extends Kernel
 {
     use MicroKernelTrait;
 
@@ -290,14 +277,5 @@ class FunctionalTestKernel extends Kernel implements CompilerPassInterface
     public function getRootDir()
     {
         return sys_get_temp_dir().'/'.uniqid('sf_maker_', true);
-    }
-
-    public function process(ContainerBuilder $container)
-    {
-        // makes all makers public to help the tests
-        foreach ($container->findTaggedServiceIds(MakeCommandRegistrationPass::MAKER_TAG) as $id => $tags) {
-            $defn = $container->getDefinition($id);
-            $defn->setPublic(true);
-        }
     }
 }


### PR DESCRIPTION
Hi guys!

This includes another minor BC break (I say minor, because it only affects people creating custom maker classes). This is necessary because of the following situation:

A) Suppose I create a maker (e.g. `make:entity`) that requires Doctrine's EntityManager in its `__construct()` method
B) If I call `make:entity` but don't have the ORM installed, I will get a dependency error from the container, instead of the nice `Please run composer require orm` error.

But, after this PR, if the user run `make:entity --help`, they will get the `Please run composer require orm` error instead of seeing the help information. That's because `MakerInterface::configureCommand()` is still non-static. But I think this is ok.

Thanks!