### PR TITLE
MakeAuthenticator : update security.yaml

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -37,10 +37,13 @@ final class MakeAuthenticator extends AbstractMaker
 
     private $configUpdater;
 
-    public function __construct(FileManager $fileManager, SecurityConfigUpdater $configUpdater)
+    private $generator;
+
+    public function __construct(FileManager $fileManager, SecurityConfigUpdater $configUpdater, Generator $generator)
     {
         $this->fileManager = $fileManager;
         $this->configUpdater = $configUpdater;
+        $this->generator = $generator;
     }
 
     public static function getCommandName(): string
@@ -69,8 +72,12 @@ final class MakeAuthenticator extends AbstractMaker
         $securityData = $manipulator->getData();
 
         $interactiveSecurityHelper = new InteractiveSecurityHelper();
+
         $command->addOption('firewall-name', null, InputOption::VALUE_OPTIONAL, '');
         $interactiveSecurityHelper->guessFirewallName($input, $io, $securityData);
+
+        $command->addOption('entry-point', null, InputOption::VALUE_OPTIONAL);
+        $interactiveSecurityHelper->guessEntryPoint($input, $io, $this->generator, $securityData);
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
@@ -93,6 +100,7 @@ final class MakeAuthenticator extends AbstractMaker
                 $newYaml = $this->configUpdater->updateForAuthenticator(
                     $this->fileManager->getFileContents($path),
                     $input->getOption('firewall-name'),
+                    $input->getOption('entry-point'),
                     $classNameDetails->getFullName()
                 );
                 $generator->dumpFile($path, $newYaml);

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -8,6 +8,8 @@
             <defaults public="false" />
 
             <service id="maker.maker.make_authenticator" class="Symfony\Bundle\MakerBundle\Maker\MakeAuthenticator">
