### PR TITLE
Fix fixtures test

### DIFF
--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -162,10 +162,10 @@ class FunctionalTest extends MakerTestCase
         yield 'fixtures' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeFixtures::class),
             [
-                'AppFixtures',
+                'AcmeFixtures',
             ])
             ->assert(function (string $output, string $directory) {
-                $this->assertContains('created: src/DataFixtures/AppFixtures.php', $output);
+                $this->assertContains('created: src/DataFixtures/AcmeFixtures.php', $output);
             })
         ];
 


### PR DESCRIPTION
The test tried to create an AppFixtures class.
However, this is included in the flex-recipe for "ormfixtures", since it's [latest release](https://github.com/symfony/recipes/commit/c447845d62ffa63eb940db89ed00a92b00350fe5)
Fix test by renaming the fixture to be generated to AcmeFixture.
