### PR TITLE
New command - make:message for Messenger

### DIFF
--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -24,6 +24,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @author Nicolas Philippe <nikophil@gmail.com>
  *
  * @internal
  */

--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @internal
+ */
+final class MakeMessage extends AbstractMaker
+{
+    public static function getCommandName(): string
+    {
+        return 'make:message';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConf)
+    {
+        $command
+            ->setDescription('Creates a new message and handler')
+            ->addArgument('name', InputArgument::OPTIONAL, 'The name of the message class (e.g. <fg=yellow>SendEmailMessage</>)')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeMessage.txt'))
+        ;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $messageClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'Message\\'
+        );
+
+        $handlerClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name').'Handler',
+            'MessageHandler\\',
+            'Handler'
+        );
+
+        $generator->generateClass(
+            $messageClassNameDetails->getFullName(),
+            'message/Message.tpl.php'
+        );
+
+        $generator->generateClass(
+            $handlerClassNameDetails->getFullName(),
+            'message/MessageHandler.tpl.php',
+            [
+                'message_full_class_name' => $messageClassNameDetails->getFullName(),
+                'message_class_name' => $messageClassNameDetails->getShortName(),
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next: Open your new message class and add the properties you need.',
+            '      Then, open thema new message handler and do whatever work you want!',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/messenger.html</>',
+        ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(
+            MessageBusInterface::class,
+            'messenger'
+        );
+    }
+}

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -61,6 +61,10 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_message" class="Symfony\Bundle\MakerBundle\Maker\MakeMessage">
+                <tag name="maker.command" />
+            </service>
+
             <service id="maker.maker.make_registration_form" class="Symfony\Bundle\MakerBundle\Maker\MakeRegistrationForm">
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.renderer.form_type_renderer" />

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -62,6 +62,7 @@
             </service>
 
             <service id="maker.maker.make_message" class="Symfony\Bundle\MakerBundle\Maker\MakeMessage">
+                <argument type="service" id="maker.file_manager" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/help/MakeMessage.txt
+++ b/src/Resources/help/MakeMessage.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new message class & handler.
+
+<info>php %command.full_name% EmailMessage</info>
+
+If the argument is missing, the command will ask for the message class interactively.

--- a/src/Resources/skeleton/message/Message.tpl.php
+++ b/src/Resources/skeleton/message/Message.tpl.php
@@ -1,0 +1,32 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace; ?>;
+
+class <?= $class_name."\n" ?>
+{
+    /*
+     * Add whatever properties & methods you need to hold the
+     * data for this message class.
+     *
+     * Note - if you're handling this message async, you may need
+     * a getter & setter method for each property so that it serializes
+     * and unserializes correctly.
+     */
+
+//     private $name;
+//
+//     public function __construct(string $name)
+//     {
+//         $this->name = $name;
+//     }
+//
+//    public function getName(): string
+//    {
+//        return $this->name;
+//    }
+//
+//    public function setName(string $name)
+//    {
+//        $this->name = $name;
+//    }
+}

--- a/src/Resources/skeleton/message/Message.tpl.php
+++ b/src/Resources/skeleton/message/Message.tpl.php
@@ -2,15 +2,11 @@
 
 namespace <?= $namespace; ?>;
 
-class <?= $class_name."\n" ?>
+final class <?= $class_name."\n" ?>
 {
     /*
      * Add whatever properties & methods you need to hold the
      * data for this message class.
-     *
-     * Note - if you're handling this message async, you may need
-     * a getter & setter method for each property so that it serializes
-     * and unserializes correctly.
      */
 
 //     private $name;
@@ -23,10 +19,5 @@ class <?= $class_name."\n" ?>
 //    public function getName(): string
 //    {
 //        return $this->name;
-//    }
-//
-//    public function setName(string $name)
-//    {
-//        $this->name = $name;
 //    }
 }

--- a/src/Resources/skeleton/message/MessageHandler.tpl.php
+++ b/src/Resources/skeleton/message/MessageHandler.tpl.php
@@ -1,0 +1,14 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace; ?>;
+
+use <?= $message_full_class_name ?>;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class <?= $class_name ?> implements MessageHandlerInterface
+{
+    public function __invoke(<?= $message_class_name ?> $message)
+    {
+        // do something with your message
+    }
+}

--- a/src/Resources/skeleton/message/MessageHandler.tpl.php
+++ b/src/Resources/skeleton/message/MessageHandler.tpl.php
@@ -5,7 +5,7 @@ namespace <?= $namespace; ?>;
 use <?= $message_full_class_name ?>;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-class <?= $class_name ?> implements MessageHandlerInterface