+                <argument type="service" id="maker.file_manager" />
+                <argument type="service" id="maker.security_config_updater" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -10,6 +10,7 @@
             <service id="maker.maker.make_authenticator" class="Symfony\Bundle\MakerBundle\Maker\MakeAuthenticator">
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.security_config_updater" />
+                <argument type="service" id="maker.generator" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class InteractiveSecurityHelper
 {
-    public function guessFirewallName(SymfonyStyle $io, array $securityData)
+    public function guessFirewallName(SymfonyStyle $io, array $securityData): string
     {
         $realFirewalls = array_filter(
             $securityData['security']['firewalls'] ?? [],

--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -11,18 +11,25 @@
 
 namespace Symfony\Bundle\MakerBundle\Security;
 
-use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
  */
 final class InteractiveSecurityHelper
 {
-    public function guessFirewallName(InputInterface $input, ConsoleStyle $io, array $securityData)
+    /**
+     * @param InputInterface $input
+     * @param SymfonyStyle   $io
+     * @param array          $securityData
+     */
+    public function guessFirewallName(InputInterface $input, SymfonyStyle $io, array $securityData)
     {
         $firewalls = array_filter(
-            $securityData['security']['firewalls'],
+            $securityData['security']['firewalls'] ?? [],
             function ($item) {
                 return !isset($item['security']) || true === $item['security'];
             }
@@ -40,5 +47,48 @@ final class InteractiveSecurityHelper
 
         $firewallName = $io->choice('Which firewall you want to update ?', array_keys($firewalls), key($firewalls));
         $input->setOption('firewall-name', $firewallName);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param SymfonyStyle   $io
+     * @param Generator      $generator
+     * @param array          $securityData
+     */
+    public function guessEntryPoint(InputInterface $input, SymfonyStyle $io, Generator $generator, array $securityData)
+    {
+        $firewallName = $input->getOption('firewall-name');
+        if (!$firewallName) {
+            throw new RuntimeCommandException("Option \"firewall-name\" must be provided.");
+        }
+
+        if (!isset($securityData['security'])) {
+            $securityData['security'] = [];
+        }
+
+        if (!isset($securityData['security']['firewalls'])) {
+            $securityData['security']['firewalls'] = [];
+        }
+
+        $firewalls = $securityData['security']['firewalls'];
+        if (!isset($firewalls[$firewallName])) {
+            throw new RuntimeCommandException("Firewall \"$firewallName\" does not exist");
+        }
+
+        if (!isset($firewalls[$firewallName]['guard'])
+            || !isset($firewalls[$firewallName]['guard']['authenticators'])
+            || !$firewalls[$firewallName]['guard']['authenticators']) {
+            return;
+        }
+
+        $authenticators = $firewalls[$firewallName]['guard']['authenticators'];
+        $classNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('authenticator-class'),
+            'Security\\'
+        );
+        $authenticators[] = $classNameDetails->getFullName();
+
+        $entryPoint = $io->choice('Which authenticator will be the entry point ?', $authenticators, current($authenticators));
+        $input->setOption('entry-point', $entryPoint);
     }
 }

--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @internal
+ */
+final class InteractiveSecurityHelper
+{
+    public function guessFirewallName(InputInterface $input, ConsoleStyle $io, array $securityData)
+    {
+        $firewalls = array_filter(
+            $securityData['security']['firewalls'],
+            function ($item) {
+                return !isset($item['security']) || true === $item['security'];
+            }
+        );
+
+        if (count($firewalls) < 2) {
+            if ($firewalls) {
+                $input->setOption('firewall-name', key($firewalls));
+            } else {
+                $input->setOption('firewall-name', 'main');
+            }
+
+            return;
+        }
+
+        $firewallName = $io->choice('Which firewall you want to update ?', array_keys($firewalls), key($firewalls));
+        $input->setOption('firewall-name', $firewallName);
+    }
+}

--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -48,7 +48,15 @@ final class SecurityConfigUpdater
         return $contents;
     }
 
-    public function updateForAuthenticator(string $yamlSource, string $firewallName, string $userClass)
+    /**
+     * @param string $yamlSource
+     * @param string $firewallName
+     * @param string $chosenEntryPoint
+     * @param string $authenticatorClass
+     *
+     * @return string
+     */
+    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass)
     {
         $this->manipulator = new YamlSourceManipulator($yamlSource);
 
@@ -74,10 +82,10 @@ final class SecurityConfigUpdater
             $firewall['guard']['authenticators'] = [];
         }
 
-        $firewall['guard']['authenticators'][] = $userClass;
+        $firewall['guard']['authenticators'][] = $authenticatorClass;
 
         if (count($firewall['guard']['authenticators']) > 1) {
-            $firewall['guard']['entry_point'] = current($firewall['guard']['authenticators']);
+            $firewall['guard']['entry_point'] = $chosenEntryPoint ?? current($firewall['guard']['authenticators']);
         }
 
         $newData['security']['firewalls'][$firewallName] = $firewall;

--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -48,15 +48,7 @@ final class SecurityConfigUpdater
         return $contents;
     }
 
-    /**
-     * @param string $yamlSource
-     * @param string $firewallName
-     * @param string $chosenEntryPoint
-     * @param string $authenticatorClass
-     *
-     * @return string
-     */
-    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass)
+    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass): string
     {
         $this->manipulator = new YamlSourceManipulator($yamlSource);
 
@@ -69,7 +61,7 @@ final class SecurityConfigUpdater
         }
 
         if (!isset($newData['security']['firewalls'][$firewallName])) {
-            $newData['security']['firewalls'][$firewallName] = [];
+            $newData['security']['firewalls'][$firewallName] = ['anonymous' => true];
         }
 
         $firewall = $newData['security']['firewalls'][$firewallName];
@@ -84,7 +76,7 @@ final class SecurityConfigUpdater
 
         $firewall['guard']['authenticators'][] = $authenticatorClass;
 
