### PR TITLE
Add description and homepage to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "description": "Symfony Maker helps you create empty commands, controllers, form classes, tests and more so you can forget about writing boilerplate code.",
     "name": "symfony/maker-bundle",
     "type": "symfony-bundle",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "description": "Symfony Maker helps you create empty commands, controllers, form classes, tests and more so you can forget about writing boilerplate code.",
+    "homepage": "https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html",
     "name": "symfony/maker-bundle",
     "type": "symfony-bundle",
     "license": "MIT",


### PR DESCRIPTION
According to `composer validate` the property description is required.

I did also add the property homepage in an separate commit. So you can cherry pick if you want.