### PR TITLE
Fixing bug where makers couldn't advertise needed *dev* dependencies

### DIFF
--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -60,8 +60,9 @@ final class MakerCommand extends Command
         if ($this->checkDependencies) {
             $dependencies = new DependencyBuilder();
             $this->maker->configureDependencies($dependencies);
-            if ($missingPackages = $dependencies->getMissingDependencies()) {
-                throw new RuntimeCommandException(sprintf("Missing package%s: to use the %s command, run: \n\ncomposer require %s", 1 === count($missingPackages) ? '' : 's', $this->getName(), implode(' ', $missingPackages)));
+
+            if ($missingPackagesMessage = $dependencies->getMissingPackagesMessage($this->getName())) {
+                throw new RuntimeCommandException($missingPackagesMessage);
             }
         }
     }

--- a/src/DependencyBuilder.php
+++ b/src/DependencyBuilder.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle;
 final class DependencyBuilder
 {
     private $dependencies = [];
+    private $devDependencies = [];
 
     /**
      * Add a dependency that will be reported if the given class is missing.
@@ -22,36 +23,37 @@ final class DependencyBuilder
      * the user if other required dependencies are missing. An example
      * is the "validator" when trying to work with forms.
      */
-    public function addClassDependency(string $class, string $package, bool $required = true)
+    public function addClassDependency(string $class, string $package, bool $required = true, bool $devDependency = false)
     {
-        $this->dependencies[$class] = [
-            'name' => $package,
-            'required' => $required,
-        ];
+        if ($devDependency) {
+            $this->devDependencies[] = [
+                'class' => $class,
+                'name' => $package,
+                'required' => $required,
+            ];
+        } else {
+            $this->dependencies[] = [
+                'class' => $class,
+                'name' => $package,
+                'required' => $required,
+            ];
+        }
     }
 
+    /**
+     * @internal
+     */
     public function getMissingDependencies(): array
     {
-        $missingPackages = [];
-        $missingOptionalPackages = [];
+        return $this->calculateMissingDependencies($this->dependencies);
+    }
 
-        foreach ($this->dependencies as $class => $package) {
-            if (class_exists($class)) {
-                continue;
-            }
-
-            if (true === $package['required']) {
-                $missingPackages[] = $package['name'];
-            } else {
-                $missingOptionalPackages[] = $package['name'];
-            }
-        }
-
-        if (empty($missingPackages)) {
-            return [];
-        }
-
-        return array_merge($missingPackages, $missingOptionalPackages);
+    /**
+     * @internal
+     */
+    public function getMissingDevDependencies(): array
+    {
+        return $this->calculateMissingDependencies($this->devDependencies);
     }
 
     /**
@@ -59,15 +61,80 @@ final class DependencyBuilder
      */
     public function getAllRequiredDependencies(): array
     {
-        $dependencies = [];
-        foreach ($this->dependencies as $class => $package) {
+        return $this->getRequiredDependencyNames($this->dependencies);
+    }
+
+    /**
+     * @internal
+     */
+    public function getAllRequiredDevDependencies(): array
+    {
+        return $this->getRequiredDependencyNames($this->devDependencies);
+    }
+
+    /**
+     * @internal
+     */
+    public function getMissingPackagesMessage(string $commandName): string
+    {
+        $packages = $this->getMissingDependencies();
+        $packagesDev = $this->getMissingDevDependencies();
+
+        if (empty($packages) && empty($packagesDev)) {
+            return '';
+        }
+
+        $packagesCount = count($packages) + count($packagesDev);
+
+        $message = sprintf(
+            "Missing package%s: to use the %s command, run:\n",
+            $packagesCount > 1 ? 's' : '',
+            $commandName
+            //
+        );
+
+        if (!empty($packages)) {
+            $message .= sprintf("\ncomposer require %s", implode(' ', $packages));
+        }
+
+        if (!empty($packagesDev)) {
+            $message .= sprintf("\ncomposer require %s --dev", implode(' ', $packagesDev));
+        }
+
+        return $message;
+    }
+
+    private function getRequiredDependencyNames(array $dependencies)
+    {
+        $packages = [];
+        foreach ($dependencies as $package) {
             if (!$package['required']) {
                 continue;
             }
-
-            $dependencies[] = $package['name'];
+            $packages[] = $package['name'];
         }
 
-        return $dependencies;
+        return $packages;
+    }
+
+    private function calculateMissingDependencies(array $dependencies)
+    {
+        $missingPackages = [];
+        $missingOptionalPackages = [];
+        foreach ($dependencies as $package) {
+            if (class_exists($package['class'])) {
+                continue;
+            }
+            if (true === $package['required']) {
+                $missingPackages[] = $package['name'];
+            } else {
+                $missingOptionalPackages[] = $package['name'];
+            }
+        }
+        if (empty($missingPackages)) {
+            return [];
+        }
+
+        return array_merge($missingPackages, $missingOptionalPackages);
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *
  * @internal
  */
-final class Generator
+class Generator
 {
     private $fileManager;
     private $io;

--- a/src/Maker/MakeFixtures.php
+++ b/src/Maker/MakeFixtures.php
@@ -78,7 +78,9 @@ final class MakeFixtures extends AbstractMaker
         );
         $dependencies->addClassDependency(
             Fixture::class,
-            'orm-fixtures'
+            'orm-fixtures',
+            true,
+            true
         );
     }
 }

--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -73,11 +73,15 @@ class MakeFunctionalTest extends AbstractMaker
     {
         $dependencies->addClassDependency(
             Client::class,
-            'browser-kit'
+            'browser-kit',
+            true,
+            true
         );
         $dependencies->addClassDependency(
             CssSelectorConverter::class,
-            'css-selector'
+            'css-selector',
+            true,
+            true
         );
     }
 }

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -157,6 +157,10 @@ final class MakerTestDetails
         $depBuilder = new DependencyBuilder();
         $this->maker->configureDependencies($depBuilder);
 
