### PR TITLE
Add framework-extra-bundle dependency

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -216,7 +216,7 @@ final class MakeCrud extends AbstractMaker
     {
         $dependencies->addClassDependency(
             Route::class,
-            'annotations'
+            'router'
         );
 
         $dependencies->addClassDependency(
@@ -246,7 +246,7 @@ final class MakeCrud extends AbstractMaker
 
         $dependencies->addClassDependency(
             ParamConverter::class,
-            'sensio/framework-extra-bundle'
+            'annotations'
         );
     }
 }

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -243,5 +243,10 @@ final class MakeCrud extends AbstractMaker
             CsrfTokenManager::class,
             'security-csrf'
         );
+
+        $dependencies->addClassDependency(
+            ParamConverter::class,
+            'sensio/framework-extra-bundle'
+        );
     }
 }


### PR DESCRIPTION
The make:crud controllers rely on ParamConverters,
which are provided by framework-extra-bundle.
Fixes #255