### PR TITLE
[make:validator] Prevent an error in PHPStorm

### DIFF
--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -55,7 +55,7 @@ final class MakeValidator extends AbstractMaker
             $validatorClassNameDetails->getFullName(),
             'validator/Validator.tpl.php',
             [
-                'constraint_class_name' => $constraintFullClassName,
+                'constraint_class_name' => '\''.$constraintFullClassName,
             ]
         );
 


### PR DESCRIPTION
The currently generated DocBlock prevent auto-completion to work properly, and triggers a warning. This patch fixes it.