### PR TITLE
Tiny fix: Don't end the link with a 'period'.

### DIFF
--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -79,7 +79,7 @@ final class MakerCommand extends Command
         if (!$this->fileManager->isNamespaceConfiguredToAutoload($this->generator->getRootNamespace())) {
             $this->io->note([
                 sprintf('It looks like your app may be using a namespace other than "%s".', $this->generator->getRootNamespace()),
-                'To configure this and make your life easier, see: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html#configuration.',
+                'To configure this and make your life easier, see: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html#configuration',
             ]);
         }
 


### PR DESCRIPTION
Not having the link end in a period makes it easier to click or copy/paste. This is also consistent with a few other places in the same bundle.