+final class <?= $class_name ?> implements MessageHandlerInterface
 {
     public function __invoke(<?= $message_class_name ?> $message)
     {

--- a/tests/Maker/MakeMessageTest.php
+++ b/tests/Maker/MakeMessageTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeMessage;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
+use Symfony\Component\Yaml\Yaml;
+
+class MakeMessageTest extends MakerTestCase
+{
+    public function getTestDetails()
+    {
+        yield 'message_basic' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeMessage::class),
+            [
+                'SendWelcomeEmail'
+            ])
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMessageBasic')
+            // because there is no version compatible with 7.0
+            ->setRequiredPhpVersion(70100)
+        ];
+
+        yield 'message_with_transport' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMessage::class),
+                [
+                    'SendWelcomeEmail',
+                    1
+                ]
+            )
+                ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMessageWithTransport')
+                // because there is no version compatible with 7.0
+                ->setRequiredPhpVersion(70100)
+                ->assert(
+                    function (string $output, string $directory) {
+                        $this->assertStringContainsString('Success', $output);
+
+                        $messengerConfig = Yaml::parse(file_get_contents(sprintf('%s/config/packages/messenger.yaml', $directory)));
+                        $this->assertArrayHasKey('routing', $messengerConfig['framework']['messenger']);
+                        $this->assertArrayHasKey('App\Message\SendWelcomeEmail', $messengerConfig['framework']['messenger']['routing']);
+                        $this->assertSame(
+                            'async',
+                            $messengerConfig['framework']['messenger']['routing']['App\Message\SendWelcomeEmail']
+                        );
+                    }
+                ),
+        ];
+
+        yield 'message_with_no_transport' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMessage::class),
+                [
+                    'SendWelcomeEmail',
+                    0
+                ]
+            )
+                ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMessageWithTransport')
+                // because there is no version compatible with 7.0
+                ->setRequiredPhpVersion(70100)
+                ->assert(
+                    function (string $output, string $directory) {
+                        $this->assertStringContainsString('Success', $output);
+
+                        $messengerConfig = Yaml::parse(file_get_contents(sprintf('%s/config/packages/messenger.yaml', $directory)));
+                        $this->assertArrayNotHasKey('routing', $messengerConfig['framework']['messenger']);
+                    }
+                ),
+        ];
+    }
+}

--- a/tests/fixtures/MakeMessageBasic/config/services_test.yaml
+++ b/tests/fixtures/MakeMessageBasic/config/services_test.yaml
@@ -1,0 +1,5 @@
+services:
+    _defaults:
+        public: true
+
+    test.message_bus: '@messenger.bus.default'

--- a/tests/fixtures/MakeMessageBasic/tests/GeneratedMessageHandlerTest.php
+++ b/tests/fixtures/MakeMessageBasic/tests/GeneratedMessageHandlerTest.php
@@ -10,7 +10,7 @@ class GeneratedMessageHandlerTest extends KernelTestCase
     public function testGeneratedMessage()
     {
         self::bootKernel();
-        $messageBus = self::$kernel->getContainer()->get('message_bus');
+        $messageBus = self::$kernel->getContainer()->get('test.message_bus');
 
         $messageBus->dispatch(new SendWelcomeEmail());
         $this->assertTrue(true, 'Smoke testing the handler did not explode');

--- a/tests/fixtures/MakeMessageBasic/tests/GeneratedMessageHandlerTest.php
+++ b/tests/fixtures/MakeMessageBasic/tests/GeneratedMessageHandlerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Tests;
+
+use App\Message\SendWelcomeEmail;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GeneratedMessageHandlerTest extends KernelTestCase
+{
+    public function testGeneratedMessage()
+    {
+        self::bootKernel();
+        $messageBus = self::$kernel->getContainer()->get('message_bus');
+
+        $messageBus->dispatch(new SendWelcomeEmail());
+        $this->assertTrue(true, 'Smoke testing the handler did not explode');
+    }
+}

--- a/tests/fixtures/MakeMessageWithTransport/config/packages/messenger.yaml
+++ b/tests/fixtures/MakeMessageWithTransport/config/packages/messenger.yaml
@@ -1,0 +1,5 @@
+framework:
+    messenger:
+        transports:
+            async: 'sync://'
+            async_high_priority: 'sync://'

--- a/tests/fixtures/MakeMessageWithTransport/config/services_test.yaml
+++ b/tests/fixtures/MakeMessageWithTransport/config/services_test.yaml
@@ -1,0 +1,5 @@
+services:
+    _defaults:
+        public: true
+
+    test.message_bus: '@messenger.bus.default'

--- a/tests/fixtures/MakeMessageWithTransport/tests/GeneratedMessageHandlerTest.php
+++ b/tests/fixtures/MakeMessageWithTransport/tests/GeneratedMessageHandlerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Tests;
+
+use App\Message\SendWelcomeEmail;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GeneratedMessageHandlerTest extends KernelTestCase
+{
+    public function testGeneratedMessage()
+    {
+        self::bootKernel();
+        $messageBus = self::$kernel->getContainer()->get('test.message_bus');
+
+        $messageBus->dispatch(new SendWelcomeEmail());
+        $this->assertTrue(true, 'Smoke testing the handler did not explode');
+    }
+}


### PR DESCRIPTION
An easy one - generated for Messenger - generates an empty message class and corresponding handler:

<img width="949" alt="screen shot 2018-12-20 at 2 23 54 pm" src="https://user-images.githubusercontent.com/121003/50306265-19a49280-0463-11e9-871a-7f215dc62ff7.png">

**Generated Code**

<details><summary>SendWelcomeEmailMessage</summary>
<p>

```php
<?php

namespace App\Message;

class SendWelcomeEmailMessage
{
    /*
     * Add whatever properties & methods you need to hold the
     * data for this message class.
     *
     * Note - if you're handling this message async, you may need
     * a getter & setter method for each property so that it serializes
     * and unserializes correctly.
     */

//     private $name;
//
//     public function __construct(string $name)
//     {
//         $this->name = $name;
//     }
//
//    public function getName(): string
//    {
//        return $this->name;
//    }
//
//    public function setName(string $name)
//    {
//        $this->name = $name;
//    }
}
```

</p>
</details>

<details><summary>SendWelcomeEmailMessageHandler</summary>
<p>

```php
<?php

namespace App\MessageHandler;

use App\Message\SendWelcomeEmailMessage;
use Symfony\Component\Messenger\Handler\MessageHandlerInterface;

class SendWelcomeEmailMessageHandler implements MessageHandlerInterface
{
    public function __invoke(SendWelcomeEmailMessage $message)
    {
        // do something with your message
    }
}

```

</p>
</details>

In the future... we could possibly ask which transport you want to use and update your YAML configuration (if needed) 🤔 