### PR TITLE
Remove Symfony Flex dependency from MakerBundle

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -1,4 +1,4 @@
-The MakerBundle
+The Symfony MakerBundle
 =======================
 
 Symfony Maker helps you create empty commands, controllers, form classes,

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -4,7 +4,9 @@ The Symfony MakerBundle
 Symfony Maker helps you create empty commands, controllers, form classes,
 tests and more so you can forget about writing boilerplate code. This
 bundle is an alternative to `SensioGeneratorBundle`_ for modern Symfony
-applications and requires using Symfony 3.4 or newer.
+applications and requires using Symfony 3.4 or newer. This bundle
+assumes you're using a standard Symfony 4 directory structure, but many
+commands can generate code into any application.
 
 Installation
 ------------

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -1,10 +1,10 @@
-The Symfony MakerBundle
+The MakerBundle
 =======================
 
 Symfony Maker helps you create empty commands, controllers, form classes,
 tests and more so you can forget about writing boilerplate code. This
 bundle is an alternative to `SensioGeneratorBundle`_ for modern Symfony
-applications and requires using Symfony 3.4 or newer and `Symfony Flex`_.
+applications and requires using Symfony 3.4 or newer.
 
 Installation
 ------------
@@ -83,6 +83,5 @@ adding your *own* maker command is so easy, that we recommend that. However, if 
 is some extension point that you'd like, please open an issue so we can discuss!
 
 .. _`SensioGeneratorBundle`: https://github.com/sensiolabs/SensioGeneratorBundle
-.. _`Symfony Flex`: https://symfony.com/doc/current/setup/flex.html
 .. _`AbstractMaker`: https://github.com/symfony/maker-bundle/blob/master/src/Maker/AbstractMaker.php
 .. _`core maker commands`: https://github.com/symfony/maker-bundle/tree/master/src/Maker


### PR DESCRIPTION
We have been confused because the documentations states that Symfony Flex is required in order to use the MakerBundle.

However, we are not using Symfony Flex in our application yet, but it was still possible to use the MakerBundle. So I would suggest to remove the part saying that Symfony Flex is a dependency.