### PR TITLE
Fix crud controller template

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -138,7 +138,7 @@ final class MakeCrud extends AbstractMaker
                     'form_class_name' => $formClassDetails->getShortName(),
                     'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
                     'route_name' => $routeName,
-                    'template_path' => $templatesPath,
+                    'templates_path' => $templatesPath,
                     'entity_var_plural' => $entityVarPlural,
                     'entity_twig_var_plural' => $entityTwigVarPlural,
                     'entity_var_singular' => $entityVarSingular,

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -126,6 +126,7 @@ final class MakeCrud extends AbstractMaker
         $entityTwigVarSingular = Str::asTwigVariable($entityVarSingular);
 
         $routeName = Str::asRouteName($controllerClassDetails->getRelativeNameWithoutSuffix());
+        $templatesPath = Str::asFilePath($controllerClassDetails->getRelativeNameWithoutSuffix());
 
         $generator->generateController(
             $controllerClassDetails->getFullName(),
@@ -137,6 +138,7 @@ final class MakeCrud extends AbstractMaker
                     'form_class_name' => $formClassDetails->getShortName(),
                     'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
                     'route_name' => $routeName,
+                    'template_path' => $templatesPath,
                     'entity_var_plural' => $entityVarPlural,
                     'entity_twig_var_plural' => $entityTwigVarPlural,
                     'entity_var_singular' => $entityVarSingular,
@@ -156,8 +158,6 @@ final class MakeCrud extends AbstractMaker
                 'form_fields' => $entityDoctrineDetails->getFormFields(),
             ]
         );
-
-        $templatesPath = Str::asFilePath($controllerClassDetails->getRelativeNameWithoutSuffix());
 
         $templates = [
             '_delete_form' => [

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -23,7 +23,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 <?php if (isset($repository_full_class_name)): ?>
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>): Response
     {
-        return $this->render('<?= $template_path ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $repository_var ?>->findAll()]);
+        return $this->render('<?= $templates_path ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $repository_var ?>->findAll()]);
     }
 <?php else: ?>
     public function index(): Response
@@ -32,7 +32,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             ->getRepository(<?= $entity_class_name ?>::class)
             ->findAll();
 
-        return $this->render('<?= $template_path ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $entity_var_plural ?>]);
+        return $this->render('<?= $templates_path ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $entity_var_plural ?>]);
     }
 <?php endif ?>
 
@@ -53,7 +53,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             return $this->redirectToRoute('<?= $route_name ?>_index');
         }
 
-        return $this->render('<?= $template_path ?>/new.html.twig', [
+        return $this->render('<?= $templates_path ?>/new.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form->createView(),
         ]);
@@ -64,7 +64,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
      */
     public function show(<?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
-        return $this->render('<?= $template_path ?>/show.html.twig', ['<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>]);
+        return $this->render('<?= $templates_path ?>/show.html.twig', ['<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>]);
     }
 
     /**
@@ -81,7 +81,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             return $this->redirectToRoute('<?= $route_name ?>_edit', ['<?= $entity_identifier ?>' => $<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>()]);
         }
 
-        return $this->render('<?= $template_path ?>/edit.html.twig', [
+        return $this->render('<?= $templates_path ?>/edit.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form->createView(),
         ]);

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -23,7 +23,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 <?php if (isset($repository_full_class_name)): ?>
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>): Response
     {
-        return $this->render('<?= $route_name ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $repository_var ?>->findAll()]);
+        return $this->render('<?= $template_path ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $repository_var ?>->findAll()]);
     }
 <?php else: ?>
     public function index(): Response
@@ -32,7 +32,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             ->getRepository(<?= $entity_class_name ?>::class)
             ->findAll();
 
-        return $this->render('<?= $route_name ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $entity_var_plural ?>]);
+        return $this->render('<?= $template_path ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $entity_var_plural ?>]);
     }
 <?php endif ?>
 
@@ -53,7 +53,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             return $this->redirectToRoute('<?= $route_name ?>_index');
         }
 
-        return $this->render('<?= $route_name ?>/new.html.twig', [
+        return $this->render('<?= $template_path ?>/new.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form->createView(),
         ]);
@@ -64,7 +64,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
      */
     public function show(<?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
-        return $this->render('<?= $route_name ?>/show.html.twig', ['<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>]);
+        return $this->render('<?= $template_path ?>/show.html.twig', ['<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>]);
     }
 
     /**
@@ -81,7 +81,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             return $this->redirectToRoute('<?= $route_name ?>_edit', ['<?= $entity_identifier ?>' => $<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>()]);
         }
 
-        return $this->render('<?= $route_name ?>/edit.html.twig', [
+        return $this->render('<?= $template_path ?>/edit.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form->createView(),
         ]);


### PR DESCRIPTION
There is a mistake in crud controller template :

Example  (`src/Resources/skeleton/crud/controller/Controller.tpl.php` - line 35) : 
`return $this->render('<?= $route_name ?>/index.html.twig', ['<?= $entity_twig_var_plural ?>' => $<?= $entity_var_plural ?>]);`

With an entity with following path :` Entity/Foo/BarBar.php` , `$route_name` will be equal to `foo_bar_bar` and does not correspond with the `index.html.twig` path (should be `foo/bar_bar`).

This pull request fix this by adding the `$templatesPath` var, used to create twig templates, for the controller generation.

:)