### PR TITLE
Fix: No need to specify preferred installation method on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
         - SYMFONY_PHPUNIT_DIR=.phpunit
 
 install:
-    - composer --prefer-dist install
+    - composer install
     - ./vendor/bin/simple-phpunit install
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,7 @@
         "symfony/process": "^3.4|^4.0"
     },
     "config": {
-        "preferred-install": {
-            "*": "dist"
-        },
+        "preferred-install": "dist",
         "sort-packages": true
     },
     "autoload": {


### PR DESCRIPTION
This PR

* [x] removes the `--prefer-dist` option when running `composer install` on Travis
* [x] simplifies the configuration for `preferred-install` in `composer.json`

💁‍♂️ It's already configured in [`composer.json`](https://github.com/symfony/maker-bundle/blob/bb0485a3b2eecc561eff735109316677e18fb1d1/composer.json#L35-L37).