### PR TITLE
Use git to reset the functional test environments

### DIFF
--- a/src/Test/MakerTestCase.php
+++ b/src/Test/MakerTestCase.php
@@ -26,41 +26,37 @@ class MakerTestCase extends TestCase
         // prepare environment to test
         $testEnv->prepare();
 
-        try {
-            // run tests
-            $makerTestProcess = $testEnv->runMaker();
-            $files = $testEnv->getGeneratedFilesFromOutputText();
+        // run tests
+        $makerTestProcess = $testEnv->runMaker();
+        $files = $testEnv->getGeneratedFilesFromOutputText();
 
-            foreach ($files as $file) {
-                $this->assertTrue($testEnv->fileExists($file));
+        foreach ($files as $file) {
+            $this->assertTrue($testEnv->fileExists($file));
 
-                if ('.php' === substr($file, -4)) {
-                    $csProcess = $testEnv->runPhpCSFixer($file);
+            if ('.php' === substr($file, -4)) {
+                $csProcess = $testEnv->runPhpCSFixer($file);
 
-                    $this->assertTrue($csProcess->isSuccessful(), sprintf('File "%s" has a php-cs problem: %s', $file, $csProcess->getOutput()));
-                }
-
-                if ('.twig' === substr($file, -5)) {
-                    $csProcess = $testEnv->runTwigCSLint($file);
-
-                    $this->assertTrue($csProcess->isSuccessful(), sprintf('File "%s" has a twig-cs problem: %s', $file, $csProcess->getOutput()));
-                }
+                $this->assertTrue($csProcess->isSuccessful(), sprintf('File "%s" has a php-cs problem: %s', $file, $csProcess->getOutput()));
             }
 
-            // run internal tests
-            $internalTestProcess = $testEnv->runInternalTests();
-            if (null !== $internalTestProcess) {
-                $this->assertTrue($internalTestProcess->isSuccessful(), sprintf("Error while running the PHPUnit tests *in* the project: \n\n %s \n\n Command Output: %s", $internalTestProcess->getOutput(), $makerTestProcess->getOutput()));
-            }
+            if ('.twig' === substr($file, -5)) {
+                $csProcess = $testEnv->runTwigCSLint($file);
 
-            // checkout user asserts
-            if (null === $testDetails->getAssert()) {
-                $this->assertContains('Success', $makerTestProcess->getOutput(), $makerTestProcess->getErrorOutput());
-            } else {
-                ($testDetails->getAssert())($makerTestProcess->getOutput(), $testEnv->getPath());
+                $this->assertTrue($csProcess->isSuccessful(), sprintf('File "%s" has a twig-cs problem: %s', $file, $csProcess->getOutput()));
             }
-        } finally {
-            $testEnv->reset();
+        }
+
+        // run internal tests
+        $internalTestProcess = $testEnv->runInternalTests();
+        if (null !== $internalTestProcess) {
+            $this->assertTrue($internalTestProcess->isSuccessful(), sprintf("Error while running the PHPUnit tests *in* the project: \n\n %s \n\n Command Output: %s", $internalTestProcess->getOutput(), $makerTestProcess->getOutput()));
+        }
+
+        // checkout user asserts
+        if (null === $testDetails->getAssert()) {
+            $this->assertContains('Success', $makerTestProcess->getOutput(), $makerTestProcess->getErrorOutput());
+        } else {
+            ($testDetails->getAssert())($makerTestProcess->getOutput(), $testEnv->getPath());
         }
     }
 


### PR DESCRIPTION
Hi,

With this PR, the first time a test environment is built, a git repository is created and a first commit is done. Then, the next time this environment is used, the repository is reset to the original form.
This fixes some cache problems : the environments didn't get back to their original form for modified files. And this way, we don't have to copy back the fixtures files to run maker commands inside the cache directories for manual testing sake.

Edited by @lyrixx: Better diff with [`?w=1`](https://github.com/symfony/maker-bundle/pull/275/files?w=1)