### PR TITLE
Don't use :contains in the functional test tpl

### DIFF
--- a/src/Resources/skeleton/test/Functional.tpl.php
+++ b/src/Resources/skeleton/test/Functional.tpl.php
@@ -12,6 +12,6 @@ class <?= $class_name ?> extends WebTestCase
         $crawler = $client->request('GET', '/');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertCount(1, $crawler->filterXPath('//h1:[contains(text(), "Hello World")]'));
+        $this->assertContains('Hello World', $crawler->filter('h1')->text());
     }
 }

--- a/src/Resources/skeleton/test/Functional.tpl.php
+++ b/src/Resources/skeleton/test/Functional.tpl.php
@@ -12,6 +12,6 @@ class <?= $class_name ?> extends WebTestCase
         $crawler = $client->request('GET', '/');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertSame(1, $crawler->filter('h1:contains("Hello World")')->count());
+        $this->assertCount(1, $crawler->filterXPath('//h1:[contains(text(), "Hello World")]'));
     }
 }


### PR DESCRIPTION
`:contains` is a proprietary jQuery selector, and has been explicitly removed from the CSS 3 spec: https://stackoverflow.com/questions/4781141/why-doesnt-the-selector-h3nth-child1containsa-work/4781167#4781167

Then, it doesn't work with Panthère (it's actually supported by Selenium, but not by WebDriver).

I propose to use Xpath instead.