### PR TITLE
[make:crud][experimental] Add generated tests to make:crud

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -197,8 +197,8 @@ final class MakeCrud extends AbstractMaker
                 'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => $routeName,
                 'class_name' => Str::getShortClassName($testClassDetails->getFullName()),
-				'namespace' => Str::getNamespace($testClassDetails->getFullName()),
-				'form_fields' => $entityDoctrineDetails->getFormFields(),
+                'namespace' => Str::getNamespace($testClassDetails->getFullName()),
+                'form_fields' => $entityDoctrineDetails->getFormFields(),
             ]
         );
 

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -33,7 +33,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -277,7 +276,7 @@ final class MakeCrud extends AbstractMaker
                 ]
             );
 
-            if (!class_exists(CssSelectorConverter::class)) {
+            if (!class_exists(WebTestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -197,7 +197,8 @@ final class MakeCrud extends AbstractMaker
                 'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => $routeName,
                 'class_name' => Str::getShortClassName($testClassDetails->getFullName()),
-                'namespace' => Str::getNamespace($testClassDetails->getFullName()),
+				'namespace' => Str::getNamespace($testClassDetails->getFullName()),
+				'form_fields' => $entityDoctrineDetails->getFormFields(),
             ]
         );
 

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -248,11 +248,6 @@ final class MakeCrud extends AbstractMaker
                 'ControllerTest'
             );
 
-            $entityFields = $entityDoctrineDetails->getDisplayFields();
-            $entityFields = array_filter($entityFields, static function ($field) use ($entityDoctrineDetails) {
-                return $field['fieldName'] !== $entityDoctrineDetails->getIdentifier();
-            });
-
             $useStatements = new UseStatementGenerator([
                 $entityClassDetails->getFullName(),
                 WebTestCase::class,
@@ -277,9 +272,7 @@ final class MakeCrud extends AbstractMaker
                     'class_name' => Str::getShortClassName($testClassDetails->getFullName()),
                     'namespace' => Str::getNamespace($testClassDetails->getFullName()),
                     'form_fields' => $entityDoctrineDetails->getFormFields(),
-                    'entity_fields' => $entityFields,
-                    'use_entity_manager' => EntityManagerInterface::class === $repositoryClassName,
-                    'repository_class_name' => EntityManagerInterface::class === $repositoryClassName ? 'EntityManagerInterface' : $repositoryVars['repository_class_name'],
+                    'repository_class_name' => $repositoryVars['repository_class_name'],
                     'form_field_prefix' => strtolower(Str::asSnakeCase($entityTwigVarSingular)),
                 ]
             );

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -260,16 +260,24 @@ final class MakeCrud extends AbstractMaker
                 'ControllerTest'
             );
 
+            $entityFields = $entityDoctrineDetails->getDisplayFields();
+            $entityFields = array_filter($entityFields, function ($field) use ($entityDoctrineDetails) {
+                return $field['fieldName'] !== $entityDoctrineDetails->getIdentifier();
+            });
+
             $generator->generateFile(
                 'tests/Controller/'.$testClassDetails->getShortName().'.php',
                 'crud/test/Test.tpl.php',
                 [
+                    'entity_full_class_name' => $entityClassDetails->getFullName(),
                     'entity_class_name' => $entityClassDetails->getShortName(),
+                    'entity_var_singular' => $entityVarSingular,
                     'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
                     'route_name' => $routeName,
                     'class_name' => Str::getShortClassName($testClassDetails->getFullName()),
                     'namespace' => Str::getNamespace($testClassDetails->getFullName()),
                     'form_fields' => $entityDoctrineDetails->getFormFields(),
+                    'entity_fields' => $entityFields,
                 ]
             );
         } else {

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -101,9 +101,7 @@ final class MakeCrud extends AbstractMaker
             $defaultControllerClass
         );
 
-        if (class_exists(CssSelectorConverter::class)) {
-            $this->generateTests = $io->confirm('Do you want to generate tests for the controller? [Experimental]', false);
-        }
+        $this->generateTests = $io->confirm('Do you want to generate tests for the controller?. [Experimental]', false);
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
@@ -278,6 +276,10 @@ final class MakeCrud extends AbstractMaker
                     'form_field_prefix' => strtolower(Str::asSnakeCase($entityTwigVarSingular)),
                 ]
             );
+
+            if (!class_exists(CssSelectorConverter::class)) {
+                $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
+            }
         }
 
         $generator->writeChanges();

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -193,8 +193,7 @@ final class MakeCrud extends AbstractMaker
             'tests/Controller/'.$testClassDetails->getShortName().'.php',
             'crud/test/Test.tpl.php',
             [
-                'bounded_full_class_name' => $entityClassDetails->getFullName(),
-                'bounded_class_name' => $entityClassDetails->getShortName(),
+                'entity_class_name' => $entityClassDetails->getShortName(),
                 'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => $routeName,
                 'class_name' => Str::getShortClassName($testClassDetails->getFullName()),

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -283,8 +283,6 @@ final class MakeCrud extends AbstractMaker
                     'form_field_prefix' => strtolower(Str::asSnakeCase($entityTwigVarSingular)),
                 ]
             );
-        } else {
-            $io->note('Skipping test generation because the test dependencies (symfony/test-pack) is not installed.');
         }
 
         $generator->writeChanges();

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -255,13 +255,15 @@ final class MakeCrud extends AbstractMaker
                 $repositoryClassName,
             ]);
 
