### PR TITLE
Add --no-template option for make:controller command

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -39,7 +39,7 @@ final class MakeController extends AbstractMaker
         $command
             ->setDescription('Creates a new controller class')
             ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
-            ->addOption('no-template', 'n', InputOption::VALUE_NONE, 'Use this option to disable template generation')
+            ->addOption('no-template', null, InputOption::VALUE_NONE, 'Use this option to disable template generation')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeController.txt'))
         ;
     }

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -38,6 +39,7 @@ final class MakeController extends AbstractMaker
         $command
             ->setDescription('Creates a new controller class')
             ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addOption('--no-template', '-n', InputOption::VALUE_OPTIONAL)
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeController.txt'))
         ;
     }
@@ -50,6 +52,7 @@ final class MakeController extends AbstractMaker
             'Controller'
         );
 
+        $withTemplate = !$input->getOption('--no-template');
         $templateName = Str::asFilePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()).'/index.html.twig';
         $controllerPath = $generator->generateController(
             $controllerClassNameDetails->getFullName(),
@@ -57,12 +60,12 @@ final class MakeController extends AbstractMaker
             [
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'twig_installed' => $this->isTwigInstalled(),
+                'twig_installed' => $this->isTwigInstalled() && $withTemplate,
                 'template_name' => $templateName,
             ]
         );
 
-        if ($this->isTwigInstalled()) {
+        if ($this->isTwigInstalled() && $withTemplate) {
             $generator->generateFile(
                 'templates/'.$templateName,
                 'controller/twig_template.tpl.php',

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -39,7 +39,7 @@ final class MakeController extends AbstractMaker
         $command
             ->setDescription('Creates a new controller class')
             ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
-            ->addOption('--no-template', '-n', InputOption::VALUE_OPTIONAL)
+            ->addOption('no-template', 'n', InputOption::VALUE_NONE, 'Use this option to disable template generation')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeController.txt'))
         ;
     }
@@ -52,7 +52,7 @@ final class MakeController extends AbstractMaker
             'Controller'
         );
 
-        $withTemplate = !$input->getOption('--no-template');
+        $noTemplate = $input->getOption('no-template');
         $templateName = Str::asFilePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()).'/index.html.twig';
         $controllerPath = $generator->generateController(
             $controllerClassNameDetails->getFullName(),
@@ -60,12 +60,12 @@ final class MakeController extends AbstractMaker
             [
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'twig_installed' => $this->isTwigInstalled() && $withTemplate,
+                'with_template' => $this->isTwigInstalled() && !$noTemplate,
                 'template_name' => $templateName,
             ]
         );
 
-        if ($this->isTwigInstalled() && $withTemplate) {
+        if ($this->isTwigInstalled() && !$noTemplate) {
             $generator->generateFile(
                 'templates/'.$templateName,
                 'controller/twig_template.tpl.php',

--- a/src/Resources/help/MakeController.txt
+++ b/src/Resources/help/MakeController.txt
@@ -3,3 +3,7 @@ The <info>%command.name%</info> command generates a new controller class.
 <info>php %command.full_name% CoolStuffController</info>
 
 If the argument is missing, the command will ask for the controller class name interactively.
+
+You can also generate the controller alone, without template with this option:
+
+<info>php %command.full_name% --no-template</info>

--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -12,7 +12,7 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
      */
     public function index()
     {
-<?php if ($twig_installed) { ?>
+<?php if ($with_template) { ?>
         return $this->render('<?= $template_name ?>', [
             'controller_name' => '<?= $class_name ?>',
         ]);

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -126,9 +126,8 @@ class FunctionalTest extends MakerTestCase
             [
                 // controller class name
                 'FooNoTemplate',
-                // option to disable template generation
-                '--no-template'
             ])
+            ->setArgumentsString('--no-template')
             ->addExtraDependencies('twig')
             ->assert(function (string $output, string $directory) {
                 // make sure the template was not configured

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -121,6 +121,22 @@ class FunctionalTest extends MakerTestCase
             ->deleteFile('templates/base.html.twig')
         ];
 
+        yield 'controller_without_template' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeController::class),
+            [
+                // controller class name
+                'FooTwig',
+                // option to disable template generation
+                '--no-template'
+            ])
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeController')
+            ->addExtraDependencies('twig')
+            ->assert(function (string $output, string $directory) {
+                // make sure the template was not configured
+                $this->assertContainsCount('created: ', $output, 1);
+            })
+        ];
+
         yield 'controller_sub_namespace' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeController::class),
             [

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -125,15 +125,16 @@ class FunctionalTest extends MakerTestCase
             $this->getMakerInstance(MakeController::class),
             [
                 // controller class name
-                'FooTwig',
+                'FooNoTemplate',
                 // option to disable template generation
                 '--no-template'
             ])
-            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeController')
             ->addExtraDependencies('twig')
             ->assert(function (string $output, string $directory) {
                 // make sure the template was not configured
                 $this->assertContainsCount('created: ', $output, 1);
+                $this->assertContains('created: src/Controller/FooNoTemplateController.php', $output);
+                $this->assertNotContains('created: templates/foo_no_template/index.html.twig', $output);
             })
         ];
 


### PR DESCRIPTION
I had several times the case in which I did not necessarily need a template when I generated a controller. So I'm trying to add an option `--no-template` to force avoid template generation.

I think that I will need help on tests writing ;) 