### PR TITLE
Fix self-referencing entity associations

### DIFF
--- a/src/Doctrine/BaseRelation.php
+++ b/src/Doctrine/BaseRelation.php
@@ -19,6 +19,7 @@ abstract class BaseRelation
     private $propertyName;
     private $targetClassName;
     private $targetPropertyName;
+    private $isSelfReferencing = false;
     private $mapInverseRelation = true;
 
     abstract public function isOwning(): bool;
@@ -55,6 +56,18 @@ abstract class BaseRelation
     public function setTargetPropertyName($targetPropertyName)
     {
         $this->targetPropertyName = $targetPropertyName;
+
+        return $this;
+    }
+
+    public function isSelfReferencing(): bool
+    {
+        return $this->isSelfReferencing;
+    }
+
+    public function setIsSelfReferencing(bool $isSelfReferencing)
+    {
+        $this->isSelfReferencing = $isSelfReferencing;
 
         return $this;
     }

--- a/src/Doctrine/EntityRelation.php
+++ b/src/Doctrine/EntityRelation.php
@@ -33,6 +33,8 @@ final class EntityRelation
 
     private $isNullable = false;
 
+    private $isSelfReferencing = false;
+
     private $orphanRemoval = false;
 
     private $mapInverseRelation = true;
@@ -50,6 +52,7 @@ final class EntityRelation
         $this->type = $type;
         $this->owningClass = $owningClass;
         $this->inverseClass = $inverseClass;
+        $this->isSelfReferencing = $owningClass === $inverseClass;
     }
 
     public function setOwningProperty(string $owningProperty)
@@ -95,6 +98,7 @@ final class EntityRelation
                     ->setTargetClassName($this->inverseClass)
                     ->setTargetPropertyName($this->inverseProperty)
                     ->setIsNullable($this->isNullable)
+                    ->setIsSelfReferencing($this->isSelfReferencing)
                     ->setMapInverseRelation($this->mapInverseRelation)
                 ;
                 break;
@@ -104,6 +108,7 @@ final class EntityRelation
                     ->setTargetClassName($this->inverseClass)
                     ->setTargetPropertyName($this->inverseProperty)
                     ->setIsOwning(true)->setMapInverseRelation($this->mapInverseRelation)
+                    ->setIsSelfReferencing($this->isSelfReferencing)
                 ;
                 break;
             case self::ONE_TO_ONE:
@@ -113,6 +118,7 @@ final class EntityRelation
                     ->setTargetPropertyName($this->inverseProperty)
                     ->setIsNullable($this->isNullable)
                     ->setIsOwning(true)
+                    ->setIsSelfReferencing($this->isSelfReferencing)
                     ->setMapInverseRelation($this->mapInverseRelation)
                 ;
                 break;
@@ -130,6 +136,7 @@ final class EntityRelation
                     ->setTargetClassName($this->owningClass)
                     ->setTargetPropertyName($this->owningProperty)
                     ->setOrphanRemoval($this->orphanRemoval)
+                    ->setIsSelfReferencing($this->isSelfReferencing)
                 ;
                 break;
             case self::MANY_TO_MANY:
@@ -138,6 +145,7 @@ final class EntityRelation
                     ->setTargetClassName($this->owningClass)
                     ->setTargetPropertyName($this->owningProperty)
                     ->setIsOwning(false)
+                    ->setIsSelfReferencing($this->isSelfReferencing)
                 ;
                 break;
             case self::ONE_TO_ONE:
@@ -147,6 +155,7 @@ final class EntityRelation
                     ->setTargetPropertyName($this->owningProperty)
                     ->setIsNullable($this->isNullable)
                     ->setIsOwning(false)
+                    ->setIsSelfReferencing($this->isSelfReferencing)
                 ;
                 break;
             default:
