### PR TITLE
fix MakerEntity when generating entity inside folder

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -827,7 +827,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
     private function doesEntityUseAnnotationMapping(string $className): bool
     {
         if (!class_exists($className)) {
-            $otherClassMetadatas = $this->doctrineHelper->getMetadata(Str::getNamespace($className), true);
+            $otherClassMetadatas = $this->doctrineHelper->getMetadata(Str::getNamespace($className) . '\\', true);
 
             // if we have no metadata, we should assume this is the first class being mapped
             if (empty($otherClassMetadatas)) {


### PR DESCRIPTION
fixes #192 

When we're trying to generate an entity inside a folder, and when the namespace of the newly created correspond to an entity that already exists, an error occurs : 

> In MakeEntity.php line 840:
> Call to a member function getName() on string

Ex :
An entity called App\Entity\BlogPost exists, and we try to create an entity named "BlogPost\Comment" 

Actually `Str::getNamespace($className)` refers to an existing class and not to a namespace, then $doctrineHelper->getMetadata() won't return an array, but a single metadata, and this leads to an error.

To prevent this behavior, the easier way is to put a trailing backslash at the end of the namespace name, so we know it won't refer to a classname.
