### PR TITLE
Checking on reserved keywords for class name validity.

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle;
 
-use Symfony\Component\DependencyInjection\Container;
 use Doctrine\Common\Inflector\Inflector;
+use Symfony\Component\DependencyInjection\Container;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -195,6 +195,29 @@ final class Str
     public static function isValidPhpVariableName($name)
     {
         return (bool) preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name, $matches);
+    }
+
+    public static function isValidPhpClassName(string $className): bool
+    {
+        $reservedKeywords = ['__halt_compiler', 'abstract', 'and', 'array',
+            'as', 'break', 'callable', 'case', 'catch', 'class',
+            'clone', 'const', 'continue', 'declare', 'default', 'die', 'do',
+            'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor',
+            'endforeach', 'endif', 'endswitch', 'endwhile', 'eval',
+            'exit', 'extends', 'final', 'for', 'foreach', 'function',
+            'global', 'goto', 'if', 'implements', 'include',
+            'include_once', 'instanceof', 'insteadof', 'interface', 'isset',
+            'list', 'namespace', 'new', 'or', 'print', 'private',
+            'protected', 'public', 'require', 'require_once', 'return',
+            'static', 'switch', 'throw', 'trait', 'try', 'unset',
+            'use', 'var', 'while', 'xor', '__CLASS__', '__DIR__', '__FILE__',
+            '__FUNCTION__', '__LINE__', '__METHOD__', '__NAMESPACE__', '__TRAIT__',
+            'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
+            'iterable', 'object',
+        ];
+
+        return !\in_array(strtolower($className), $reservedKeywords, true) &&
+            preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $className);
     }
 
     public static function areClassesAlphabetical(string $class1, string $class2)

--- a/src/Str.php
+++ b/src/Str.php
@@ -197,29 +197,6 @@ final class Str
         return (bool) preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name, $matches);
     }
 
-    public static function isValidPhpClassName(string $className): bool
-    {
-        $reservedKeywords = ['__halt_compiler', 'abstract', 'and', 'array',
-            'as', 'break', 'callable', 'case', 'catch', 'class',
-            'clone', 'const', 'continue', 'declare', 'default', 'die', 'do',
-            'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor',
-            'endforeach', 'endif', 'endswitch', 'endwhile', 'eval',
-            'exit', 'extends', 'final', 'for', 'foreach', 'function',
-            'global', 'goto', 'if', 'implements', 'include',
-            'include_once', 'instanceof', 'insteadof', 'interface', 'isset',
-            'list', 'namespace', 'new', 'or', 'print', 'private',
-            'protected', 'public', 'require', 'require_once', 'return',
-            'static', 'switch', 'throw', 'trait', 'try', 'unset',
-            'use', 'var', 'while', 'xor', '__CLASS__', '__DIR__', '__FILE__',
-            '__FUNCTION__', '__LINE__', '__METHOD__', '__NAMESPACE__', '__TRAIT__',
-            'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
-            'iterable', 'object',
-        ];
-
-        return !\in_array(strtolower($className), $reservedKeywords, true) &&
-            preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $className);
-    }
-
     public static function areClassesAlphabetical(string $class1, string $class2)
     {
         $arr1 = [$class1, $class2];

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -29,7 +29,7 @@ final class Validator
         $pieces = explode('\\', ltrim($className, '\\'));
 
         foreach ($pieces as $piece) {
-            if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $piece)) {
+            if (!Str::isValidPhpClassName($piece)) {
                 $errorMessage = $errorMessage ?: sprintf('"%s" is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores)', $className);
 
                 throw new RuntimeCommandException($errorMessage);

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -27,12 +27,34 @@ final class Validator
     {
         // remove potential opening slash so we don't match on it
         $pieces = explode('\\', ltrim($className, '\\'));
+        $shortClassName = Str::getShortClassName($className);
+
+        $reservedKeywords = ['__halt_compiler', 'abstract', 'and', 'array',
+            'as', 'break', 'callable', 'case', 'catch', 'class',
+            'clone', 'const', 'continue', 'declare', 'default', 'die', 'do',
+            'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor',
+            'endforeach', 'endif', 'endswitch', 'endwhile', 'eval',
+            'exit', 'extends', 'final', 'for', 'foreach', 'function',
+            'global', 'goto', 'if', 'implements', 'include',
+            'include_once', 'instanceof', 'insteadof', 'interface', 'isset',
+            'list', 'namespace', 'new', 'or', 'print', 'private',
+            'protected', 'public', 'require', 'require_once', 'return',
+            'static', 'switch', 'throw', 'trait', 'try', 'unset',
+            'use', 'var', 'while', 'xor',
+            'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
+            'iterable', 'object', '__FILE__', '__LINE__', '__DIR__', '__FUNCTION__', '__CLASS__',
+            '__METHOD__', '__NAMESPACE__', '__TRAIT__',
+        ];
 
         foreach ($pieces as $piece) {
-            if (!Str::isValidPhpClassName($piece)) {
+            if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $piece)) {
                 $errorMessage = $errorMessage ?: sprintf('"%s" is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores)', $className);
 
                 throw new RuntimeCommandException($errorMessage);
+            }
+
+            if (\in_array(strtolower($shortClassName), $reservedKeywords, true)) {
+                throw new RuntimeCommandException(sprintf('"%s" is a reserved keyword and thus cannot be used as class name in PHP.', $shortClassName));
             }
         }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -49,4 +49,17 @@ class ValidatorTest extends TestCase
 
         Validator::validateScale(31);
     }
+
+    public function testValidateClassName()
+    {
+        $this->assertSame('\App\Service\Foo', Validator::validateClassName('\App\Service\Foo'));
+        $this->assertSame('Foo', Validator::validateClassName('Foo'));
+    }
+
+    public function testInvalidClassName()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('"class" is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores)');
+        Validator::validateClassName('class');
+    }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -59,7 +59,7 @@ class ValidatorTest extends TestCase
     public function testInvalidClassName()
     {
         $this->expectException(RuntimeCommandException::class);
-        $this->expectExceptionMessage('"class" is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores)');
-        Validator::validateClassName('class');
+        $this->expectExceptionMessage('"Class" is a reserved keyword and thus cannot be used as class name in PHP.');
+        Validator::validateClassName('App\Entity\Class');
     }
 }


### PR DESCRIPTION
Validator should also check if the given class name is a reserved keyword or not.
However we have to come up with a better exception message, since this one does not reflect the error. Any suggestion?

Thanks for your help @weaverryan during #SymfonyConHackDay2018

Fixes #305 