### PR TITLE
Fixing a bug in the tests where too many deps might be installed

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Common\Inflector\Inflector;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -335,6 +335,11 @@ final class MakerTestDetails
         );
     }
 
+    public function getExtraDependencies()
+    {
+        return $this->extraDependencies;
+    }
+
     public function getDependencyBuilder(): DependencyBuilder
     {
         $depBuilder = new DependencyBuilder();

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -326,14 +326,21 @@ final class MakerTestDetails
 
     public function getDependencies()
     {
-        $depBuilder = new DependencyBuilder();
-        $this->maker->configureDependencies($depBuilder);
+        $depBuilder = $this->getDependencyBuilder();
 
         return array_merge(
             $depBuilder->getAllRequiredDependencies(),
             $depBuilder->getAllRequiredDevDependencies(),
             $this->extraDependencies
         );
+    }
+
+    public function getDependencyBuilder(): DependencyBuilder
+    {
+        $depBuilder = new DependencyBuilder();
+        $this->maker->configureDependencies($depBuilder);
+
+        return $depBuilder;
     }
 
     public function getArgumentsString(): string

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -83,7 +83,8 @@ final class MakerTestEnvironment
                 $this->fs->mirror($this->flexPath, $this->path);
 
                 // install any missing dependencies
-                if ($dependencies = $this->testDetails->getDependencies()) {
+                $dependencies = $this->determineMissingDependencies();
+                if ($dependencies) {
                     MakerTestProcess::create(sprintf('composer require %s', implode(' ', $dependencies)), $this->path)
                         ->run();
                 }
@@ -380,5 +381,37 @@ final class MakerTestEnvironment
 
             file_put_contents($path, str_replace($replacement['find'], $replacement['replace'], $contents));
         }
+    }
+
+    /**
+     * Executes the DependencyBuilder for the Maker command inside the
+     * actual project, so we know exactly what dependencies we need or
+     * don't need.
+     */
+    private function determineMissingDependencies(): array
+    {
+        $depBuilder = $this->testDetails->getDependencyBuilder();
+        file_put_contents($this->path.'/dep_builder', serialize($depBuilder));
+        file_put_contents($this->path.'/dep_runner.php', '<?php
+
+require __DIR__."/vendor/autoload.php";
+$depBuilder = unserialize(file_get_contents("dep_builder"));
+$missingDependencies = array_merge(
+    $depBuilder->getMissingDependencies(),
+    $depBuilder->getMissingDevDependencies()
+);
+echo json_encode($missingDependencies);
+        ');
+
+        $process = MakerTestProcess::create('php dep_runner.php', $this->path)->run();
+        $data = json_decode($process->getOutput(), true);
+        if (null === $data) {
+            throw new \Exception('Could not determine dependencies');
+        }
+
+        unlink($this->path.'/dep_builder');
+        unlink($this->path.'/dep_runner.php');
+
+        return $data;
     }
 }

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -412,6 +412,6 @@ echo json_encode($missingDependencies);
         unlink($this->path.'/dep_builder');
         unlink($this->path.'/dep_runner.php');
 
-        return $data;
+        return array_merge($data, $this->testDetails->getExtraDependencies());
     }
 }

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -450,7 +450,7 @@ class YamlSourceManipulator
         $endValuePosition = $this->findEndPositionOfValue($originalVal);
 
         $newYamlValue = $this->convertToYaml($value);
-        if (!is_array($originalVal) && is_array($value)) {
+        if (!\is_array($originalVal) && \is_array($value)) {
             // we're converting from a scalar to a (multiline) array
             // this means we need to break onto the next line
 
@@ -798,7 +798,7 @@ class YamlSourceManipulator
          * to look for indentation.
          */
         if ($this->isCharLineBreak(substr($this->contents, $originalPosition - 1, 1))) {
-            $originalPosition--;
+            --$originalPosition;
         }
 
         // look for empty lines and track the current indentation
@@ -890,7 +890,7 @@ class YamlSourceManipulator
             // because we are either moving along one line until [ {
             // or we are finding a line break and stopping: indentation
             // should not be calculated
-            $this->currentPosition++;
+            ++$this->currentPosition;
 
             if ($this->isCharLineBreak($nextCharacter)) {
                 return self::ARRAY_FORMAT_MULTILINE;

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -303,6 +303,7 @@ class FunctionalTest extends MakerTestCase
             ->addExtraDependencies('doctrine')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeUserEntityPassword')
             ->configureDatabase()
+            ->addExtraDependencies('doctrine')
             ->setGuardAuthenticator('main', 'App\\Security\\AutomaticAuthenticator')
             ->setRequiredPhpVersion(70100)
             ->updateSchemaAfterCommand()


### PR DESCRIPTION
This could create a situation where we tell a user to install libraries
A, B & C only, but really, we also depend on library D, which was
not recommended because we are missing that dependency from our Maker.
However, library D may have been installed in the functional test
(because we previously installed ALL dependencies, even if it was
related to a class we already had).

This would have caught #256.