### PR TITLE
"make:entity" root directory location improvment

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('root_namespace')->defaultValue('App')->end()
+                ->scalarNode('root_entity_directory')->defaultValue('src/Entity/')->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -37,6 +37,11 @@ class MakerExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        $rootEntityDirectory = trim($config['root_entity_directory']);
+
+        $makeEntityCommandDefinition = $container->getDefinition('maker.maker.make_entity');
+        $makeEntityCommandDefinition->replaceArgument(3, $rootEntityDirectory);
+
         $rootNamespace = trim($config['root_namespace'], '\\');
 
         $makeCommandDefinition = $container->getDefinition('maker.generator');

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -29,6 +29,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.doctrine_helper" />
                 <argument>%kernel.project_dir%</argument>
+                <argument /> <!-- root entity directory-->
                 <argument type="service" id="maker.generator" />
                 <tag name="maker.command" />
             </service>


### PR DESCRIPTION
As a developer using Symfony 3.x, I got issues using `make:entity`

I made this pull request to allow users to override the hardcoded `src/Entity/` as the root directory for entities.
Now there are two ways to override it : 

* define the new available configuration in your `config.yml`
```yaml
maker:
    root_namespace: Acme\AwesomeBundle
    root_entity_directory: src/Acme/AwesomeBundle/Entity/
```
* use the new option of the `make:entity` command : 
```shell
php bin/console make:entity --rootdir=src/Acme/AwesomeBundle/Entity/
```

Anyway the file will be created to the correct location (corresponding to the class namespace), that was already the case before my pull request.