### PR TITLE
Working around deprecation errors to get the test suite to pass

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,8 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="TEST_DATABASE_DSN" value="mysql://root:@127.0.0.1:3306/test_maker" />
+        <!-- See #237 -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
     </php>
 
     <testsuites>

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -338,6 +338,15 @@ final class MakerTestEnvironment
         MakerTestProcess::create('composer require phpunit browser-kit symfony/css-selector', $this->flexPath)
                         ->run();
 
+        // temporarily ignoring indirect deprecations - see #237
+        $replacements = [
+            [
+                'filename' => 'phpunit.xml.dist',
+                'find' => '</php>',
+                'replace' => '    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />'."\n".'    </php>',
+            ],
+        ];
+
         MakerTestProcess::create('php bin/console cache:clear --no-warmup', $this->flexPath)
                         ->run();
     }


### PR DESCRIPTION
This is a repeat of #237. The tests have been failing for too long. I think we need to fix them, and then we can revert later when doctrine/orm v2.6.3 is released.

Cheers!