### PR TITLE
Don't make Twig filters safe for HTML by default

### DIFF
--- a/src/Resources/skeleton/twig/Extension.tpl.php
+++ b/src/Resources/skeleton/twig/Extension.tpl.php
@@ -11,7 +11,7 @@ class <?= $class_name ?> extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('filter_name', [$this, 'doSomething'], ['is_safe' => ['html']]),
+            new TwigFilter('filter_name', [$this, 'doSomething']),
         ];
     }
 


### PR DESCRIPTION
This fixes #200.

I disagree with this change ... but I guess most people will agree with it ... so let's do it.