### PR TITLE
Type hints for repositories

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -1,24 +1,30 @@
-<?= "<?php\n" ?>
+<?= "<?php\n"; ?>
 
 namespace App\Repository;
 
-use App\Entity\<?= $entity_class_name ?>;
+use App\Entity\<?= $entity_class_name; ?>;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 
-class <?= $repository_class_name ?> extends ServiceEntityRepository
+/**
+ * @method <?= $entity_class_name; ?>|null find($id, $lockMode = null, $lockVersion = null)
+ * @method <?= $entity_class_name; ?>|null findOneBy(array $criteria, array $orderBy = null)
+ * @method <?= $entity_class_name; ?>[]    findAll()
+ * @method <?= $entity_class_name; ?>[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class <?= $repository_class_name; ?> extends ServiceEntityRepository
 {
     public function __construct(RegistryInterface $registry)
     {
-        parent::__construct($registry, <?= $entity_class_name ?>::class);
+        parent::__construct($registry, <?= $entity_class_name; ?>::class);
     }
 
     /*
     public function findBySomething($value)
     {
-        return $this->createQueryBuilder('<?= $entity_alias ?>')
-            ->where('<?= $entity_alias ?>.something = :value')->setParameter('value', $value)
-            ->orderBy('<?= $entity_alias ?>.id', 'ASC')
+        return $this->createQueryBuilder('<?= $entity_alias; ?>')
+            ->where('<?= $entity_alias; ?>.something = :value')->setParameter('value', $value)
+            ->orderBy('<?= $entity_alias; ?>.id', 'ASC')
             ->setMaxResults(10)
             ->getQuery()
             ->getResult()


### PR DESCRIPTION
It helps IDE to get correct type if you do calls like this

```php
$user = $this->userRepository->find(1);
$user->getId(); //IDE knows that this is a User class and gives correct autocomplete
```