### PR TITLE
Throwing CustomUserMessageAuthenticationException in make:auth login

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
 use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
 use Symfony\Bundle\MakerBundle\Security\SecurityControllerBuilder;
+use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
@@ -237,6 +238,7 @@ final class MakeAuthenticator extends AbstractMaker
                 'user_fully_qualified_class_name' => trim($userClassNameDetails->getFullName(), '\\'),
                 'user_class_name' => $userClassNameDetails->getShortName(),
                 'username_field' => $userNameField,
+                'username_field_label' => Str::asHumanWords($userNameField),
                 'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
                 'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
             ]
@@ -281,7 +283,7 @@ final class MakeAuthenticator extends AbstractMaker
             [
                 'username_field' => $userNameField,
                 'username_is_email' => false !== stripos($userNameField, 'email'),
-                'username_label' => ucfirst(implode(' ', preg_split('/(?=[A-Z])/', $userNameField))),
+                'username_label' => ucfirst(Str::asHumanWords($userNameField)),
             ]
         );
     }

--- a/src/Str.php
+++ b/src/Str.php
@@ -205,4 +205,9 @@ final class Str
 
         return $arr1[0] == $arr2[0];
     }
+
+    public static function asHumanWords(string $variableName): string
+    {
+        return implode(' ', preg_split('/(?=[A-Z])/', $variableName));
+    }
 }


### PR DESCRIPTION
The idea is that this is easier and more self-documenting than teaching the user to translate the "Username could not be found." message.

```diff
// src/Security/LoginFormAuthenticator.php
// ...

public function getUser($credentials, UserProviderInterface $userProvider)
{
// ...

-   return $this->entityManager->getRepository(User::class)->findOneBy([
+   $user = $this->entityManager->getRepository(User::class)->findOneBy([
        'email' => $credentials['email'],
    ]);

+   if (!$user) {
+       // fail authentication with a custom error
+       throw new CustomUserMessageAuthenticationException('Email could not be found.');
+   }

+   return $user;
}
```

Cheers!