### PR TITLE
Fixing dependency issue on maker

### DIFF
--- a/src/DependencyBuilder.php
+++ b/src/DependencyBuilder.php
@@ -53,4 +53,21 @@ final class DependencyBuilder
 
         return array_merge($missingPackages, $missingOptionalPackages);
     }
+
+    /**
+     * @internal
+     */
+    public function getAllRequiredDependencies(): array
+    {
+        $dependencies = [];
+        foreach ($this->dependencies as $class => $package) {
+            if (!$package['required']) {
+                continue;
+            }
+
+            $dependencies[] = $package['name'];
+        }
+
+        return $dependencies;
+    }
 }

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
-use Symfony\Component\Routing\Annotation\Route;
+use Doctrine\Common\Annotations\Annotation;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
@@ -86,7 +86,9 @@ final class MakeController extends AbstractMaker
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
-            Route::class,
+            // we only need doctrine/annotations, which contains
+            // the recipe that loads annotation routes
+            Annotation::class,
             'annotations'
         );
     }

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -157,6 +157,6 @@ final class MakerTestDetails
         $depBuilder = new DependencyBuilder();
         $this->maker->configureDependencies($depBuilder);
 
-        return array_merge($depBuilder->getMissingDependencies(), $this->extraDependencies);
+        return array_merge($depBuilder->getAllRequiredDependencies(), $this->extraDependencies);
     }
 }


### PR DESCRIPTION
Also needed tweak to a test so that this dep IS installed in the functional tests, even though the class exists in MakerBundle itself.

The cool thing is that the test failure *was* correct: we mis-configured the dependencies on this maker (the user DOES have the `Route` class, but even still, they need to install a library so it's loaded).