### PR TITLE
Look for the target entity in the namespace first

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -468,16 +468,16 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
             $targetEntityClass = $io->askQuestion($question);
 
-            if (!class_exists($targetEntityClass)) {
-                if (!class_exists($this->getEntityNamespace().'\\'.$targetEntityClass)) {
+            if (!class_exists($designatedTargetClass = $this->getEntityNamespace().'\\'.$targetEntityClass)) {
+                if (!class_exists($designatedTargetClass = $targetEntityClass)) {
                     $io->error(sprintf('Unknown class "%s"', $targetEntityClass));
                     $targetEntityClass = null;
 
                     continue;
                 }
-
-                $targetEntityClass = $this->getEntityNamespace().'\\'.$targetEntityClass;
             }
+
+            $targetEntityClass = $designatedTargetClass;
         }
 
         // help the user select the type

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -906,6 +906,36 @@ class FunctionalTest extends MakerTestCase
            ->setRequiredPhpVersion(70100)
         ];
 
+        yield 'entity_exists_in_root' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeEntity::class),
+            [
+                // entity class name
+                'Directory',
+                // field name
+                'parentDirectory',
+                // add a relationship field
+                'relation',
+                // the target entity
+                'Directory',
+                // relation type
+                'ManyToOne',
+                // nullable
+                'y',
+                // do you want to generate an inverse relation? (default to yes)
+                '',
+                // field name on opposite side
+                'childDirectories',
+                // orphanRemoval (default to no)
+                '',
+                // finish adding fields
+                '',
+            ])
+           ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeEntityExistsInRoot')
+           ->configureDatabase()
+           ->updateSchemaAfterCommand()
+           ->setRequiredPhpVersion(70100)
+        ];
+
         yield 'entity_one_to_many_simple' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeEntity::class),
             [

--- a/tests/fixtures/MakeEntityExistsInRoot/src/Entity/Directory.php
+++ b/tests/fixtures/MakeEntityExistsInRoot/src/Entity/Directory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Directory
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $createdAt;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeInterface $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/tests/fixtures/MakeEntityExistsInRoot/tests/GeneratedEntityTest.php
+++ b/tests/fixtures/MakeEntityExistsInRoot/tests/GeneratedEntityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Tests;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Doctrine\ORM\EntityManager;
+use App\Entity\Directory;
+
+class GeneratedEntityTest extends KernelTestCase
+{
+    public function testGeneratedEntity()
+    {
+        self::bootKernel();
+        /** @var EntityManager $em */
+        $em = self::$kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $em->createQuery('DELETE FROM App\\Entity\\Directory u')->execute();
+
+        $directory = new Directory();
+        // check that the constructor was instantiated properly
+        $this->assertInstanceOf(ArrayCollection::class, $directory->getChildUsers());
+        // set existing field
+        $directory->setName('root');
+        $em->persist($directory);
+
+        $subDir = new Directory();
+        $subDir->setName('settings');
+        $subDir->setParentDirectory($directory);
+        $em->persist($subDir);
+
+        // set via the inverse side
+        $subDir2 = new Directory();
+        $subDir2->setName('fixtures');
+        $directory->addChildUser($subDir2);
+        $em->persist($subDir2);
+
+        $em->flush();
+        $em->refresh($directory);
+
+        $actualDirectory = $em->getRepository(Directory::class)
+            ->findAll();
+
+        $this->assertCount(3, $actualDirectory);
+        $this->assertCount(2, $actualDirectory[0]->getChildDirectories());
+    }
+}

--- a/tests/fixtures/MakeEntityExistsInRoot/tests/GeneratedEntityTest.php
+++ b/tests/fixtures/MakeEntityExistsInRoot/tests/GeneratedEntityTest.php
@@ -21,7 +21,7 @@ class GeneratedEntityTest extends KernelTestCase
 
         $directory = new Directory();
         // check that the constructor was instantiated properly
-        $this->assertInstanceOf(ArrayCollection::class, $directory->getChildUsers());
+        $this->assertInstanceOf(ArrayCollection::class, $directory->getChildDirectories());
         // set existing field
         $directory->setName('root');
         $em->persist($directory);
@@ -34,7 +34,7 @@ class GeneratedEntityTest extends KernelTestCase
         // set via the inverse side
         $subDir2 = new Directory();
         $subDir2->setName('fixtures');
-        $directory->addChildUser($subDir2);
+        $directory->addChildDirectory($subDir2);
         $em->persist($subDir2);
 
         $em->flush();


### PR DESCRIPTION
As in #322 the entity maker cannot make a relation, where the target entity is also presented in the root namespace, beacuse `Symfony\Bundle\MakerBundle\Maker\MakeEntity::askRelationDetails()` looks for it in the root namespace at first.

I don't think this is the good behaviour.

This PR makes it look for first in the namepace defined in the config, and after that in other places.