### PR TITLE
[Voter] Use the subject's FQCN in the support method

### DIFF
--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -13,7 +13,7 @@ class <?= $class_name ?> extends Voter
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
         return in_array($attribute, ['POST_EDIT', 'POST_VIEW'])
-            && $subject instanceof App\Entity\BlogPost;
+            && $subject instanceof \App\Entity\BlogPost;
     }
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)


### PR DESCRIPTION
People could replace only the `BlogPost` class. So the support method will always return `false`.

With a leading `\`, the class name will resolve "normally"