### PR TITLE
Fix expected variable type

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,4 +19,10 @@
             <exclude>tests/tmp</exclude>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -62,7 +62,7 @@ final class Validator
             throw new RuntimeCommandException(sprintf('Invalid length "%s".', $length));
         }
 
-        return $length;
+        return $result;
     }
 
     public static function validatePrecision($precision)
@@ -79,7 +79,7 @@ final class Validator
             throw new RuntimeCommandException(sprintf('Invalid precision "%s".', $precision));
         }
 
-        return $precision;
+        return $result;
     }
 
     public static function validateScale($scale)
@@ -96,7 +96,7 @@ final class Validator
             throw new RuntimeCommandException(sprintf('Invalid scale "%s".', $scale));
         }
 
-        return $scale;
+        return $result;
     }
 
     public static function validateBoolean($value)

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+
+class ValidatorTest extends TestCase
+{
+    public function testValidateLength()
+    {
+        $this->assertSame(100, Validator::validateLength('100'));
+        $this->assertSame(99, Validator::validateLength(99));
+    }
+
+    public function testInvalidLength()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('Invalid length "-100".');
+
+        Validator::validateLength(-100);
+    }
+
+    public function testValidatePrecision()
+    {
+        $this->assertSame(15, Validator::validatePrecision('15'));
+        $this->assertSame(21, Validator::validatePrecision(21));
+    }
+
+    public function testInvalidPrecision()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('Invalid precision "66".');
+
+        Validator::validatePrecision(66);
+    }
+
+    public function testValidateScale()
+    {
+        $this->assertSame(2, Validator::validateScale('2'));
+        $this->assertSame(5, Validator::validateScale(5));
+    }
+
+    public function testInvalidScale()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('Invalid scale "31".');
+
+        Validator::validateScale(31);
+    }
+}


### PR DESCRIPTION
error when run `doctrine:schema:update --dump-sql` after creating entity using maker-bundle because of the attribute type error.

for example when generate field with length 100 the annotation will be generate like this
`@ORM\Column(type="string", length="100", nullable=true)` and when run the schema update command will throw exception 
```
In AnnotationException.php line 83:

  [Type Error] Attribute "length" of @ORM\Column declared on property App\Entity\Entity::$field expects a(n) integer, but got string.
```

and it is also affect for `precision` and `scale`