### PR TITLE
Generate forms in Form\Type namespace

### DIFF
--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -76,7 +76,7 @@ final class MakeForm extends AbstractMaker
     {
         $formClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Form\\',
+            'Form\\Type\\',
             'Type'
         );
 

--- a/tests/fixtures/MakeForm/tests/GeneratedFormTest.php
+++ b/tests/fixtures/MakeForm/tests/GeneratedFormTest.php
@@ -2,7 +2,7 @@
 
 namespace App\Tests;
 
-use App\Form\FooBarType;
+use App\Form\Type\FooBarType;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class GeneratedFormTest extends TypeTestCase

--- a/tests/fixtures/MakeFormEmbedableEntity/tests/GeneratedFormTest.php
+++ b/tests/fixtures/MakeFormEmbedableEntity/tests/GeneratedFormTest.php
@@ -3,7 +3,7 @@
 namespace App\Tests;
 
 use App\Entity\Food;
-use App\Form\FoodType;
+use App\Form\Type\FoodType;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class GeneratedFormTest extends TypeTestCase

--- a/tests/fixtures/MakeFormForEntity/tests/GeneratedFormTest.php
+++ b/tests/fixtures/MakeFormForEntity/tests/GeneratedFormTest.php
@@ -3,7 +3,7 @@
 namespace App\Tests;
 
 use App\Entity\SourFood;
-use App\Form\SourFoodType;
+use App\Form\Type\SourFoodType;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class GeneratedFormTest extends TypeTestCase

--- a/tests/fixtures/MakeFormSTIEntity/tests/GeneratedFormTest.php
+++ b/tests/fixtures/MakeFormSTIEntity/tests/GeneratedFormTest.php
@@ -3,7 +3,7 @@
 namespace App\Tests;
 
 use App\Entity\SourFood;
-use App\Form\SourFoodType;
+use App\Form\Type\SourFoodType;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class GeneratedFormTest extends TypeTestCase


### PR DESCRIPTION
According to rule 37-045 of Insights, Forms should by in `Form\Type` namespace
[See Insights rule](https://insight.sensiolabs.com/what-we-analyse/symfony.form.form_type_not_in_type_form_folder)