### PR TITLE
Running phpcs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,6 @@ install:
     - composer --prefer-dist install
     - ./vendor/bin/simple-phpunit install
 
-script: ./vendor/bin/simple-phpunit
+script:
+    - ./vendor/bin/simple-phpunit
+    - ./vendor/bin/php-cs-fixer fix --dry-run


### PR DESCRIPTION
Usually this is done by fabbot, but it mis-reports all of our `[]` as invalid. I'd rather not use fabbot (it makes all of our PR's look like build failures) and just validate the CS on the tests.