### PR TITLE
Fix name of fixture in tests

### DIFF
--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -162,10 +162,10 @@ class FunctionalTest extends MakerTestCase
         yield 'fixtures' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeFixtures::class),
             [
-                'AppFixtures',
+                'FooFixtures',
             ])
             ->assert(function (string $output, string $directory) {
-                $this->assertContains('created: src/DataFixtures/AppFixtures.php', $output);
+                $this->assertContains('created: src/DataFixtures/FooFixtures.php', $output);
             })
         ];
 


### PR DESCRIPTION
Problem: Tests are failing due to the name of the fixture which is *AppFixture*. But a fixture with that name is created by [DoctrineFixtures recipe](https://github.com/symfony/recipes/commit/c447845d62ffa63eb940db89ed00a92b00350fe5).

As talked during #SymfonyConHackDay2018, the fix was to change the name of the fixture's that we want to create during the tests.