### PR TITLE
Fixing bad empty line when source file uses tabs

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -658,8 +658,10 @@ final class ClassSourceManipulator
             $this->oldTokens
         );
 
-        // this fake property is a placeholder for a linebreak
-        $newCode = str_replace(['    private $__EXTRA__LINE;', 'use __EXTRA__LINE;', '        $__EXTRA__LINE;'], '', $newCode);
+        // replace the 3 "fake" items that may be in the code (allowing for different indentation)
+        $newCode = preg_replace('/(\ |\t)*private\ \$__EXTRA__LINE;/', '', $newCode);
+        $newCode = preg_replace('/use __EXTRA__LINE;/', '', $newCode);
+        $newCode = preg_replace('/(\ |\t)*\$__EXTRA__LINE;/', '', $newCode);
 
         // process comment lines
         foreach ($this->pendingComments as $i => $comment) {
@@ -829,7 +831,7 @@ final class ClassSourceManipulator
         $newStatements[] = $methodNode;
 
         if (null === $existingIndex) {
-            // just them on the end!
+            // add them to the end!
 
             $classNode->stmts = array_merge($classNode->stmts, $newStatements);
         } else {

--- a/src/Util/PrettyPrinter.php
+++ b/src/Util/PrettyPrinter.php
@@ -20,6 +20,32 @@ use PhpParser\Node\Stmt;
 final class PrettyPrinter extends Standard
 {
     /**
+     * Overridden to fix indentation problem with tabs.
+     *
+     * If the original source code uses tabs, then the tokenizer
+     * will see this as "1" indent level, and will indent new lines
+     * with just 1 space. By changing 1 indent to 4, we effectively
+     * "correct" this problem when printing.
+     *
+     * For code that is even further indented (e.g. 8 spaces),
+     * the printer uses the first indentation (here corrected
+     * from 1 space to 4) and already (without needing any other
+     * changes) adds 4 spaces onto that. This is why we don't
+     * also need to handle indent levels of 5, 9, etc: these
+     * do not occur (at least in the code we generate);
+     *
+     * @param int $level
+     */
+    protected function setIndentLevel(int $level)
+    {
+        if (1 === $level) {
+            $level = 4;
+        }
+
+        parent::setIndentLevel($level);
+    }
+
+    /**
      * Overridden to change coding standards.
      *
      * Before:

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -515,4 +515,22 @@ class ClassSourceManipulatorTest extends TestCase
                 ->setIsOwning(true)
         ];
     }
+
+    public function testGenerationWithTabs()
+    {
+        $source = file_get_contents(__DIR__.'/fixtures/source/ProductWithTabs.php');
+        $expectedSource = file_get_contents(__DIR__.'/fixtures/with_tabs/ProductWithTabs.php');
+
+        $manipulator = new ClassSourceManipulator($source);
+
+        $method = (new \ReflectionObject($manipulator))->getMethod('addProperty');
+        $method->setAccessible(true);
+        $method->invoke($manipulator, 'name', ['@ORM\Column(type="string", length=255)']);
+
+        $method = (new \ReflectionObject($manipulator))->getMethod('addGetter');
+        $method->setAccessible(true);
+        $method->invoke($manipulator, 'id', 'int', false);
+
+        $this->assertSame($expectedSource, $manipulator->getSourceCode());
+    }
 }

--- a/tests/Util/fixtures/source/ProductWithTabs.php
+++ b/tests/Util/fixtures/source/ProductWithTabs.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\ProductRepository")
+ */
+class Product
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 */
+	private $id;
+}

--- a/tests/Util/fixtures/with_tabs/ProductWithTabs.php
+++ b/tests/Util/fixtures/with_tabs/ProductWithTabs.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\ProductRepository")
+ */
+class Product
+{
+	/**
+	 * @ORM\Id()
+	 * @ORM\GeneratedValue()
+	 * @ORM\Column(type="integer")
+	 */
+	private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private $name;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Woo! Fixes #170 

PHP-Parser is responsible for determining indentation for new code. When tabs are used, it sees this as 1 indent, and uses 1 space to indent. This had two side-effects:

1) My original `str_replace` code was not smart enough to handle that. Easy fix using regex
2) In general, any new code (e.g. getter method) is indented with 1 space.