### PR TITLE
Update absolutizePath

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -140,7 +140,7 @@ class FileManager
 
     private function absolutizePath($path): string
     {
-        if (0 === strpos($path, '/')) {
+        if (0 === strpos($path, '/')|| 0 === strpos($path, substr($this->rootDirectory, 0, -1))) {
             return $path;
         }
 


### PR DESCRIPTION
Fix problem, when path might appears twice like this
`
C:\Users\RSalo\PhpstormProjects\symfony-test-project//C:\Users\RSalo\PhpstormProjects\symfony-test-project\vendor\composer/../../src/Entity
`
https://github.com/symfony/symfony/issues/26258