-            if (EntityManagerInterface::class === $repositoryClassName) {
+            $usesEntityManager = EntityManagerInterface::class === $repositoryClassName;
+
+            if ($usesEntityManager) {
                 $useStatements->addUseStatement(EntityRepository::class);
             }
 
             $generator->generateFile(
                 'tests/Controller/'.$testClassDetails->getShortName().'.php',
-                EntityManagerInterface::class === $repositoryClassName ? 'crud/test/Test.EntityManager.tpl.php' : 'crud/test/Test.tpl.php',
+                $usesEntityManager ? 'crud/test/Test.EntityManager.tpl.php' : 'crud/test/Test.tpl.php',
                 [
                     'use_statements' => $useStatements,
                     'entity_full_class_name' => $entityClassDetails->getFullName(),
@@ -272,7 +274,7 @@ final class MakeCrud extends AbstractMaker
                     'class_name' => Str::getShortClassName($testClassDetails->getFullName()),
                     'namespace' => Str::getNamespace($testClassDetails->getFullName()),
                     'form_fields' => $entityDoctrineDetails->getFormFields(),
-                    'repository_class_name' => $repositoryVars['repository_class_name'],
+                    'repository_class_name' => $usesEntityManager ? EntityManagerInterface::class : $repositoryVars['repository_class_name'],
                     'form_field_prefix' => strtolower(Str::asSnakeCase($entityTwigVarSingular)),
                 ]
             );

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -26,10 +26,12 @@ use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -181,6 +183,25 @@ final class MakeCrud extends AbstractMaker
             )
         );
 
+        $testClassDetails = $generator->createClassNameDetails(
+            $entityClassDetails->getRelativeNameWithoutSuffix(),
+            'Test\\Controller\\',
+            'ControllerTest'
+        );
+
+        $generator->generateFile(
+            'tests/Controller/'.$testClassDetails->getShortName().'.php',
+            'crud/test/Test.tpl.php',
+            [
+                'bounded_full_class_name' => $entityClassDetails->getFullName(),
+                'bounded_class_name' => $entityClassDetails->getShortName(),
+                'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
+                'route_name' => $routeName,
+                'class_name' => Str::getShortClassName($testClassDetails->getFullName()),
+                'namespace' => Str::getNamespace($testClassDetails->getFullName()),
+            ]
+        );
+
         $this->formTypeRenderer->render(
             $formClassDetails,
             $entityDoctrineDetails->getFormFields(),
@@ -274,6 +295,16 @@ final class MakeCrud extends AbstractMaker
         $dependencies->addClassDependency(
             ParamConverter::class,
             'annotations'
+        );
+
+        $dependencies->addClassDependency(
+            CssSelectorConverter::class,
+            'css-selector'
+        );
+
+        $dependencies->addClassDependency(
+            Client::class,
+            'browser-kit'
         );
     }
 }

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -54,7 +54,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 
         self::assertResponseRedirects('/sweet/food/');
 
-        self::assertSame(1, $this->manager->getRepository()->count([]));
+        self::assertSame(1, $this->getRepository()->count([]));
     }
 
     public function testShow(): void

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -7,8 +7,11 @@ namespace <?= $namespace ?>;
 
 class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 {
+<?= $use_typed_properties ? null : "    /** @var KernelBrowser */\n" ?>
     private <?= $use_typed_properties ? 'KernelBrowser ' : null ?>$client;
+<?= $use_typed_properties ? null : "    /** @var EntityManagerInterface */\n" ?>
     private <?= $use_typed_properties ? 'EntityManagerInterface ' : null ?>$manager;
+<?= $use_typed_properties ? null : "    /** @var EntityRepository */\n" ?>
     private <?= $use_typed_properties ? 'EntityRepository ' : null ?>$repository;
     private <?= $use_typed_properties ? 'string ' : null ?>$path = '<?= $route_path; ?>/';
 

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -77,7 +77,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $this->markTestIncomplete();
         $fixture = new <?= $entity_class_name; ?>();
 <?php foreach ($form_fields as $form_field => $typeOptions): ?>
-        $fixture->set<?= ucfirst($form_field); ?>('My Title');
+        $fixture->set<?= ucfirst($form_field); ?>('Value');
 <?php endforeach; ?>
 
         $this->manager->persist($fixture);
@@ -105,13 +105,13 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $this->markTestIncomplete();
         $fixture = new <?= $entity_class_name; ?>();
 <?php foreach ($form_fields as $form_field => $typeOptions): ?>
-        $fixture->set<?= ucfirst($form_field); ?>('My Title');
+        $fixture->set<?= ucfirst($form_field); ?>('Value');
 <?php endforeach; ?>
 
         $$this->manager->remove($fixture);
         $this->manager->flush();
 
-        $this->client->request('GET', '/sweet/food/'.$fixture->getId());
+        $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('<?= $route_path; ?>/');

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -7,10 +7,10 @@ namespace <?= $namespace ?>;
 
 class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 {
-    private KernelBrowser $client;
-    private EntityManagerInterface $manager;
-    private EntityRepository $repository;
-    private string $path = '<?= $route_path; ?>/';
+    private <?= $use_typed_properties ? 'KernelBrowser ' : null ?>$client;
+    private <?= $use_typed_properties ? 'EntityManagerInterface ' : null ?>$manager;
+    private <?= $use_typed_properties ? 'EntityRepository ' : null ?>$repository;
+    private <?= $use_typed_properties ? 'string ' : null ?>$path = '<?= $route_path; ?>/';
 
     protected function setUp(): void
     {

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -12,68 +12,119 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $crawler = $client->request('GET', '<?= $route_path ?>/');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertContains('<?= $bounded_class_name ?> index', $crawler->filter('h1')->text());
+        $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+        $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+
+        $newLink = $crawler->filter('a:contains("Create new")')->eq(0)->link();
+
+        return $newLink;
     }
 
-    public function testNew()
+    /**
+     * @depends testIndex
+     */
+    public function testNew($newLink)
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '<?= $route_path ?>/new');
+        $crawler = $client->click($newLink);
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertContains('Create new <?= $bounded_class_name ?>', $crawler->filter('h1')->text());
+        $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+        $this->assertContains('Create new <?= $entity_class_name ?>', $crawler->filter('h1')->text());
 
         $form = $crawler->selectButton('Save')->form();
 
-        // @TODO add your fields
-        //$form['formname[fieldname]']->setValue('Lorem ipsum');
+        // @TODO Set valid values for your fields
+<?php foreach ($form_fields as $form_field): ?>
+		// $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum');
+<?php endforeach; ?>
+        // $client->submit($form);
 
-        $crawler = $client->submit($form);
-        $response = $client->getResponse();
+        // $this->assertTrue($client->getResponse()->isRedirect());
 
-        // @TODO Find the Id
-        // return $id;
+        // $crawler = $client->followRedirect();
+        // $this->assertTrue($client->getResponse()->isSuccessful());
+        // $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+        // $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+        // $this->assertContains('<td>Lorem ipsum</td>', $client->getResponse()->getContent());
     }
 
