### PR TITLE
Exception when property not found in given user entity

### DIFF
--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -134,6 +134,10 @@ authenticators will be ignored, and can be blank.',
             $classProperties[] = $property->name;
         }
 
+        if (empty($classProperties)) {
+            throw new \LogicException(sprintf('No properties were found in "%s" entity', $userClass));
+        }
+
         return $io->choice(
             sprintf('Which field on your <fg=yellow>%s</> class will people enter when logging in?', $userClass),
             $classProperties,


### PR DESCRIPTION
Better message when try to generate authenticator through `make:auth` command.

Before:
![image](https://user-images.githubusercontent.com/34964382/51033977-6896a100-15a5-11e9-9bde-6e0d3d07af7f.png)

After:
![image](https://user-images.githubusercontent.com/34964382/51033998-7cda9e00-15a5-11e9-8d6e-1d7064b168a2.png)
