### PR TITLE
Get the autoloader class from current registered autoload functions

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,9 +13,7 @@
                 <argument>%kernel.project_dir%</argument>
             </service>
 
-            <service id="maker.autoloader_util" class="Symfony\Bundle\MakerBundle\Util\AutoloaderUtil">
-                <argument>%kernel.project_dir%</argument>
-            </service>
+            <service id="maker.autoloader_util" class="Symfony\Bundle\MakerBundle\Util\AutoloaderUtil" />
 
             <service id="maker.event_registry" class="Symfony\Bundle\MakerBundle\EventRegistry">
                 <argument type="service" id="event_dispatcher" />


### PR DESCRIPTION
If the default folder for vendor is changed the AutloaderUtil class is no more able to find the ClassLoader. Testing the failure can be easily done by changing the **vendor-dir** in composer.json. After adjusting the autoload require in console file, all makers that use AutoloadUtil will fail.

Motivation behind this is development with docker. The application is a lot faster on windows and mac if the vendor folder is not a shared folder.