-    // @TODO implement show test
-    ///**
-    // * @depends testNew
-    // */
-    //public function testShow($testableId)
-    //{
-    //    $client = static::createClient();
-    //    $crawler = $client->request('GET', '<?= $route_path ?>/'.$testableId);
-    //
-    //    $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //    $this->assertContains('<?= $bounded_class_name ?>', $crawler->filter('h1')->text());
-    //    $this->assertContains('Lorem ipsum', $crawler->filter('body')->text());
-    //}
-
     // @TODO implement edit test
-    ///**
-    // * @depends testNew
-    // */
-    //public function testEdit($testableId)
-    //{
-    //	  $client = static::createClient();
-    //    $crawler = $client->request('GET', '<?= $route_path ?>/'.$testableId.'/edit');
+    // /**
+    //  * @depends testNew
+    //  */
+    // public function testEdit()
+    // {
+    //      $client = static::createClient();
+    //      $crawler = $client->request('GET', '<?= $route_path ?>/');
     //
-    //    $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //    $this->assertContains('Edit <?= $bounded_class_name ?>', $crawler->filter('h1')->text());
-    //}
+    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //      $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+    //
+    //      $editLink = $crawler->filter('a:contains("edit")')->eq(0)->link();
+    //
+    //      $crawler = $client->click($editLink);
+    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //      $this->assertContains('Edit <?= $entity_class_name ?>', $crawler->filter('h1')->text());
+    //      $this->assertGreaterThan(0, $crawler->filter('input[type=text]')->count());
+    //
+    //      $editForm = $crawler->selectButton('Update')->form();
+	// 		@TODO Set valid values for your fields
+<?php foreach ($form_fields as $form_field): ?>
+	// 		$form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum edited');
+<?php endforeach; ?>
+    // 		$client->submit($form);
+    //      $this->assertTrue($client->getResponse()->isRedirect());
+    //
+    //      $crawler = $client->followRedirect();
+    //      $this->assertTrue($client->getResponse()->isSuccessful());
+    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //      $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+    //      $this->assertContains('Lorem ipsum edited', $client->getResponse()->getContent());
+    //
+    //      $showLink = $crawler->filter('a:contains("show")')->eq(0)->link();
+    //      return $showLink;
+    // }
+
+    // @TODO implement show test
+    // /**
+    //  * @depends testEdit
+    //  */
+    // public function testShow($showLink)
+    // {
+    //      $client = static::createClient();
+    //      $crawler = $client->click($showLink);
+    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //      $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
+    //      $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
+    //
+    //      return $showLink;
+    // }
 
     // @TODO implement delete test
-    ///**
-    // * @depends testNew
-    // */
-    //public function testDelete($testableId)
-    //{
-    //    // obtain csrf token with a call to show first.
+    // /**
+    //  * @depends testShow
+    //  */
+    // public function testDelete($showLink)
+    // {
+    //      $client = static::createClient();
+    //      $crawler = $client->click($showLink);
+    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //      $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
+    //      $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
     //
-    //	  $client = static::createClient();
-    //    $crawler = $client->request('POST', '<?= $route_path ?>/'.$testableId.'/delete');
+    //      $deleteForm = $crawler->selectButton('Delete')->form();
+    //      $client->submit($deleteForm);
+    //      $this->assertTrue($client->getResponse()->isRedirect());
     //
-    //    $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //    $this->assertContains('Create new <?= $bounded_class_name ?>', $crawler->filter('h1')->text());
-    //}
+    //      $client->followRedirect();
+    //      $this->assertTrue($client->getResponse()->isSuccessful());
+    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //      $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+    //      $this->assertContains('no records found', $client->getResponse()->getContent());
+    // }
 }

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -1,32 +1,50 @@
 <?= "<?php\n" ?>
+<?php use Symfony\Bundle\MakerBundle\Str; ?>
 
 namespace <?= $namespace ?>;
 
