### PR TITLE
Fix the EntityRegenerator on Mac

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,6 +3,18 @@
 if (!file_exists(__DIR__.'/src')) {
     exit(0);
 }
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    // the PHP template files are a bit special
+    ->notName('*.tpl.php')
+;
+
+if (\PHP_VERSION_ID < 70100) {
+    // EntityRegenerator works only with PHP 7.1+
+    $finder->notName('EntityRegenerator.php');
+}
+
 return PhpCsFixer\Config::create()
     ->setRules(array(
         '@Symfony' => true,
@@ -22,10 +34,5 @@ EOF
         ]
     ))
     ->setRiskyAllowed(true)
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->in(__DIR__.'/src')
-            // the PHP template files are a bit special
-            ->notName('*.tpl.php')
-    )
+    ->setFinder($finder)
 ;

--- a/src/Doctrine/EntityRegenerator.php
+++ b/src/Doctrine/EntityRegenerator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Doctrine;
 
+use Doctrine\Common\Persistence\Mapping\MappingException as CommonMappingException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
@@ -43,7 +44,7 @@ final class EntityRegenerator
     {
         try {
             $metadata = $this->doctrineHelper->getMetadata($classOrNamespace);
-        } catch (MappingException $mappingException) {
+        } catch (MappingException | CommonMappingException $mappingException) {
             $metadata = $this->doctrineHelper->getMetadata($classOrNamespace, true);
         }
 


### PR DESCRIPTION
On Mac, an instance of `Doctrine\Common\Persistence\Mapping\MappingException` is thrown by Doctrine when a mapping file references a non-existing class. Currently, the code only catches `Doctrine\ORM\Mapping\MappingException` instances.

This PR makes the tests green on Mac (https://github.com/symfony/maker-bundle/issues/167#issuecomment-387976395). This also probably fixes a real bug.

I've no idea why Doctrine throws a different exception on Mac than on Linux.