### PR TITLE
Extend from AbstractController when using Symfony 4.1 or higher

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -55,6 +56,7 @@ final class MakeController extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'controller/Controller.tpl.php',
             [
+                'parent_class_name' => (Kernel::VERSION_ID) >= 40100 ? 'AbstractController' : 'Controller',
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'twig_installed' => $this->isTwigInstalled(),

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -21,7 +22,6 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -56,7 +56,7 @@ final class MakeController extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'controller/Controller.tpl.php',
             [
-                'parent_class_name' => (Kernel::VERSION_ID) >= 40100 ? 'AbstractController' : 'Controller',
+                'parent_class_name' => class_exists(AbstractController::class) ? 'AbstractController' : 'Controller',
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'twig_installed' => $this->isTwigInstalled(),

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -56,7 +56,7 @@ final class MakeController extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'controller/Controller.tpl.php',
             [
-                'parent_class_name' => class_exists(AbstractController::class) ? 'AbstractController' : 'Controller',
+                'parent_class_name' => \method_exists(AbstractController::class, 'getParameter') ? 'AbstractController' : 'Controller',
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'twig_installed' => $this->isTwigInstalled(),

--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -2,10 +2,10 @@
 
 namespace <?= $namespace; ?>;
 
+use Symfony\Bundle\FrameworkBundle\Controller\<?= $parent_class_name; ?>;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
-class <?= $class_name; ?> extends Controller
+class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
     /**
      * @Route("<?= $route_path ?>", name="<?= $route_name ?>")


### PR DESCRIPTION
Related to https://github.com/symfony/symfony-docs/pull/9991 ... let's extend from `AbstractController` when possible.