+use <?= $entity_full_class_name ?>;
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 {
+    private static ?KernelBrowser $client = null;
+
+    private ?EntityManager $entityManager;
+
+    protected function setUp(): void
+    {
+        if (null === self::$client) {
+            self::$client = static::createClient();
+        }
+
+        $kernel = self::bootKernel();
+
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+    }
+
     public function testIndex()
     {
-        $client = static::createClient();
+        $client = self::$client;
         $crawler = $client->request('GET', '<?= $route_path ?>/');
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
         $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
-
-        $newLink = $crawler->filter('a:contains("Create new")')->eq(0)->link();
-
-        return $newLink;
     }
 
     /**
      * @TODO implement new test
-     * @depends testIndex
      */
-    public function testNew($newLink)
+    public function testNew()
     {
-        $client = static::createClient();
+        $client = self::$client;
+        $crawler = $client->request('GET', '<?= $route_path ?>/');
+        $newLink = $crawler->filter('a:contains("Create new")')->eq(0)->link();
         $crawler = $client->click($newLink);
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
@@ -35,9 +53,9 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 
         $form = $crawler->selectButton('Save')->form();
 
-        // @TODO Set valid values for your fields
-<?php foreach ($form_fields as $form_field): ?>
-        // $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum');
+        // // @TODO Set valid values for your fields
+<?php foreach ($form_fields as $form_field => $typeOptions): ?>
+        // $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('New ipsum');
 <?php endforeach; ?>
         // $client->submit($form);
 
@@ -47,34 +65,41 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         // $this->assertTrue($client->getResponse()->isSuccessful());
         // $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
         // $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
-        // $this->assertContains('<td>Lorem ipsum</td>', $client->getResponse()->getContent());
+        // $this->assertContains('New ipsum', $client->getResponse()->getContent());
     }
 
     // /**
     //  * @TODO implement edit test
-    //  * @depends testNew
     //  */
     // public function testEdit()
     // {
-    //     $client = static::createClient();
+    //     $<?= $entity_var_singular ?> = new <?= $entity_class_name ?>;
+<?php foreach ($entity_fields as $propertyName => $mapping): ?>
+    //     $<?= lcfirst($entity_var_singular) ?>->set<?= Str::asCamelCase($propertyName) ?>('Edit ipsum');
+<?php endforeach; ?>
+    //     $this->entityManager->persist($<?= $entity_var_singular ?>);
+    //     $this->entityManager->flush();
+    //
+    //     $client = self::$client;
     //     $crawler = $client->request('GET', '<?= $route_path ?>/');
-    //
-    //     $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //     $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
-    //
-    //     $editLink = $crawler->filter('a:contains("edit")')->eq(0)->link();
+<?php if(!empty($entity_fields)):?>
+    //     $editLink = $crawler->filter('tr:contains('.$<?= lcfirst($entity_var_singular) ?>->get<?= Str::asCamelCase(array_keys($entity_fields)[0]) ?>().') a:contains("edit")')->eq(0)->link();
+<?php else: ?>
+    //     $editLink = $crawler->filter('tr:contains('Edit ipsum') a:contains("edit")')->eq(0)->link();
+<?php endif; ?>
     //
     //     $crawler = $client->click($editLink);
     //     $this->assertSame(200, $client->getResponse()->getStatusCode());
     //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
     //     $this->assertContains('Edit <?= $entity_class_name ?>', $crawler->filter('h1')->text());
-    //     $this->assertGreaterThan(0, $crawler->filter('input[type=text]')->count());
+<?php if(!empty($entity_fields)):?>
+    //     $this->assertGreaterThan(0, $crawler->filter('input')->count());
+<?php endif; ?>
     //
     //     $form = $crawler->selectButton('Update')->form();
     //     // @TODO Set valid values for your fields
-<?php foreach ($form_fields as $form_field): ?>
-    //     $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum edited');
+<?php foreach ($form_fields as $form_field => $typeOptions): ?>
+    //     $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Edited ipsum');
 <?php endforeach; ?>
     //     $client->submit($form);
     //     $this->assertTrue($client->getResponse()->isRedirect());
@@ -82,44 +107,68 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
     //     $crawler = $client->followRedirect();
     //     $this->assertTrue($client->getResponse()->isSuccessful());
     //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //     $this->assertContains('Edited ipsum', $client->getResponse()->getContent());
     // }
 
     // /**
     //  * @TODO implement show test
-    //  * @depends testEdit
     //  */
     // public function testShow()
     // {
-    //     $client = static::createClient();
-    //     $crawler = $client->request('GET', '/task/');
-
-    //     $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //     $this->assertContains('Task index', $crawler->filter('h1')->text());
-
-    //     $showLink = $crawler->filter('a:contains("show")')->eq(0)->link();
-
+    //     $<?= $entity_var_singular ?> = new <?= $entity_class_name ?>;
+<?php foreach ($entity_fields as $propertyName => $mapping): ?>
+    //     $<?= lcfirst($entity_var_singular) ?>->set<?= Str::asCamelCase($propertyName) ?>('Lorem ipsum');
+<?php endforeach; ?>
+    //     $this->entityManager->persist($<?= $entity_var_singular ?>);
+    //     $this->entityManager->flush();
+    //
+    //     $client = self::$client;
+    //     $crawler = $client->request('GET', '<?= $route_path ?>/');
+<?php if(!empty($entity_fields)):?>
+    //     $showLink = $crawler->filter('tr:contains('.$<?= lcfirst($entity_var_singular) ?>->get<?= Str::asCamelCase(array_keys($entity_fields)[0]) ?>().') a:contains("show")')->eq(0)->link();
+<?php else: ?>
+    //     $showLink = $crawler->filter('tr:contains('Edit ipsum') a:contains("show")')->eq(0)->link();
+<?php endif; ?>
     //     $crawler = $client->click($showLink);
     //     $this->assertSame(200, $client->getResponse()->getStatusCode());
     //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
     //     $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
-    //     $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
-    //
-    //     return $showLink;
+<?php if(!empty($entity_fields)):?>
+    //     $this->assertContains($<?= lcfirst($entity_var_singular) ?>->get<?= Str::asCamelCase(array_keys($entity_fields)[0]) ?>(), $client->getResponse()->getContent());
+<?php else: ?>
+    //     $this->assertContains('Lorem ipsum', $client->getResponse()->getContent());
+<?php endif; ?>
     // }
 
     // /**
     //  * @TODO implement delete test
-    //  * @depends testShow
     //  */
-    // public function testDelete($showLink)
+    // public function testDelete()
     // {
-    //     $client = static::createClient();
+    //     $<?= $entity_var_singular ?> = new <?= $entity_class_name ?>;
+<?php foreach ($entity_fields as $propertyName => $mapping): ?>
+    //     $<?= lcfirst($entity_var_singular) ?>->set<?= Str::asCamelCase($propertyName) ?>('Delete ipsum');
+<?php endforeach; ?>
+    //     $this->entityManager->persist($<?= $entity_var_singular ?>);
+    //     $this->entityManager->flush();
+    //
+    //     $client = self::$client;
+    //     $crawler = $client->request('GET', '<?= $route_path ?>/');
+<?php if(!empty($entity_fields)):?>
+    //     $showLink = $crawler->filter('tr:contains('.$<?= lcfirst($entity_var_singular) ?>->get<?= Str::asCamelCase(array_keys($entity_fields)[0]) ?>().') a:contains("show")')->eq(0)->link();
+<?php else: ?>
+    //     $showLink = $crawler->filter('tr:contains('Delete ipsum') a:contains("show")')->eq(0)->link();
+<?php endif; ?>
+    //
     //     $crawler = $client->click($showLink);
     //     $this->assertSame(200, $client->getResponse()->getStatusCode());
     //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
     //     $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
-    //     $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
+<?php if(!empty($entity_fields)):?>
+    //     $this->assertContains($<?= lcfirst($entity_var_singular) ?>->get<?= Str::asCamelCase(array_keys($entity_fields)[0]) ?>(), $crawler->filter('body')->text());
+<?php else: ?>
+    //     $this->assertContains('Delete ipsum', $crawler->filter('body')->text());
+<?php endif; ?>
     //
     //     $form = $crawler->selectButton('Delete')->form();
     //     $client->submit($form);
@@ -129,6 +178,18 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
     //     $this->assertTrue($client->getResponse()->isSuccessful());
     //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
     //     $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
-    //     $this->assertContains('no records found', $client->getResponse()->getContent());
+<?php if(!empty($entity_fields)):?>
+    //     $this->assertNotContains($<?= lcfirst($entity_var_singular) ?>->get<?= Str::asCamelCase(array_keys($entity_fields)[0]) ?>(), $client->getResponse()->getContent());
+<?php else: ?>
+    //     $this->assertNotContains('Delete ipsum', $client->getResponse()->getContent());
+<?php endif; ?>
     // }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->entityManager->close();
+        $this->entityManager = null;
+    }
 }

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -26,7 +26,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $form = $crawler->selectButton('Save')->form();
 
         // @TODO add your fields