-        return array_merge($depBuilder->getAllRequiredDependencies(), $this->extraDependencies);
+        return array_merge(
+            $depBuilder->getAllRequiredDependencies(),
+            $depBuilder->getAllRequiredDevDependencies(),
+            $this->extraDependencies
+        );
     }
 }

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Command\MakerCommand;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\MakerInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class MakerCommandTest extends TestCase
+{
+    /**
+     * @expectedException \Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException
+     * @expectedExceptionMessageRegExp /composer require foo-package/
+     */
+    public function testExceptionOnMissingDependencies()
+    {
+        $maker = $this->createMock(MakerInterface::class);
+        $maker->expects($this->once())
+            ->method('configureDependencies')
+            ->willReturnCallback(function(DependencyBuilder $depBuilder) {
+                $depBuilder->addClassDependency('Foo', 'foo-package');
+            });
+
+        $generator = $this->createMock(Generator::class);
+
+        $command = new MakerCommand($maker, $generator);
+        // needed because it's normally set by the Application
+        $command->setName('make:foo');
+        $tester = new CommandTester($command);
+        $tester->execute(array());
+    }
+}

--- a/tests/DependencyBuilderTest.php
+++ b/tests/DependencyBuilderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+
+class DependencyBuilderTest extends TestCase
+{
+    public function testGetAllRequiredDependencies()
+    {
+        $depBuilder = new DependencyBuilder();
+        $depBuilder->addClassDependency('Foo', 'foo-package');
+        $depBuilder->addClassDependency('Bar', 'bar-package');
+        $depBuilder->addClassDependency('DevStuff', 'dev-stuff-package', true, true);
+        $depBuilder->addClassDependency('DevStuff2', 'dev-stuff2-package', true, true);
+
+        $this->assertSame(['foo-package', 'bar-package'], $depBuilder->getAllRequiredDependencies());
+        $this->assertSame(['dev-stuff-package', 'dev-stuff2-package'], $depBuilder->getAllRequiredDevDependencies());
+    }
+
+    public function testGetMissingDependencies()
+    {
+        $depBuilder = new DependencyBuilder();
+        $depBuilder->addClassDependency('Foo', 'foo-package');
+        $depBuilder->addClassDependency('Bar', 'bar-package', false);
+        $depBuilder->addClassDependency('DevStuff', 'dev-stuff-package', true, true);
+        $depBuilder->addClassDependency('DevStuff2', 'dev-stuff2-package', false, true);
+
+        $this->assertSame(['foo-package', 'bar-package'], $depBuilder->getMissingDependencies());
+        $this->assertSame(['dev-stuff-package', 'dev-stuff2-package'], $depBuilder->getMissingDevDependencies());
+    }
+
+    public function testGetMissingDependenciesNoMissingRequired()
+    {
+        $depBuilder = new DependencyBuilder();
+        $depBuilder->addClassDependency(__CLASS__, 'foo-package');
+        $depBuilder->addClassDependency('Bar', 'bar-package', false);
+
+        $actualDeps = $depBuilder->getMissingDependencies();
+        $this->assertSame([], $actualDeps);
+    }
+
+    /**
+     * @dataProvider getMissingPackagesMessageTests
+     */
+    public function testGetMissingPackagesMessage(array $missingPackages, array $missingDevPackages, string $expectedMessage)
+    {
+        $depBuilder = new DependencyBuilder();
+        foreach ($missingPackages as $missingPackage) {
+            $depBuilder->addClassDependency('Foo', $missingPackage);
+        }
+
+        foreach ($missingDevPackages as $missingPackage) {
+            $depBuilder->addClassDependency('Foo', $missingPackage, true, true);
+        }
+
+        $this->assertSame($expectedMessage, $depBuilder->getMissingPackagesMessage('make:something'));
+    }
+
+    public function getMissingPackagesMessageTests()
+    {
+        yield 'nothing_missing' => [
+            [],
+            [],
+            ''
+        ];
+
+        yield 'missing_one_package' => [
+            ['bar-package'],
+            [],
+            <<<EOF
+Missing package: to use the make:something command, run:
+
+composer require bar-package
+EOF
+        ];
+
+        yield 'missing_multiple_packages' => [
+            ['bar-package', 'other-package'],
+            [],
+            <<<EOF
+Missing packages: to use the make:something command, run:
+
+composer require bar-package other-package
+EOF
+        ];
+
+        yield 'missing_dev_packages' => [
+            [],
+            ['bar-package', 'other-package'],
+            <<<EOF
+Missing packages: to use the make:something command, run:
+
+composer require bar-package other-package --dev
+EOF
+        ];
+    }
+}


### PR DESCRIPTION
Diff is a bit big so that I could get the message just right, but it's covered by tests: you can now say that your maker has a `require` dependency or a `require-dev` dependency and it will report it correctly to the user (e.g. `composer require symfony/foo --dev`).