### PR TITLE
Fix: Case mismatch

### DIFF
--- a/src/Util/ClassNameDetails.php
+++ b/src/Util/ClassNameDetails.php
@@ -54,6 +54,6 @@ final class ClassNameDetails
 
     public function getRelativeNameWithoutSuffix(): string
     {
-        return str::removeSuffix($this->getRelativeName(), $this->suffix);
+        return Str::removeSuffix($this->getRelativeName(), $this->suffix);
     }
 }


### PR DESCRIPTION
This PR

* [x] fixes a case mismatch when referencing a class