### PR TITLE
fixed EntityRegenerator when using MappedSuperclass or Traits

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -535,7 +535,20 @@ final class ClassSourceManipulator
     private function addStatementToConstructor(Node\Stmt $stmt)
     {
         if (!$this->getConstructorNode()) {
-            $constructorNode = $getterNodeBuilder = (new Builder\Method('__construct'))->makePublic()->getNode();
+            $constructorNode = (new Builder\Method('__construct'))->makePublic()->getNode();
+
+            // add call to parent::__construct() if there is a need to
+            try {
+                $ref = new \ReflectionClass($this->getThisFullClassName());
+
+                if ($ref->getParentClass() && $ref->getParentClass()->getConstructor()) {
+                    $constructorNode->stmts[] = new Node\Stmt\Expression(
+                        new Node\Expr\StaticCall(new Node\Name('parent'), new Node\Identifier('__construct'))
+                    );
+                }
+            } catch (\ReflectionException $e) {
+            }
+
             $this->addNodeAfterProperties($constructorNode);
         }
 

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass()
+ */
+class BaseClient
+{
+    use TeamTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $name;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="User")
+     */
+    private $creator;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $magic;
+
+    public function __construct()
+    {
+        $this->magic = 42;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getMagic(): ?int
+    {
+        return $this->magic;
+    }
+
+    public function setMagic(int $magic): self
+    {
+        $this->magic = $magic;
+
+        return $this;
+    }
+
+    public function getCreator(): ?User
+    {
+        return $this->creator;
+    }
+
+    public function setCreator(?User $creator): self
+    {
+        $this->creator = $creator;
+
+        return $this;
+    }
+}

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Client extends BaseClient
+{
+    use TimestampableTrait;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Tag")
+     */
+    private $tags;
+
+    /**
+     * @ORM\Embedded(class="Embed")
+     */
+    private $embed;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->embed = new Embed();
+        $this->tags = new ArrayCollection();
+    }
+
+    public function getEmbed(): Embed
+    {
+        return $this->embed;
+    }
+
+    public function setEmbed(Embed $embed): self
+    {
+        $this->embed = $embed;
+
+        return $this;
+    }
+
+    public function getApiKey(): ?string
+    {
+        return $this->apiKey;
+    }
+
+    public function setApiKey(string $apiKey): self
+    {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Tag[]
+     */
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(Tag $tag): self
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags[] = $tag;
+        }
+
+        return $this;
+    }
+
+    public function removeTag(Tag $tag): self
+    {
+        if ($this->tags->contains($tag)) {
+            $this->tags->removeElement($tag);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Embed.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable()
+ */
+class Embed
+{
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $val;
+
+    public function getVal(): ?int
+    {
+        return $this->val;
+    }
+
+    public function setVal(int $val): self
+    {
+        $this->val = $val;
+
+        return $this;
+    }
+}

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass()
+ */
+class BaseClient
+{
+    use TeamTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $name;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="User")
+     */
+    private $creator;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $magic;
+
+    public function __construct()
+    {
+        $this->magic = 42;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getMagic(): ?int
+    {
+        return $this->magic;
+    }
+
+    public function setMagic(int $magic): self
+    {
+        $this->magic = $magic;
+
+        return $this;
+    }
+
+    public function getCreator(): ?User
+    {
+        return $this->creator;
+    }
+
+    public function setCreator(?User $creator): self
+    {
+        $this->creator = $creator;
+
+        return $this;
+    }
+}

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Client extends BaseClient
+{
+    use TimestampableTrait;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Tag")
+     */
+    private $tags;
+
+    /**
+     * @ORM\Embedded(class="Embed")
+     */
+    private $embed;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->embed = new Embed();
+        $this->tags = new ArrayCollection();
+    }
+
+    public function getEmbed(): Embed
+    {
+        return $this->embed;
+    }
+
+    public function setEmbed(Embed $embed): self
+    {
+        $this->embed = $embed;
+
+        return $this;
+    }
+
+    public function getApiKey(): ?string
+    {
+        return $this->apiKey;
+    }
+
+    public function setApiKey(string $apiKey): self
+    {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Tag[]
+     */
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function addTag(Tag $tag): self
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags[] = $tag;
+        }
+
+        return $this;
+    }
+
+    public function removeTag(Tag $tag): self
+    {
+        if ($this->tags->contains($tag)) {
+            $this->tags->removeElement($tag);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Embed.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable()
+ */
+class Embed
+{
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $val;
+
+    public function getVal(): ?int
+    {
+        return $this->val;
+    }
+
+    public function setVal(int $val): self
+    {
+        $this->val = $val;
+
+        return $this;
+    }
+}

--- a/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass()
+ */
+class BaseClient
+{
+    use TeamTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private $name;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="User")
+     */
+    private $creator;
+
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $magic;
+
+    public function __construct()
+    {
+        $this->magic = 42;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Client.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Client extends BaseClient
+{
+    use TimestampableTrait;
+
+    /**
+     * @ORM\Column(type="string")
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Tag")
+     */
+    private $tags;
+
+    /**
+     * @ORM\Embedded(class="Embed")
+     */
+    private $embed;
+}

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Embed.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable()
+ */
+class Embed
+{
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $val;
+}

--- a/tests/Doctrine/fixtures/source_project/src/Entity/TeamTrait.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/TeamTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait TeamTrait
+{
+    /**
+     * @ORM\ManyToMany(targetEntity="User")
+     */
+    private $members;
+}

--- a/tests/Doctrine/fixtures/source_project/src/Entity/TimestampableTrait.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/TimestampableTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine\fixtures\source_project\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait TimestampableTrait
+{
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private $updatedAt;
+
+    /**
+     * @return mixed
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param mixed $createdAt
+     */
+    public function setCreatedAt($createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param mixed $updatedAt
+     */
+    public function setUpdatedAt($updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}


### PR DESCRIPTION
Should fix #167 

**What has been fixed**

- generation for mapped inherited fields
- generation for mapped fields that come from direct traits
- skipping ```parent::__construct()``` if Entity has parent class and it has constructor

**How it is done**

- fields (fields, and associations, but not embedded) are checked before generation, generation happens only for class' fields
- ClassSourceManipulator is updated to include parent call (if parent class exists and the class has already been generated)
- EntityRegeneratorTest skips copying of Traits as it causes autoloader to fail (again, strangely, on Travis only, works fine on Mac)

Verified on live project, seems to generate OK with a lot of different entities (MappedSuperclasses, DiscriminatorMaps etc).

- [x] fix errors generating embedded fields
- [x] fix strange Kernel class errors