### PR TITLE
Id integers should default to unsigned.

### DIFF
--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -16,7 +16,7 @@ class <?= $class_name."\n" ?>
     /**
      * @ORM\Id()
      * @ORM\GeneratedValue()
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type="integer", options={"unsigned"=true})
      */
     private $id;
 


### PR DESCRIPTION
There should never be a reason to have an id a signed integer. Having your integers wrap around into the negatives is a very bad thing.