@@ -182,6 +191,11 @@ final class EntityRelation
     public function isNullable(): bool
     {
         return $this->isNullable;
+    }
+
+    public function isSelfReferencing(): bool
+    {
+        return $this->isSelfReferencing;
     }
 
     public function getMapInverseRelation(): bool

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -201,12 +201,12 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             } elseif ($newField instanceof EntityRelation) {
                 // both overridden below for OneToMany
                 $newFieldName = $newField->getOwningProperty();
-                if ($newField->getInverseClass() !== $newField->getOwningClass()) {
-                    $otherManipulatorFilename = $this->getPathOfClass($newField->getInverseClass());
-                    $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
-                } else {
+                if ($newField->isSelfReferencing()) {
                     $otherManipulatorFilename = $entityPath;
                     $otherManipulator = $manipulator;
+                } else {
+                    $otherManipulatorFilename = $this->getPathOfClass($newField->getInverseClass());
+                    $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
                 }
                 switch ($newField->getType()) {
                     case EntityRelation::MANY_TO_ONE:

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -201,8 +201,13 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             } elseif ($newField instanceof EntityRelation) {
                 // both overridden below for OneToMany
                 $newFieldName = $newField->getOwningProperty();
-                $otherManipulatorFilename = $this->getPathOfClass($newField->getInverseClass());
-                $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
+                if ($newField->getInverseClass() !== $newField->getOwningClass()) {
+                    $otherManipulatorFilename = $this->getPathOfClass($newField->getInverseClass());
+                    $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
+                } else {
+                    $otherManipulatorFilename = $entityPath;
+                    $otherManipulator = $manipulator;
+                }
                 switch ($newField->getType()) {
                     case EntityRelation::MANY_TO_ONE:
                         if ($newField->getOwningClass() === $entityClassDetails->getFullName()) {

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -447,7 +447,7 @@ final class ClassSourceManipulator
 
     private function addCollectionRelation(BaseCollectionRelation $relation)
     {
-        $typeHint = !$relation->isSelfReferencing() ? $this->addUseStatementIfNecessary($relation->getTargetClassName()) : 'self';
+        $typeHint = $relation->isSelfReferencing() ? 'self' : $this->addUseStatementIfNecessary($relation->getTargetClassName());
 
         $arrayCollectionTypeHint = $this->addUseStatementIfNecessary(ArrayCollection::class);
         $collectionTypeHint = $this->addUseStatementIfNecessary(Collection::class);

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -447,7 +447,7 @@ final class ClassSourceManipulator
 
     private function addCollectionRelation(BaseCollectionRelation $relation)
     {
-        $typeHint = $this->addUseStatementIfNecessary($relation->getTargetClassName());
+        $typeHint = !$relation->isSelfReferencing() ? $this->addUseStatementIfNecessary($relation->getTargetClassName()) : 'self';
 
         $arrayCollectionTypeHint = $this->addUseStatementIfNecessary(ArrayCollection::class);
         $collectionTypeHint = $this->addUseStatementIfNecessary(Collection::class);

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -805,6 +805,36 @@ class FunctionalTest extends MakerTestCase
             ->setRequiredPhpVersion(70100)
         ];
 
+        yield 'entity_many_to_one_self_referencing' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeEntity::class),
+            [
+                // entity class name
+                'User',
+                // field name
+                'guardian',
+                // add a relationship field
+                'relation',
+                // the target entity
+                'User',
+                // relation type
+                'ManyToOne',
+                // nullable
+                'n',
+                // do you want to generate an inverse relation? (default to yes)
+                '',
+                // field name on opposite side - use default 'userAvatarPhotos'
+                'wards',
+                // orphanRemoval (default to no)
+                '',
+                // finish adding fields
+                '',
+            ])
+           ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeEntitySelfReferencing')
+           ->configureDatabase()
+           ->updateSchemaAfterCommand()
+           ->setRequiredPhpVersion(70100)
+        ];
+
         yield 'entity_one_to_many_simple' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeEntity::class),
             [

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -819,10 +819,10 @@ class FunctionalTest extends MakerTestCase
                 // relation type
                 'ManyToOne',
                 // nullable
-                'n',
+                'y',
                 // do you want to generate an inverse relation? (default to yes)
                 '',
-                // field name on opposite side - use default 'userAvatarPhotos'
+                // field name on opposite side
                 'wards',
                 // orphanRemoval (default to no)
                 '',

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -823,7 +823,7 @@ class FunctionalTest extends MakerTestCase
                 // do you want to generate an inverse relation? (default to yes)
                 '',
                 // field name on opposite side
-                'wards',
+                'dependants',
                 // orphanRemoval (default to no)
                 '',
                 // finish adding fields

--- a/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
+++ b/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $firstName;
+
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $createdAt;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName)
+    {
+        $this->firstName = $firstName;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeInterface $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/fixtures/MakeEntitySelfReferencing/tests/GeneratedEntityTest.php
+++ b/tests/fixtures/MakeEntitySelfReferencing/tests/GeneratedEntityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Tests;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Doctrine\ORM\EntityManager;
+use App\Entity\User;
+
+class GeneratedEntityTest extends KernelTestCase
+{
+    public function testGeneratedEntity()
+    {
+        self::bootKernel();
+        /** @var EntityManager $em */
+        $em = self::$kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $em->createQuery('DELETE FROM App\\Entity\\User u')->execute();
+
+        $user = new User();
+        // check that the constructor was instantiated properly
+        $this->assertInstanceOf(ArrayCollection::class, $user->getWards());
+        // set existing field
+        $user->setFirstName('Ryan');
+        $em->persist($user);
+
+        $ward = new User();
+        $ward->setFirstName('Tim');
+        $ward->setGuardian($user);
+        $em->persist($ward);
+
+        // set via the inverse side
+        $ward2 = new User();
+        $ward2->setFirstName('Fabien');
+        $user->addWard($ward2);
+        $em->persist($ward2);
+
+        $em->flush();
+        $em->refresh($user);
+
+        $actualUser = $em->getRepository(User::class)
+            ->findAll();
+
+        $this->assertCount(3, $actualUser);
+        $this->assertCount(2, $actualUser[0]->getWards());
+    }
+}

--- a/tests/fixtures/MakeEntitySelfReferencing/tests/GeneratedEntityTest.php
+++ b/tests/fixtures/MakeEntitySelfReferencing/tests/GeneratedEntityTest.php
@@ -21,7 +21,7 @@ class GeneratedEntityTest extends KernelTestCase
 
         $user = new User();
         // check that the constructor was instantiated properly
-        $this->assertInstanceOf(ArrayCollection::class, $user->getWards());
+        $this->assertInstanceOf(ArrayCollection::class, $user->getDependants());
         // set existing field
         $user->setFirstName('Ryan');
         $em->persist($user);
@@ -34,7 +34,7 @@ class GeneratedEntityTest extends KernelTestCase
         // set via the inverse side
         $ward2 = new User();
         $ward2->setFirstName('Fabien');
-        $user->addWard($ward2);
+        $user->addDependant($ward2);
         $em->persist($ward2);
 
         $em->flush();
@@ -44,6 +44,6 @@ class GeneratedEntityTest extends KernelTestCase
             ->findAll();
 
         $this->assertCount(3, $actualUser);
-        $this->assertCount(2, $actualUser[0]->getWards());
+        $this->assertCount(2, $actualUser[0]->getDependants());
     }
 }


### PR DESCRIPTION
Fixes faulty generation of entities with self-referencing associations https://github.com/symfony/maker-bundle/issues/166. It looks like changes for the owning entity were overwritten by the changes for the inversed entity.