-        $form['formname[fieldname]']->setValue('Lorem ipsum');
+        //$form['formname[fieldname]']->setValue('Lorem ipsum');
 
         $crawler = $client->submit($form);
         $response = $client->getResponse();

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -21,6 +21,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
     }
 
     /**
+     * @TODO implement new test
      * @depends testIndex
      */
     public function testNew($newLink)
@@ -36,7 +37,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 
         // @TODO Set valid values for your fields
 <?php foreach ($form_fields as $form_field): ?>
-		// $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum');
+        // $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum');
 <?php endforeach; ?>
         // $client->submit($form);
 
@@ -49,82 +50,85 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         // $this->assertContains('<td>Lorem ipsum</td>', $client->getResponse()->getContent());
     }
 
-    // @TODO implement edit test
     // /**
+    //  * @TODO implement edit test
     //  * @depends testNew
     //  */
     // public function testEdit()
     // {
-    //      $client = static::createClient();
-    //      $crawler = $client->request('GET', '<?= $route_path ?>/');
+    //     $client = static::createClient();
+    //     $crawler = $client->request('GET', '<?= $route_path ?>/');
     //
-    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //      $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+    //     $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //     $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
     //
-    //      $editLink = $crawler->filter('a:contains("edit")')->eq(0)->link();
+    //     $editLink = $crawler->filter('a:contains("edit")')->eq(0)->link();
     //
-    //      $crawler = $client->click($editLink);
-    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //      $this->assertContains('Edit <?= $entity_class_name ?>', $crawler->filter('h1')->text());
-    //      $this->assertGreaterThan(0, $crawler->filter('input[type=text]')->count());
+    //     $crawler = $client->click($editLink);
+    //     $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //     $this->assertContains('Edit <?= $entity_class_name ?>', $crawler->filter('h1')->text());
+    //     $this->assertGreaterThan(0, $crawler->filter('input[type=text]')->count());
     //
-    //      $editForm = $crawler->selectButton('Update')->form();
-	// 		@TODO Set valid values for your fields
+    //     $form = $crawler->selectButton('Update')->form();
+    //     // @TODO Set valid values for your fields
 <?php foreach ($form_fields as $form_field): ?>
