### PR TITLE
Adding a max length validator

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -307,6 +307,8 @@ final class MakeRegistrationForm extends AbstractMaker
                     new Length([
                         'min' => 6,
                         'minMessage' => 'Your password should be at least {{ limit }} characters',
+                        // max length allowed by Symfony for security reasons
+                        'max' => 4096,
                     ]),
                 ],
 EOF


### PR DESCRIPTION
https://symfony.com/doc/current/doctrine/registration_form.html#registration-password-max