### PR TITLE
make:entity __method__ (or line, dir and file)

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -43,7 +43,7 @@ final class Validator
             'use', 'var', 'while', 'xor',
             'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
             'iterable', 'object', '__file__', '__line__', '__dir__', '__function__', '__class__',
-            '__method__', '__namespace__', '__trait__', 'self', 'parent', 'file', 'line', 'dir', 'method', 
+            '__method__', '__namespace__', '__trait__', 'self', 'parent', 'file', 'line', 'dir', 'method',
         ];
 
         foreach ($pieces as $piece) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -43,7 +43,7 @@ final class Validator
             'use', 'var', 'while', 'xor',
             'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
             'iterable', 'object', '__file__', '__line__', '__dir__', '__function__', '__class__',
-            '__method__', '__namespace__', '__trait__', 'self', 'parent',
+            '__method__', '__namespace__', '__trait__', 'self', 'parent', 'file', 'line', 'dir', 'method', 
         ];
 
         foreach ($pieces as $piece) {


### PR DESCRIPTION
After trying the latest PR #350 , I think is needed to add these controls.

However, ```'__file__', '__line__', '__dir__', '__function__', '__class__', '__file__', '__line__', '__dir__', '__function__', '__class__', '__method__', '__namespace__', '__trait__'``` can be removed from the array because in ``src/Generator.php`` the ``classname`` is replaced by :
```$className = rtrim($fullNamespacePrefix, '\\').'\\'.Str::asClassName($name, $suffix);```

For example, ``__METHOD__`` become ``method`` and ``method`` dos not exist in array and ``make:entity`` builds 2 files.
But, I don't know if ``$reservedKeywords`` is used elsewhere.