-	// 		$form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum edited');
+    //     $form['<?= $route_name ?>[<?= $form_field ?>]']->setValue('Lorem ipsum edited');
 <?php endforeach; ?>
-    // 		$client->submit($form);
-    //      $this->assertTrue($client->getResponse()->isRedirect());
+    //     $client->submit($form);
+    //     $this->assertTrue($client->getResponse()->isRedirect());
     //
-    //      $crawler = $client->followRedirect();
-    //      $this->assertTrue($client->getResponse()->isSuccessful());
-    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //      $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
-    //      $this->assertContains('Lorem ipsum edited', $client->getResponse()->getContent());
-    //
-    //      $showLink = $crawler->filter('a:contains("show")')->eq(0)->link();
-    //      return $showLink;
+    //     $crawler = $client->followRedirect();
+    //     $this->assertTrue($client->getResponse()->isSuccessful());
+    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
     // }
 
-    // @TODO implement show test
     // /**
+    //  * @TODO implement show test
     //  * @depends testEdit
     //  */
-    // public function testShow($showLink)
+    // public function testShow()
     // {
-    //      $client = static::createClient();
-    //      $crawler = $client->click($showLink);
-    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //      $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
-    //      $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
+    //     $client = static::createClient();
+    //     $crawler = $client->request('GET', '/task/');
+
+    //     $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //     $this->assertContains('Task index', $crawler->filter('h1')->text());
+
+    //     $showLink = $crawler->filter('a:contains("show")')->eq(0)->link();
+
+    //     $crawler = $client->click($showLink);
+    //     $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //     $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
+    //     $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
     //
-    //      return $showLink;
+    //     return $showLink;
     // }
 
-    // @TODO implement delete test
     // /**
+    //  * @TODO implement delete test
     //  * @depends testShow
     //  */
     // public function testDelete($showLink)
     // {
-    //      $client = static::createClient();
-    //      $crawler = $client->click($showLink);
-    //      $this->assertSame(200, $client->getResponse()->getStatusCode());
-    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //      $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
-    //      $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
+    //     $client = static::createClient();
+    //     $crawler = $client->click($showLink);
+    //     $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //     $this->assertContains('<?= $entity_class_name ?>', $crawler->filter('h1')->text());
+    //     $this->assertContains('Lorem ipsum edited', $crawler->filter('body')->text());
     //
-    //      $deleteForm = $crawler->selectButton('Delete')->form();
-    //      $client->submit($deleteForm);
-    //      $this->assertTrue($client->getResponse()->isRedirect());
+    //     $form = $crawler->selectButton('Delete')->form();
+    //     $client->submit($form);
+    //     $this->assertTrue($client->getResponse()->isRedirect());
     //
-    //      $client->followRedirect();
-    //      $this->assertTrue($client->getResponse()->isSuccessful());
-    //      $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-    //      $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
-    //      $this->assertContains('no records found', $client->getResponse()->getContent());
+    //     $crawler = $client->followRedirect();
+    //     $this->assertTrue($client->getResponse()->isSuccessful());
+    //     $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
+    //     $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+    //     $this->assertContains('no records found', $client->getResponse()->getContent());
     // }
 }

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -1,0 +1,79 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '<?= $route_path ?>/');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertContains('<?= $bounded_class_name ?> index', $crawler->filter('h1')->text());
+    }
+
+    public function testNew()
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '<?= $route_path ?>/new');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertContains('Create new <?= $bounded_class_name ?>', $crawler->filter('h1')->text());
+
+        $form = $crawler->selectButton('Save')->form();
+
+        // @TODO add your fields
+        $form['formname[fieldname]']->setValue('Lorem ipsum');
+
+        $crawler = $client->submit($form);
+        $response = $client->getResponse();
+
+        // @TODO Find the Id
+        // return $id;
+    }
+
+    // @TODO implement show test
+    ///**
+    // * @depends testNew
+    // */
+    //public function testShow($testableId)
+    //{
+    //    $client = static::createClient();
+    //    $crawler = $client->request('GET', '<?= $route_path ?>/'.$testableId);
+    //
+    //    $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //    $this->assertContains('<?= $bounded_class_name ?>', $crawler->filter('h1')->text());
+    //    $this->assertContains('Lorem ipsum', $crawler->filter('body')->text());
+    //}
+
+    // @TODO implement edit test
+    ///**
+    // * @depends testNew
+    // */
+    //public function testEdit($testableId)
+    //{
+    //	  $client = static::createClient();
+    //    $crawler = $client->request('GET', '<?= $route_path ?>/'.$testableId.'/edit');
+    //
+    //    $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //    $this->assertContains('Edit <?= $bounded_class_name ?>', $crawler->filter('h1')->text());
+    //}
+
+    // @TODO implement delete test
+    ///**
+    // * @depends testNew
+    // */
+    //public function testDelete($testableId)
+    //{
+    //    // obtain csrf token with a call to show first.
+    //
+    //	  $client = static::createClient();
+    //    $crawler = $client->request('POST', '<?= $route_path ?>/'.$testableId.'/delete');
+    //
+    //    $this->assertSame(200, $client->getResponse()->getStatusCode());
+    //    $this->assertContains('Create new <?= $bounded_class_name ?>', $crawler->filter('h1')->text());
+    //}
+}

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -105,7 +105,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 
         $this->repository->add($fixture, true);
 
