### PR TITLE
MakerBundle doc : use dev file name

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -51,7 +51,7 @@ the root namespace that is used to "guess" what classes you want to generate:
 
 .. code-block:: yaml
 
-    # config/packages/maker.yaml
+    # config/packages/dev/maker.yaml
     # create this file if you need to configure anything
     maker:
         # tell MakerBundle that all of your classes lives in an


### PR DESCRIPTION
By default, the maker bundle is only active in `dev` environment, so the configuration file should be in the `config/packages/dev/` directory, not directly in the `config/packages/`