### PR TITLE
Put the Form Type in a Type folder

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -112,7 +112,7 @@ final class MakeCrud extends AbstractMaker
         do {
             $formClassDetails = $generator->createClassNameDetails(
                 $entityClassDetails->getRelativeNameWithoutSuffix().($iter ?: ''),
-                'Form\\',
+                'Form\\Type\\',
                 'Type'
             );
             ++$iter;

--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -76,7 +76,7 @@ final class MakeForm extends AbstractMaker
     {
         $formClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Form\\',
+            'Form\\Type\\',
             'Type'
         );
 


### PR DESCRIPTION
It makes app scales with ease:

* It's really common to have some extension / transformer / listener:
  It's a mess if you mix extensions / transformers / litener in the same
  folrders. It's better to organize class (/file) responability in
  specific NS / folder
* It's not harmful since people are using (should ?) autocomplete

You may argue it's overkill. But really it's really common to extends
forms capability. So IMHO it's better to put type in a separate folders.
Thus, the only diff in userland is an extra NS level... Not a big deal!