-        if (count($firewall['guard']['authenticators']) > 1) {
+        if (\count($firewall['guard']['authenticators']) > 1) {
             $firewall['guard']['entry_point'] = $chosenEntryPoint ?? current($firewall['guard']['authenticators']);
         }
 

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -450,7 +450,7 @@ class YamlSourceManipulator
         $endValuePosition = $this->findEndPositionOfValue($originalVal);
 
         $newYamlValue = $this->convertToYaml($value);
-        if (!is_array($originalVal) && is_array($value)) {
+        if (!\is_array($originalVal) && \is_array($value)) {
             // we're converting from a scalar to a (multiline) array
             // this means we need to break onto the next line
 
@@ -798,7 +798,7 @@ class YamlSourceManipulator
          * to look for indentation.
          */
         if ($this->isCharLineBreak(substr($this->contents, $originalPosition - 1, 1))) {
-            $originalPosition--;
+            --$originalPosition;
         }
 
         // look for empty lines and track the current indentation
@@ -890,7 +890,7 @@ class YamlSourceManipulator
             // because we are either moving along one line until [ {
             // or we are finding a line break and stopping: indentation
             // should not be calculated
-            $this->currentPosition++;
+            ++$this->currentPosition;
 
             if ($this->isCharLineBreak($nextCharacter)) {
                 return self::ARRAY_FORMAT_MULTILINE;

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -342,6 +342,67 @@ class FunctionalTest extends MakerTestCase
                 ),
         ];
 
+        yield 'auth_empty_existing_authenticator' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeAuthenticator::class),
+                [
+                    // class name
+                    'AppCustomAuthenticator',
+                    1
+                ]
+            )
+                ->addExtraDependencies('security')
+                ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorExistingAuthenticator')
+                ->setRequiredPhpVersion(70100)
+                ->assert(
+                    function (string $output, string $directory) {
+                        $this->assertContains('Success', $output);
+
+                        $finder = new Finder();
+                        $finder->in($directory.'/src/Security')
+                            ->name('AppCustomAuthenticator.php');
+                        $this->assertCount(1, $finder);
+
+                        $securityConfig = Yaml::parse(file_get_contents("$directory/config/packages/security.yaml"));
+                        $this->assertEquals(
+                            'App\\Security\\AppCustomAuthenticator',
+                            $securityConfig['security']['firewalls']['main']['guard']['entry_point']
+                        );
+                    }
+                ),
+        ];
+
+        yield 'auth_empty_multiple_firewalls_existing_authenticator' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeAuthenticator::class),
+                [
+                    // class name
+                    'AppCustomAuthenticator',
+                    1,
+                    1
+                ]
+            )
+                ->addExtraDependencies('security')
+                ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorMultipleFirewallsExistingAuthenticator')
+                ->setRequiredPhpVersion(70100)
+                ->assert(
+                    function (string $output, string $directory) {
+                        $this->assertContains('Success', $output);
+
+                        $finder = new Finder();
+                        $finder->in($directory.'/src/Security')
+                            ->name('AppCustomAuthenticator.php');
+                        $this->assertCount(1, $finder);
+
+                        $securityConfig = Yaml::parse(file_get_contents("$directory/config/packages/security.yaml"));
+                        $this->assertEquals(
+                            'App\\Security\\AppCustomAuthenticator',
+                            $securityConfig['security']['firewalls']['second']['guard']['entry_point']
+                        );
+                    }
+                ),
+        ];
+
         yield 'user_security_entity_with_password' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeUser::class),
             [

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -32,6 +32,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
@@ -293,17 +294,14 @@ class FunctionalTest extends MakerTestCase
             )
                 ->addExtraDependencies('security')
                 ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticator')
