### PR TITLE
Ignorning tests so it is not downloaded via Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore


### PR DESCRIPTION
This is different than the policy in symfony/symfony. But, this library is a bit different:  the tests do *not* contain example usage code, as most of the classes are internal. By not packing the tests/ directory, we avoid polluting the user's project with extra User classes (etc) that confuse IDE's.

Fixes #144