### PR TITLE
make:entity "Self" or "Parent"

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -42,8 +42,8 @@ final class Validator
             'static', 'switch', 'throw', 'trait', 'try', 'unset',
             'use', 'var', 'while', 'xor',
             'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
-            'iterable', 'object', '__FILE__', '__LINE__', '__DIR__', '__FUNCTION__', '__CLASS__',
-            '__METHOD__', '__NAMESPACE__', '__TRAIT__', 'self', 'parent',
+            'iterable', 'object', '__file__', '__line__', '__dir__', '__function__', '__class__',
+            '__method__', '__namespace__', '__trait__', 'self', 'parent',
         ];
 
         foreach ($pieces as $piece) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -43,7 +43,7 @@ final class Validator
             'use', 'var', 'while', 'xor',
             'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
             'iterable', 'object', '__FILE__', '__LINE__', '__DIR__', '__FUNCTION__', '__CLASS__',
-            '__METHOD__', '__NAMESPACE__', '__TRAIT__',
+            '__METHOD__', '__NAMESPACE__', '__TRAIT__', 'self', 'parent',
         ];
 
         foreach ($pieces as $piece) {


### PR DESCRIPTION
After using ``make:entity Self`` or ``make:entity Parent``, maker-bundle build 2 files :
```
 created: src/Entity/Self.php
 created: src/Repository/SelfRepository.php
```
But, after that :
```
Fatal error: Cannot use 'Self' as class name as it is reserved in /var/www/html/demo/src/Entity/Self.php on line 10
```
 ... and others "Call Stack" to finish with a "CRITICAL".

You must remove ``src/Entity/Self.php`` and ``src/Repository/SelfRepository.php`` to continue.