-        $this->client->request('GET', '/sweet/food/'.$fixture->getId());
+        $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('<?= $route_path; ?>/');

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -5,36 +5,18 @@ namespace <?= $namespace ?>;
 
 use <?= $entity_full_class_name ?>;
 use Doctrine\ORM\EntityManager;
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 {
-    private static ?KernelBrowser $client = null;
-
-    private ?EntityManager $entityManager;
-
-    protected function setUp(): void
+    public function testIndex(): void
     {
-        if (null === self::$client) {
-            self::$client = static::createClient();
-        }
+        $client = static::createClient();
 
-        $kernel = self::bootKernel();
-
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')
-            ->getManager();
-    }
-
-    public function testIndex()
-    {
-        $client = self::$client;
         $crawler = $client->request('GET', '<?= $route_path ?>/');
 
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
-        $this->assertContains('<!DOCTYPE html>', $client->getResponse()->getContent());
-        $this->assertContains('<?= $entity_class_name ?> index', $crawler->filter('h1')->text());
+        self::assertResponseStatusCodeSame(200);
+        self::assertPageTitleContains('SweetFood index');
     }
 
     /**
@@ -42,6 +24,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
      */
     public function testNew()
     {
+        $this->markTestIncomplete();
         $client = self::$client;
         $crawler = $client->request('GET', '<?= $route_path ?>/');
         $newLink = $crawler->filter('a:contains("Create new")')->eq(0)->link();
@@ -184,12 +167,4 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
     //     $this->assertNotContains('Delete ipsum', $client->getResponse()->getContent());
 <?php endif; ?>
     // }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $this->entityManager->close();
-        $this->entityManager = null;
-    }
 }

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -7,9 +7,9 @@ namespace <?= $namespace ?>;
 
 class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 {
-    private KernelBrowser $client;
-    private <?= $repository_class_name; ?> $repository;
-    private string $path = '<?= $route_path; ?>/';
+    private <?= $use_typed_properties ? 'KernelBrowser ' : null ?>$client;
+    private <?= $use_typed_properties ? "$repository_class_name " : null ?>$repository;
+    private <?= $use_typed_properties ? 'string ' : null ?>$path = '<?= $route_path; ?>/';
 
     protected function setUp(): void
     {

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -7,7 +7,9 @@ namespace <?= $namespace ?>;
 
 class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 {
+<?= $use_typed_properties ? null : "    /** @var KernelBrowser */\n" ?>
     private <?= $use_typed_properties ? 'KernelBrowser ' : null ?>$client;
+<?= $use_typed_properties ? null : "    /** @var $repository_class_name */\n" ?>
     private <?= $use_typed_properties ? "$repository_class_name " : null ?>$repository;
     private <?= $use_typed_properties ? 'string ' : null ?>$path = '<?= $route_path; ?>/';
 

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -67,34 +67,23 @@ class MakeCrudTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_crud_with_custom_root_namespace' => [$this->createMakerTest()
-        yield 'crud_basic_tests' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeCrud::class),
-            [
-                // entity class name
-                'SweetFood',
-            ])
-            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeCrud')
-            ->addExtraDependencies('symfony/css-selector')
-            ->addExtraDependencies('symfony/browser-kit')
-            // need for crud web tests
-            ->configureDatabase()
-            ->assert(function (string $output, string $directory) {
+        yield 'crud_basic_tests' => [$this->createMakerTest()
+            ->addExtraDependencies('symfony/css-selector', 'symfony/browser-kit')
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([
+                    'SweetFood', // Entity Class Name
+                    '',          // Default Controller
+                ]);
+
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
                 $this->assertStringContainsString('created: src/Form/SweetFoodType.php', $output);
                 $this->assertStringContainsString('created: tests/Controller/SweetFoodControllerTest.php', $output);
-            })
-            // workaround for segfault in PHP 7.1 CI :/
-            ->setRequiredPhpVersion(70200),
+
+                $this->runCrudTest($runner, 'it_generates_basic_crud.php');
+            }),
         ];
 
-        yield 'crud_basic_in_custom_root_namespace' => [MakerTestDetails::createTest(
-            $this->getMakerInstance(MakeCrud::class),
-            [
-                // entity class name
-                'SweetFood',
-            ])
-            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeCrudInCustomRootNamespace')
+        yield 'it_generates_crud_with_custom_root_namespace' => [$this->createMakerTest()
             ->changeRootNamespace('Custom')
             ->run(function (MakerTestRunner $runner) {
                 $runner->writeFile(

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -68,6 +68,33 @@ class MakeCrudTest extends MakerTestCase
         ];
 
         yield 'it_generates_crud_with_custom_root_namespace' => [$this->createMakerTest()
+        yield 'crud_basic_tests' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeCrud::class),
+            [
+                // entity class name
+                'SweetFood',
+            ])
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeCrud')
+            ->addExtraDependencies('symfony/css-selector')
+            ->addExtraDependencies('symfony/browser-kit')
+            // need for crud web tests
+            ->configureDatabase()
+            ->assert(function (string $output, string $directory) {
+                $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
+                $this->assertStringContainsString('created: src/Form/SweetFoodType.php', $output);
+                $this->assertStringContainsString('created: tests/Controller/SweetFoodControllerTest.php', $output);
+            })
+            // workaround for segfault in PHP 7.1 CI :/
+            ->setRequiredPhpVersion(70200),
+        ];
+
+        yield 'crud_basic_in_custom_root_namespace' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeCrud::class),
+            [
+                // entity class name
+                'SweetFood',
+            ])
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeCrudInCustomRootNamespace')
             ->changeRootNamespace('Custom')
             ->run(function (MakerTestRunner $runner) {
                 $runner->writeFile(

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -71,7 +71,7 @@ class MakeCrudTest extends MakerTestCase
             ->addExtraDependencies('symfony/css-selector', 'symfony/browser-kit')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
-                    'make-crud/SweetFood.php',
+                    $this->getFixturePath('SweetFood.php', $runner),
                     'src/Entity/SweetFood.php'
                 );
 

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -67,9 +67,14 @@ class MakeCrudTest extends MakerTestCase
             }),
         ];
 
