### PR TITLE
Fix deprecation for symfony/config 4.2+

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,8 +21,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('maker');
+        $treeBuilder = new TreeBuilder('maker');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('maker');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fix deprecation for symfony/config 4.2

Fixed the same way as in https://github.com/doctrine/DoctrineBundle/pull/853