### PR TITLE
Fix make:user dependency: more precise to get the recipe

### DIFF
--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -26,12 +26,12 @@ use Symfony\Bundle\MakerBundle\Security\UserClassConfiguration;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
 use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Security\Core\Encoder\Argon2iPasswordEncoder;
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -223,8 +223,9 @@ final class MakeUser extends AbstractMaker
     {
         $dependencies->requirePHP71();
 
+        // checking for SecurityBundle guarantees security.yaml is present
         $dependencies->addClassDependency(
-            UserInterface::class,
+            SecurityBundle::class,
             'security'
         );
 


### PR DESCRIPTION
We fully need SecurityBundle so the recipe has been executed.

Discovered at a workshop - if you installed `security-csrf` first, and then ran this command, it would allow you to continue, though the `security.yaml` file would be missing.