-                ->setRequiredPhpVersion(70100)
                 ->assert(
                     function (string $output, string $directory) {
                         $this->assertContains('Success', $output);
 
-                        $finder = new Finder();
-                        $finder->in($directory.'/src/Security')
-                            ->name('AppCustomAuthenticator.php');
-                        $this->assertCount(1, $finder);
+                        $fs = new Filesystem();
+                        $this->assertTrue($fs->exists(sprintf('%s/src/Security/AppCustomAuthenticator.php', $directory)));
 
-                        $securityConfig = Yaml::parse(file_get_contents("$directory/config/packages/security.yaml"));
+                        $securityConfig = Yaml::parse(file_get_contents(sprintf("%s/config/packages/security.yaml", $directory)));
                         $this->assertEquals(
                             'App\\Security\\AppCustomAuthenticator',
                             $securityConfig['security']['firewalls']['main']['guard']['authenticators'][0]
@@ -318,22 +316,17 @@ class FunctionalTest extends MakerTestCase
                 [
                     // class name
                     'AppCustomAuthenticator',
+                    // firewall name
                     1
                 ]
             )
                 ->addExtraDependencies('security')
                 ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorMultipleFirewalls')
-                ->setRequiredPhpVersion(70100)
                 ->assert(
                     function (string $output, string $directory) {
                         $this->assertContains('Success', $output);
 
-                        $finder = new Finder();
-                        $finder->in($directory.'/src/Security')
-                            ->name('AppCustomAuthenticator.php');
-                        $this->assertCount(1, $finder);
-
-                        $securityConfig = Yaml::parse(file_get_contents("$directory/config/packages/security.yaml"));
+                        $securityConfig = Yaml::parse(file_get_contents(sprintf("%s/config/packages/security.yaml", $directory)));
                         $this->assertEquals(
                             'App\\Security\\AppCustomAuthenticator',
                             $securityConfig['security']['firewalls']['second']['guard']['authenticators'][0]
@@ -348,22 +341,17 @@ class FunctionalTest extends MakerTestCase
                 [
                     // class name
                     'AppCustomAuthenticator',
+                    // firewall name
                     1
                 ]
             )
                 ->addExtraDependencies('security')
                 ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorExistingAuthenticator')
-                ->setRequiredPhpVersion(70100)
                 ->assert(
                     function (string $output, string $directory) {
                         $this->assertContains('Success', $output);
 
-                        $finder = new Finder();
-                        $finder->in($directory.'/src/Security')
-                            ->name('AppCustomAuthenticator.php');
-                        $this->assertCount(1, $finder);
-
-                        $securityConfig = Yaml::parse(file_get_contents("$directory/config/packages/security.yaml"));
+                        $securityConfig = Yaml::parse(file_get_contents(sprintf("%s/config/packages/security.yaml", $directory)));
                         $this->assertEquals(
                             'App\\Security\\AppCustomAuthenticator',
                             $securityConfig['security']['firewalls']['main']['guard']['entry_point']
@@ -378,23 +366,19 @@ class FunctionalTest extends MakerTestCase
                 [
                     // class name
                     'AppCustomAuthenticator',
+                    // firewall name
                     1,
+                    // entry point
                     1
                 ]
             )
                 ->addExtraDependencies('security')
                 ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorMultipleFirewallsExistingAuthenticator')
-                ->setRequiredPhpVersion(70100)
                 ->assert(
                     function (string $output, string $directory) {
                         $this->assertContains('Success', $output);
 
-                        $finder = new Finder();
-                        $finder->in($directory.'/src/Security')
-                            ->name('AppCustomAuthenticator.php');
-                        $this->assertCount(1, $finder);
-
-                        $securityConfig = Yaml::parse(file_get_contents("$directory/config/packages/security.yaml"));
+                        $securityConfig = Yaml::parse(file_get_contents(sprintf("%s/config/packages/security.yaml", $directory)));
                         $this->assertEquals(
                             'App\\Security\\AppCustomAuthenticator',
                             $securityConfig['security']['firewalls']['second']['guard']['entry_point']

--- a/tests/Security/InteractiveSecurityHelperTest.php
+++ b/tests/Security/InteractiveSecurityHelperTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
+use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class InteractiveSecurityHelperTest extends TestCase
+{
+    /**
+     * @dataProvider getFirewallNameTests
+     *
+     * @param array  $securityData
+     * @param string $expectedFirewallName
+     * @param bool   $multipleValues
+     */
+    public function testGuessFirewallName(array $securityData, string $expectedFirewallName, $multipleValues = false)
+    {
+        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
+        $input = $this->createMock(InputInterface::class);
+        $input->expects($this->once())
+            ->method('setOption')
+            ->with('firewall-name', $expectedFirewallName);
+
+        /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->exactly(false === $multipleValues ? 0 : 1))
+            ->method('choice')
+            ->willReturn($expectedFirewallName);
+
+        $helper = new InteractiveSecurityHelper();
+        $helper->guessFirewallName($input, $io, $securityData);
+    }
+
+    public function getFirewallNameTests()
+    {
+        yield 'empty_security' => [
+            [],
+            'main',
+        ];
+
+        yield 'no_firewall' => [
+            ['security' => ['firewalls' => []]],
+            'main',
+        ];
+
+        yield 'no_secured_firewall' => [
+            ['security' => ['firewalls' => ['dev' => ['security' => false]]]],
+            'main',
+        ];
+
+        yield 'main_firewall' => [
+            ['security' => ['firewalls' => ['dev' => ['security' => false], 'main' => null]]],
+            'main',
+        ];
+
+        yield 'foo_firewall' => [
+            ['security' => ['firewalls' => ['dev' => ['security' => false], 'foo' => null]]],
+            'foo',
+        ];
+
+        yield 'foo_bar_firewalls_1' => [
+            ['security' => ['firewalls' => ['dev' => ['security' => false], 'foo' => null, 'bar' => null]]],
+            'foo',
+            true,
+        ];
+
+        yield 'foo_bar_firewalls_2' => [
+            ['security' => ['firewalls' => ['dev' => ['security' => false], 'foo' => null, 'bar' => null]]],
+            'bar',
+            true,
+        ];
+    }
+
+    /**
+     * @expectedException \Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException
+     */
+    public function testGuessEntryPointWithNoFirewallNameThrowsException()
+    {
+        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
+        $input = $this->createMock(InputInterface::class);
+
+        /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
+        $io = $this->createMock(SymfonyStyle::class);
+
+        /** @var Generator|\PHPUnit_Framework_MockObject_MockObject $generator */
+        $generator = $this->createMock(Generator::class);
+
+        $helper = new InteractiveSecurityHelper();
+        $helper->guessEntryPoint($input, $io, $generator, []);
+    }
+
+    /**
+     * @expectedException \Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException
+     */
+    public function testGuessEntryPointWithNonExistingFirewallThrowsException()
+    {
+        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
+        $input = $this->createMock(InputInterface::class);
+        $input->expects($this->once())
+            ->method('getOption')
+            ->with('firewall-name')
+            ->willReturn('foo');
+
+        /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
+        $io = $this->createMock(SymfonyStyle::class);
+
+        /** @var Generator|\PHPUnit_Framework_MockObject_MockObject $generator */
+        $generator = $this->createMock(Generator::class);
+
+        $helper = new InteractiveSecurityHelper();
+        $helper->guessEntryPoint($input, $io, $generator, []);
+    }
+
+    /**
+     * @dataProvider getEntryPointTests
+     */
+    public function testGuestEntryPoint(array $securityData, string $firewallName, bool $multipleAuthenticators = false)
+    {
+        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
+        $input = $this->createMock(InputInterface::class);
+        $input->expects($this->once())
+            ->method('getOption')
+            ->with('firewall-name')
+            ->willReturn($firewallName);
+
+        $input->expects($this->exactly(false === $multipleAuthenticators ? 0 : 1))
+            ->method('getArgument')
+            ->with('authenticator-class')
+            ->willReturn('NewAuthenticator');
+
+
+        /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects($this->exactly(false === $multipleAuthenticators ? 0 : 1))
+            ->method('choice');
+
+        /** @var Generator|\PHPUnit_Framework_MockObject_MockObject $generator */
+        $generator = $this->createMock(Generator::class);
+        $generator->expects($this->exactly(false === $multipleAuthenticators ? 0 : 1))
+            ->method('createClassNameDetails')
+            ->willReturn(new ClassNameDetails('App\\Security\\NewAuthenticator', 'App\\Security'));
+
+        $helper = new InteractiveSecurityHelper();
+        $helper->guessEntryPoint($input, $io, $generator, $securityData);
+    }
+
+    public function getEntryPointTests()
+    {
+        yield 'no_guard' => [
+            ['security' => ['firewalls' => ['main' => []]]],
+            'main'
+        ];
+
+        yield 'no_authenticators_key' => [
+            ['security' => ['firewalls' => ['main' => ['guard' => []]]]],
+            'main'
+        ];
+
+        yield 'no_authenticator' => [
+            ['security' => ['firewalls' => ['main' => ['guard' => ['authenticators' => []]]]]],
+            'main'
+        ];
+
+        yield 'one_authenticator' => [
+            ['security' => ['firewalls' => ['main' => ['guard' => ['authenticators' => ['App\\Security\\Authenticator']]]]]],
+            'main',
+            true
+        ];
+    }
+}

--- a/tests/Security/InteractiveSecurityHelperTest.php
+++ b/tests/Security/InteractiveSecurityHelperTest.php
@@ -3,29 +3,16 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Security;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
-use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 class InteractiveSecurityHelperTest extends TestCase
 {
     /**
      * @dataProvider getFirewallNameTests
-     *
-     * @param array  $securityData
-     * @param string $expectedFirewallName
-     * @param bool   $multipleValues
      */
     public function testGuessFirewallName(array $securityData, string $expectedFirewallName, $multipleValues = false)
     {
-        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
-        $input = $this->createMock(InputInterface::class);
-        $input->expects($this->once())
-            ->method('setOption')
-            ->with('firewall-name', $expectedFirewallName);
-
         /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
         $io = $this->createMock(SymfonyStyle::class);
         $io->expects($this->exactly(false === $multipleValues ? 0 : 1))
@@ -33,7 +20,10 @@ class InteractiveSecurityHelperTest extends TestCase
             ->willReturn($expectedFirewallName);
 
         $helper = new InteractiveSecurityHelper();
-        $helper->guessFirewallName($input, $io, $securityData);
+        $this->assertEquals(
+            $expectedFirewallName,
+            $helper->guessFirewallName($io, $securityData)
+        );
     }
 
     public function getFirewallNameTests()
@@ -79,41 +69,13 @@ class InteractiveSecurityHelperTest extends TestCase
     /**
      * @expectedException \Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException
      */
-    public function testGuessEntryPointWithNoFirewallNameThrowsException()
-    {
-        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
-        $input = $this->createMock(InputInterface::class);
-
-        /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
-        $io = $this->createMock(SymfonyStyle::class);
-
-        /** @var Generator|\PHPUnit_Framework_MockObject_MockObject $generator */
-        $generator = $this->createMock(Generator::class);
-
-        $helper = new InteractiveSecurityHelper();
-        $helper->guessEntryPoint($input, $io, $generator, []);
-    }
-
-    /**
-     * @expectedException \Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException
-     */
     public function testGuessEntryPointWithNonExistingFirewallThrowsException()
     {
-        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
-        $input = $this->createMock(InputInterface::class);
-        $input->expects($this->once())
-            ->method('getOption')
-            ->with('firewall-name')
-            ->willReturn('foo');
-
         /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
         $io = $this->createMock(SymfonyStyle::class);
 
-        /** @var Generator|\PHPUnit_Framework_MockObject_MockObject $generator */
-        $generator = $this->createMock(Generator::class);
-
         $helper = new InteractiveSecurityHelper();
-        $helper->guessEntryPoint($input, $io, $generator, []);
+        $helper->guessEntryPoint($io, [], '', 'foo');
     }
 
     /**
@@ -121,55 +83,41 @@ class InteractiveSecurityHelperTest extends TestCase
      */
     public function testGuestEntryPoint(array $securityData, string $firewallName, bool $multipleAuthenticators = false)
     {
-        /** @var InputInterface|\PHPUnit_Framework_MockObject_MockObject $input */
-        $input = $this->createMock(InputInterface::class);
-        $input->expects($this->once())
-            ->method('getOption')
-            ->with('firewall-name')
-            ->willReturn($firewallName);
-
-        $input->expects($this->exactly(false === $multipleAuthenticators ? 0 : 1))
-            ->method('getArgument')
-            ->with('authenticator-class')
-            ->willReturn('NewAuthenticator');
-
-
         /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
         $io = $this->createMock(SymfonyStyle::class);
         $io->expects($this->exactly(false === $multipleAuthenticators ? 0 : 1))
             ->method('choice');
 
-        /** @var Generator|\PHPUnit_Framework_MockObject_MockObject $generator */
-        $generator = $this->createMock(Generator::class);
-        $generator->expects($this->exactly(false === $multipleAuthenticators ? 0 : 1))
-            ->method('createClassNameDetails')
-            ->willReturn(new ClassNameDetails('App\\Security\\NewAuthenticator', 'App\\Security'));
-
         $helper = new InteractiveSecurityHelper();
-        $helper->guessEntryPoint($input, $io, $generator, $securityData);
+        $helper->guessEntryPoint($io, $securityData, 'App\\Security\\NewAuthenticator', $firewallName);
     }
 
     public function getEntryPointTests()
     {
         yield 'no_guard' => [
             ['security' => ['firewalls' => ['main' => []]]],
-            'main'
+            'main',
         ];
 
         yield 'no_authenticators_key' => [
             ['security' => ['firewalls' => ['main' => ['guard' => []]]]],
-            'main'
+            'main',
         ];
 
         yield 'no_authenticator' => [
             ['security' => ['firewalls' => ['main' => ['guard' => ['authenticators' => []]]]]],
-            'main'
+            'main',
         ];
 
         yield 'one_authenticator' => [
             ['security' => ['firewalls' => ['main' => ['guard' => ['authenticators' => ['App\\Security\\Authenticator']]]]]],
             'main',
-            true
+            true,
+        ];
+
+        yield 'one_authenticator' => [
+            ['security' => ['firewalls' => ['main' => ['guard' => ['entry_point' => 'App\\Security\\Authenticator', 'authenticators' => ['App\\Security\\Authenticator']]]]]],
+            'main',
         ];
     }
 }

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -71,11 +71,11 @@ class SecurityConfigUpdaterTest extends TestCase
     /**
      * @dataProvider getAuthenticatorTests
      */
-    public function testUpdateForAuthenticator(string $firewallName, string $expectedSourceFilename, string $startingSourceFilename)
+    public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename)
     {
         $updater = new SecurityConfigUpdater();
         $source = file_get_contents(__DIR__.'/yaml_fixtures/source/'.$startingSourceFilename);
-        $actualSource = $updater->updateForAuthenticator($source, $firewallName, 'App\\Security\\AppCustomAuthenticator');
+        $actualSource = $updater->updateForAuthenticator($source, $firewallName, $entryPoint, 'App\\Security\\AppCustomAuthenticator');
         $expectedSource = file_get_contents(__DIR__.'/yaml_fixtures/expected_authenticator/'.$expectedSourceFilename);
 
         $this->assertSame($expectedSource, $actualSource);
@@ -85,21 +85,37 @@ class SecurityConfigUpdaterTest extends TestCase
     {
         yield 'empty_source' => [
             'main',
+            null,
             'empty_source.yaml',
             'empty_security.yaml'
         ];
 
-        // waiting for YamlSourceManipulator to be debugged
-//        yield 'empty_source' => [
-//            'main',
-//            'simple_security_source.yaml',
-//            'simple_security.yaml'
-//        ];
+        yield 'empty_source' => [
+            'main',
+            null,
+            'simple_security_source.yaml',
+            'simple_security.yaml'
+        ];
 
         yield 'simple_security_with_firewalls' => [
             'main',
+            null,
             'simple_security_with_firewalls.yaml',
             'simple_security_with_firewalls.yaml'
+        ];
+
+        yield 'simple_security_with_firewalls' => [
+            'main',
+            null,
+            'simple_security_with_firewalls.yaml',
+            'simple_security_with_firewalls.yaml'
+        ];
+
+        yield 'simple_security_with_firewalls_and_authenticator' => [
+            'main',
+            'App\\Security\\AppCustomAuthenticator',
+            'simple_security_with_firewalls_and_authenticator.yaml',
+            'simple_security_with_firewalls_and_authenticator.yaml'
         ];
     }
 }

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -90,7 +90,7 @@ class SecurityConfigUpdaterTest extends TestCase
             'empty_security.yaml'
         ];
 
-        yield 'empty_source' => [
+        yield 'simple_security' => [
             'main',
             null,
             'simple_security_source.yaml',

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -67,4 +67,39 @@ class SecurityConfigUpdaterTest extends TestCase
             'empty_security.yaml'
         ];
     }
+
+    /**
+     * @dataProvider getAuthenticatorTests
+     */
+    public function testUpdateForAuthenticator(string $firewallName, string $expectedSourceFilename, string $startingSourceFilename)
+    {
+        $updater = new SecurityConfigUpdater();
+        $source = file_get_contents(__DIR__.'/yaml_fixtures/source/'.$startingSourceFilename);
+        $actualSource = $updater->updateForAuthenticator($source, $firewallName, 'App\\Security\\AppCustomAuthenticator');
+        $expectedSource = file_get_contents(__DIR__.'/yaml_fixtures/expected_authenticator/'.$expectedSourceFilename);
+
+        $this->assertSame($expectedSource, $actualSource);
+    }
+
+    public function getAuthenticatorTests()
+    {
+        yield 'empty_source' => [
+            'main',
+            'empty_source.yaml',
+            'empty_security.yaml'
+        ];
+
+        // waiting for YamlSourceManipulator to be debugged
+//        yield 'empty_source' => [
+//            'main',
+//            'simple_security_source.yaml',
+//            'simple_security.yaml'
+//        ];
+
+        yield 'simple_security_with_firewalls' => [
+            'main',
+            'simple_security_with_firewalls.yaml',
+            'simple_security_with_firewalls.yaml'
+        ];
+    }
 }

--- a/tests/Security/yaml_fixtures/expected_authenticator/empty_source.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/empty_source.yaml
@@ -1,0 +1,5 @@
+security:
+    firewalls:
+        main:
+            guard:
+                authenticators: [App\Security\AppCustomAuthenticator]

--- a/tests/Security/yaml_fixtures/expected_authenticator/empty_source.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/empty_source.yaml
@@ -1,5 +1,6 @@
 security:
     firewalls:
         main:
+            anonymous: true
             guard:
                 authenticators: [App\Security\AppCustomAuthenticator]

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_source.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_source.yaml
@@ -1,0 +1,8 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main: ~

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_source.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_source.yaml
@@ -6,6 +6,7 @@ security:
     firewalls:
         dev: ~
         main:
+            anonymous: true
             guard:
                 authenticators:
                     - App\Security\AppCustomAuthenticator

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls.yaml
@@ -1,0 +1,14 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+            guard:
+                authenticators:
+                    - App\Security\AppCustomAuthenticator

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_authenticator.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_authenticator.yaml
@@ -4,8 +4,15 @@ security:
         in_memory: { memory: ~ }
 
     firewalls:
-        dev: ~
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
         main:
+            anonymous: true
             guard:
                 authenticators:
+                    - App\Security\Authenticator
                     - App\Security\AppCustomAuthenticator
+                entry_point: App\Security\AppCustomAuthenticator
+        foo:
+            anonymous: true

--- a/tests/Security/yaml_fixtures/source/simple_security_with_firewalls.yaml
+++ b/tests/Security/yaml_fixtures/source/simple_security_with_firewalls.yaml
@@ -1,0 +1,11 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true

--- a/tests/Security/yaml_fixtures/source/simple_security_with_firewalls_and_authenticator.yaml
+++ b/tests/Security/yaml_fixtures/source/simple_security_with_firewalls_and_authenticator.yaml
@@ -4,8 +4,13 @@ security:
         in_memory: { memory: ~ }
 
     firewalls:
-        dev: ~
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
         main:
+            anonymous: true
             guard:
                 authenticators:
-                    - App\Security\AppCustomAuthenticator
+                    - App\Security\Authenticator
+        foo:
+            anonymous: true

--- a/tests/fixtures/MakeAuthenticator/config/packages/security.yaml
+++ b/tests/fixtures/MakeAuthenticator/config/packages/security.yaml
@@ -1,0 +1,24 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+
+            # activate different ways to authenticate
+
+            # http_basic: true
+            # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate
+
+            # form_login: true
+            # https://symfony.com/doc/current/security/form_login_setup.html
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+    # - { path: ^/admin, roles: ROLE_ADMIN }
+    # - { path: ^/profile, roles: ROLE_USER }

--- a/tests/fixtures/MakeAuthenticatorExistingAuthenticator/config/packages/security.yaml
+++ b/tests/fixtures/MakeAuthenticatorExistingAuthenticator/config/packages/security.yaml
@@ -1,0 +1,27 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+            guard:
+                authenticators:
+                    - App\Security\Authenticator
+
+            # activate different ways to authenticate
+
+            # http_basic: true
+            # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate
+
+            # form_login: true
+            # https://symfony.com/doc/current/security/form_login_setup.html
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+    # - { path: ^/admin, roles: ROLE_ADMIN }
+    # - { path: ^/profile, roles: ROLE_USER }

--- a/tests/fixtures/MakeAuthenticatorExistingAuthenticator/src/Security/Authenticator.php
+++ b/tests/fixtures/MakeAuthenticatorExistingAuthenticator/src/Security/Authenticator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+class Authenticator extends AbstractGuardAuthenticator
+{
+    public function supports(Request $request)
+    {
+        // todo
+    }
+
+    public function getCredentials(Request $request)
+    {
+        // todo
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        // todo
+    }
+
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        // todo
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        // todo
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        // todo
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        // todo
+    }
+
+    public function supportsRememberMe()
+    {
+        // todo
+    }
+}

--- a/tests/fixtures/MakeAuthenticatorMultipleFirewalls/config/packages/security.yaml
+++ b/tests/fixtures/MakeAuthenticatorMultipleFirewalls/config/packages/security.yaml
@@ -1,0 +1,26 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+        second:
+            anonymous: true
+
+            # activate different ways to authenticate
+
+            # http_basic: true
+            # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate
+
+            # form_login: true
+            # https://symfony.com/doc/current/security/form_login_setup.html
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+    # - { path: ^/admin, roles: ROLE_ADMIN }
+    # - { path: ^/profile, roles: ROLE_USER }

--- a/tests/fixtures/MakeAuthenticatorMultipleFirewallsExistingAuthenticator/config/packages/security.yaml
+++ b/tests/fixtures/MakeAuthenticatorMultipleFirewallsExistingAuthenticator/config/packages/security.yaml
@@ -1,0 +1,29 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+        second:
+            anonymous: true
+            guard:
+                authenticators:
+                    - App\Security\Authenticator
+
+            # activate different ways to authenticate
+
+            # http_basic: true
+            # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate
+
+            # form_login: true
+            # https://symfony.com/doc/current/security/form_login_setup.html
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+    # - { path: ^/admin, roles: ROLE_ADMIN }
+    # - { path: ^/profile, roles: ROLE_USER }

--- a/tests/fixtures/MakeAuthenticatorMultipleFirewallsExistingAuthenticator/src/Security/Authenticator.php
+++ b/tests/fixtures/MakeAuthenticatorMultipleFirewallsExistingAuthenticator/src/Security/Authenticator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+class Authenticator extends AbstractGuardAuthenticator
+{
+    public function supports(Request $request)
+    {
+        // todo
+    }
+
+    public function getCredentials(Request $request)
+    {
+        // todo
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        // todo
+    }
+
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        // todo
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        // todo
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        // todo
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        // todo
+    }
+
+    public function supportsRememberMe()
+    {
+        // todo
+    }
+}


### PR DESCRIPTION
This PR adds the newly created authenticator to `security.yaml`

The process is the following :
- if no firewall exist, a "main" firewall is automatically created (this should never happen)
- if there is only one "real" firewall (i.e. : a firewall withou security: false"), the authenticator is added to this firewall
- if there are more than one firewall, the user is asked to which firewall the authenticator should be added
- if the target firewall already has an authenticator, the user is asked which authenticator should be the entry point.