-        yield 'crud_basic_tests' => [$this->createMakerTest()
+        yield 'it_generates_crud_with_tests' => [$this->createMakerTest()
             ->addExtraDependencies('symfony/css-selector', 'symfony/browser-kit')
             ->run(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-crud/SweetFood.php',
+                    'src/Entity/SweetFood.php'
+                );
+
                 $output = $runner->runMaker([
                     'SweetFood', // Entity Class Name
                     '',          // Default Controller

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -35,9 +35,9 @@ class MakeCrudTest extends MakerTestCase
                 );
 
                 $output = $runner->runMaker([
-                    // entity class name
-                    'SweetFood',
-                    '', // default controller
+                    'SweetFood', // entity class name
+                    '',          // default controller,
+                    'n',         // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
@@ -55,9 +55,9 @@ class MakeCrudTest extends MakerTestCase
                 );
 
                 $output = $runner->runMaker([
-                    // entity class name
-                    'SweetFood',
-                    'SweetFoodAdminController', // default controller
+                    'SweetFood',                // entity class name
+                    'SweetFoodAdminController', // default controller,
+                    'y',                        // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodAdminController.php', $output);
@@ -130,9 +130,9 @@ class MakeCrudTest extends MakerTestCase
                 );
 
                 $output = $runner->runMaker([
-                    // entity class name
-                    'SweetFood',
-                    '', // default controller
+                    'SweetFood', // entity class name
+                    '',          // default controller,
+                    'n',         // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
@@ -154,9 +154,9 @@ class MakeCrudTest extends MakerTestCase
                 );
 
                 $output = $runner->runMaker([
-                    // entity class name
-                    'SweetFood',
-                    '', // default controller
+                    'SweetFood', // entity class name
+                    '',          // default controller,
+                    'n',         // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
@@ -181,9 +181,9 @@ class MakeCrudTest extends MakerTestCase
                 $runner->deleteFile('templates/base.html.twig');
 
                 $output = $runner->runMaker([
-                    // entity class name
-                    'SweetFood',
-                    '', // default controller
+                    'SweetFood', // entity class name
+                    '',          // default controller,
+                    'n',         // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -68,7 +68,7 @@ class MakeCrudTest extends MakerTestCase
         ];
 
         yield 'it_generates_crud_with_tests' => [$this->createMakerTest()
-            ->addExtraDependencies('symfony/css-selector', 'symfony/browser-kit')
+            ->addExtraDependencies('symfony/test-pack')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
                     $this->getFixturePath('SweetFood.php', $runner),
@@ -77,7 +77,35 @@ class MakeCrudTest extends MakerTestCase
 
                 $output = $runner->runMaker([
                     'SweetFood', // Entity Class Name
-                    '',          // Default Controller
+                    '',          // Default Controller,
+                    'y', // Generate Tests
+                ]);
+
+                $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
+                $this->assertStringContainsString('created: src/Form/SweetFoodType.php', $output);
+                $this->assertStringContainsString('created: tests/Controller/SweetFoodControllerTest.php', $output);
+
+                $this->runCrudTest($runner, 'it_generates_basic_crud.php');
+            }),
+        ];
+
+        yield 'it_generates_crud_custom_repository_with_test' => [$this->createMakerTest()
+            ->addExtraDependencies('symfony/test-pack')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    $this->getFixturePath('SweetFoodCustomRepository.php', $runner),
+                    'src/Entity/SweetFood.php'
+                );
+
+                $runner->copy(
+                    'make-crud/SweetFoodRepository.php',
+                    'src/Repository/SweetFoodRepository.php'
+                );
+
+                $output = $runner->runMaker([
+                    'SweetFood', // Entity Class Name
+                    '',          // Default Controller,
+                    'y', // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -78,7 +78,7 @@ class MakeCrudTest extends MakerTestCase
                 $output = $runner->runMaker([
                     'SweetFood', // Entity Class Name
                     '',          // Default Controller,
-                    'y', // Generate Tests
+                    'y',         // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
@@ -105,7 +105,7 @@ class MakeCrudTest extends MakerTestCase
                 $output = $runner->runMaker([
                     'SweetFood', // Entity Class Name
                     '',          // Default Controller,
-                    'y', // Generate Tests
+                    'y',         // Generate Tests
                 ]);
 
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);


### PR DESCRIPTION
Add tests for the controller methods.
Add necessary dependencies.
Closes #229

Edit by @jrushlow:
- Feature is experimental - We generate a minimum WebTestCase for generated CRUD. 
- Generating tests is on an opt-in basis _if_ the user has `test-pack` already installed. Otherwise we're not advertising this feature yet.
- Entity / Form Field guessing is not _fully_ implemented. "Setter" values other than `string` will not match the Entity's property types and must be manually changed.
- Tests (other than `testIndex()`) are all generated with `markTestIncomplete()` 
- Better integration w/ Panther, Fixtures, Foundry, etc... to come in future PR's