### PR TITLE
[CRUD] Redirect to index after edit

### DIFF
--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -78,7 +78,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         if ($form->isSubmitted() && $form->isValid()) {
             $this->getDoctrine()->getManager()->flush();
 
-            return $this->redirectToRoute('<?= $route_name ?>_edit', ['<?= $entity_identifier ?>' => $<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>()]);
+            return $this->redirectToRoute('<?= $route_name ?>_index', ['<?= $entity_identifier ?>' => $<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>()]);
         }
 
         return $this->render('<?= $templates_path ?>/edit.html.twig', [

--- a/tests/fixtures/MakeCrud/tests/GeneratedCrudControllerTest.php
+++ b/tests/fixtures/MakeCrud/tests/GeneratedCrudControllerTest.php
@@ -44,15 +44,6 @@ class GeneratedCrudControllerTest extends WebTestCase
         $crawler = $client->followRedirect();
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-        $this->assertContains('Edit SweetFood', $client->getResponse()->getContent());
-        $this->assertGreaterThan(0, $crawler->filter('input[type=text]')->count());
-        $this->assertEquals('Candy edited', $crawler->filter('input[type=text]')->attr('value'));
-
-        $backTolistLink = $crawler->filter('a:contains("back to list")')->eq(0)->link();
-
-        $crawler = $client->click($backTolistLink);
-        $this->assertTrue($client->getResponse()->isSuccessful());
-        $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
         $this->assertContains('SweetFood index', $client->getResponse()->getContent());
         $this->assertContains('Candy edited', $client->getResponse()->getContent());
 

--- a/tests/fixtures/MakeCrudInCustomRootNamespace/tests/GeneratedCrudControllerTest.php
+++ b/tests/fixtures/MakeCrudInCustomRootNamespace/tests/GeneratedCrudControllerTest.php
@@ -44,15 +44,6 @@ class GeneratedCrudControllerTest extends WebTestCase
         $crawler = $client->followRedirect();
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-        $this->assertContains('Edit SweetFood', $client->getResponse()->getContent());
-        $this->assertGreaterThan(0, $crawler->filter('input[type=text]')->count());
-        $this->assertEquals('Candy edited', $crawler->filter('input[type=text]')->attr('value'));
-
-        $backTolistLink = $crawler->filter('a:contains("back to list")')->eq(0)->link();
-
-        $crawler = $client->click($backTolistLink);
-        $this->assertTrue($client->getResponse()->isSuccessful());
-        $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
         $this->assertContains('SweetFood index', $client->getResponse()->getContent());
         $this->assertContains('Candy edited', $client->getResponse()->getContent());
 


### PR DESCRIPTION
Update the generated edit action.
This now redirects to the index instead of the edit form.
Fixes #257