### PR TITLE
Add a trailing slash to $route_path to avoid "No route found" error

### DIFF
--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class <?= $class_name; ?> extends Controller
 {
     /**
-     * @Route("<?= $route_path ?>", name="<?= $route_name ?>")
+     * @Route("<?= $route_path.'/' ?>", name="<?= $route_name ?>")
      */
     public function index()
     {


### PR DESCRIPTION
Request with a trailing slash to a controller generated by "make:controller" cause "No route found" error.

Add a trailing slash to $route_path in 'src/Resources/skeleton/controller/Controller.tpl.php' since ["adding a trailing slash in the route path is the best way to ensure that both URLs work."](http://symfony.com/doc/current/routing.html#redirecting-urls-with-trailing-slashes)