### PR TITLE
Configuration for custom namespaces

### DIFF
--- a/config/makers.xml
+++ b/config/makers.xml
@@ -27,6 +27,7 @@
 
             <service id="maker.maker.make_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeController">
                 <tag name="maker.command" />
+                <argument type="service" id="maker.namespaces_helper" />
             </service>
 
             <service id="maker.maker.make_crud" class="Symfony\Bundle\MakerBundle\Maker\MakeCrud">
@@ -90,6 +91,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.doctrine_helper" />
                 <argument type="service" id="maker.entity_class_generator" />
+                <argument type="service" id="maker.namespaces_helper" />
                 <argument type="service" id="router" on-invalid="ignore" />
                 <tag name="maker.command" />
             </service>
@@ -118,6 +120,7 @@
             </service>
 
             <service id="maker.maker.make_test" class="Symfony\Bundle\MakerBundle\Maker\MakeTest">
+                <argument type="service" id="maker.namespaces_helper" />
                 <tag name="maker.command" />
             </service>
 

--- a/config/makers.xml
+++ b/config/makers.xml
@@ -83,6 +83,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.renderer.form_type_renderer" />
                 <argument type="service" id="maker.doctrine_helper" />
+                <argument type="service" id="maker.namespaces_helper" />
                 <argument type="service" id="router" on-invalid="ignore" />
                 <tag name="maker.command" />
             </service>
@@ -160,6 +161,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.security_config_updater" />
                 <argument type="service" id="maker.security_controller_builder" />
+                <argument type="service" id="maker.namespaces_helper" />
                 <tag name="maker.command" />
             </service>
 

--- a/config/services.xml
+++ b/config/services.xml
@@ -16,7 +16,7 @@
             </service>
 
             <service id="maker.autoloader_finder" class="Symfony\Bundle\MakerBundle\Util\ComposerAutoloaderFinder" >
-                <argument /> <!-- root namespace -->
+                <argument type="service" id="maker.namespaces_helper" />
             </service>
 
             <service id="maker.autoloader_util" class="Symfony\Bundle\MakerBundle\Util\AutoloaderUtil">
@@ -36,8 +36,12 @@
             </service>
 
             <service id="maker.doctrine_helper" class="Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper">
-                <argument /> <!-- entity namespace -->
+                <argument type="service" id="maker.namespaces_helper" />
                 <argument type="service" id="doctrine" on-invalid="ignore" />
+            </service>
+
+            <service id="maker.namespaces_helper" class="Symfony\Bundle\MakerBundle\Util\NamespacesHelper">
+                <argument type="collection" /> <!-- namespaces -->
             </service>
 
             <service id="maker.template_linter" class="Symfony\Bundle\MakerBundle\Util\TemplateLinter">
@@ -54,7 +58,7 @@
 
             <service id="maker.generator" class="Symfony\Bundle\MakerBundle\Generator">
                 <argument type="service" id="maker.file_manager" />
-                <argument /> <!-- root namespace -->
+                <argument type="service" id="maker.namespaces_helper" />
                 <argument>null</argument> <!-- PhpCompatUtil -->
                 <argument type="service" id="maker.template_component_generator" />
             </service>
@@ -82,7 +86,7 @@
             <service id="maker.template_component_generator" class="Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator">
                 <argument /> <!-- generate_final_classes -->
                 <argument /> <!-- generate_final_entities -->
-                <argument /> <!-- root_namespace -->
+                <argument type="service" id="maker.namespaces_helper" />
             </service>
         </services>
 </container>

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -26,6 +26,7 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\MappingException as PersistenceMappingException;
 use Doctrine\Persistence\Mapping\StaticReflectionService;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 
@@ -39,11 +40,10 @@ use Symfony\Component\Uid\Uuid;
 final class DoctrineHelper
 {
     public function __construct(
-        private string $entityNamespace,
+        private NamespacesHelper $namespacesHelper,
         private ?ManagerRegistry $registry = null,
         private ?array $mappingDriversByPrefix = null,
     ) {
-        $this->entityNamespace = trim($entityNamespace, '\\');
     }
 
     public function getRegistry(): ManagerRegistry
@@ -64,7 +64,11 @@ final class DoctrineHelper
 
     public function getEntityNamespace(): string
     {
-        return $this->entityNamespace;
+        return sprintf(
+            '%s\\%s',
+            $this->namespacesHelper->getRootNamespace(),
+            $this->namespacesHelper->getEntityNamespace()
+        );
     }
 
     public function doesClassUseDriver(string $className, string $driverClass): bool
@@ -138,7 +142,7 @@ final class DoctrineHelper
             $allMetadata = $this->getMetadata();
 
             foreach (array_keys($allMetadata) as $classname) {
-                $entityClassDetails = new ClassNameDetails($classname, $this->entityNamespace);
+                $entityClassDetails = new ClassNameDetails($classname, $this->getEntityNamespace());
                 $entities[] = $entityClassDetails->getRelativeName();
             }
         }

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -64,7 +64,7 @@ final class DoctrineHelper
 
     public function getEntityNamespace(): string
     {
-        return sprintf(
+        return \sprintf(
             '%s\\%s',
             $this->namespacesHelper->getRootNamespace(),
             $this->namespacesHelper->getEntityNamespace()

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -44,7 +44,7 @@ final class EntityClassGenerator
     {
         $repoClassDetails = $this->generator->createClassNameDetails(
             $entityClassDetails->getRelativeName(),
-            'Repository\\',
+            $this->generator->getNamespacesHelper()->getRepositoryNamespace(),
             'Repository'
         );
 

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -151,7 +151,7 @@ final class MakeAuthenticator extends AbstractMaker
         );
         $input->setArgument('authenticator-class', $io->askQuestion($questionAuthenticatorClass));
 
-        $interactiveSecurityHelper = new InteractiveSecurityHelper();
+        $interactiveSecurityHelper = new InteractiveSecurityHelper($this->generator->getNamespacesHelper());
         $command->addOption('firewall-name', null, InputOption::VALUE_OPTIONAL);
         $input->setOption('firewall-name', $interactiveSecurityHelper->guessFirewallName($io, $securityData));
 

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -69,7 +69,7 @@ final class MakeCommand extends AbstractMaker
 
         $commandClassNameDetails = $generator->createClassNameDetails(
             $commandNameHasAppPrefix ? substr($commandName, 4) : $commandName,
-            'Command\\',
+            $generator->getNamespacesHelper()->getCommandNamespace(),
             'Command',
             \sprintf('The "%s" command name is not valid because it would be implemented by "%s" class, which is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores).', $commandName, Str::asClassName($commandName, 'Command'))
         );

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -142,7 +142,7 @@ final class MakeController extends AbstractMaker
         }
 
         if ($this->shouldGenerateTests()) {
-            $testClassName =\sprintf(
+            $testClassName = \sprintf(
                 '%s\%s\%s',
                 $this->namespacesHelper->getTestNamespace(),
                 $this->namespacesHelper->getControllerNamespace(),

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -248,7 +248,7 @@ final class MakeCrud extends AbstractMaker
         }
 
         if ($this->shouldGenerateTests()) {
-            $testClassName =\sprintf(
+            $testClassName = \sprintf(
                 '%s\%s\%s',
                 $generator->getNamespacesHelper()->getTestNamespace(),
                 $generator->getNamespacesHelper()->getControllerNamespace(),

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -107,7 +107,7 @@ final class MakeCrud extends AbstractMaker
     {
         $entityClassDetails = $generator->createClassNameDetails(
             Validator::entityExists($input->getArgument('entity-class'), $this->doctrineHelper->getEntitiesForAutocomplete()),
-            'Entity\\'
+            $generator->getNamespacesHelper()->getEntityNamespace()
         );
 
         $entityDoctrineDetails = $this->doctrineHelper->createDoctrineDetails($entityClassDetails->getFullName());
@@ -118,7 +118,7 @@ final class MakeCrud extends AbstractMaker
         if (null !== $entityDoctrineDetails->getRepositoryClass()) {
             $repositoryClassDetails = $generator->createClassNameDetails(
                 '\\'.$entityDoctrineDetails->getRepositoryClass(),
-                'Repository\\',
+                $generator->getNamespacesHelper()->getRepositoryNamespace(),
                 'Repository'
             );
 
@@ -133,7 +133,7 @@ final class MakeCrud extends AbstractMaker
 
         $controllerClassDetails = $generator->createClassNameDetails(
             $this->controllerClassName,
-            'Controller\\',
+            $generator->getNamespacesHelper()->getControllerNamespace(),
             'Controller'
         );
 
@@ -141,14 +141,15 @@ final class MakeCrud extends AbstractMaker
         do {
             $formClassDetails = $generator->createClassNameDetails(
                 $entityClassDetails->getRelativeNameWithoutSuffix().($iter ?: '').'Type',
-                'Form\\',
+                $generator->getNamespacesHelper()->getFormNamespace(),
                 'Type'
             );
             ++$iter;
         } while (class_exists($formClassDetails->getFullName()));
 
         $controllerClassData = ClassData::create(
-            class: \sprintf('Controller\%s', $this->controllerClassName),
+            class: \sprintf('%s\%s', $generator->getNamespacesHelper()->getControllerNamespace(), $this->controllerClassName),
+            rootNamespace: $generator->getRootNamespace(),
             suffix: 'Controller',
             extendsClass: AbstractController::class,
             useStatements: [
@@ -247,8 +248,15 @@ final class MakeCrud extends AbstractMaker
         }
 
         if ($this->shouldGenerateTests()) {
+            $testClassName =\sprintf(
+                '%s\%s\%s',
+                $generator->getNamespacesHelper()->getTestNamespace(),
+                $generator->getNamespacesHelper()->getControllerNamespace(),
+                $entityClassDetails->getRelativeNameWithoutSuffix()
+            );
             $testClassData = ClassData::create(
-                class: \sprintf('Tests\Controller\%s', $entityClassDetails->getRelativeNameWithoutSuffix()),
+                class: $testClassName,
+                rootNamespace: $generator->getRootNamespace(),
                 suffix: 'ControllerTest',
                 extendsClass: WebTestCase::class,
                 useStatements: [

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -143,7 +143,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (
             !$input->getOption('api-resource')
             && class_exists(ApiResource::class)
-            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->getEntityNamespace())->getFullName())
+            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->generator->getNamespacesHelper()->getEntityNamespace())->getFullName())
         ) {
             $description = $command->getDefinition()->getOption('api-resource')->getDescription();
             $question = new ConfirmationQuestion($description, false);
@@ -155,7 +155,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (
             !$input->getOption('broadcast')
             && class_exists(Broadcast::class)
-            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->getEntityNamespace())->getFullName())
+            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->generator->getNamespacesHelper()->getEntityNamespace())->getFullName())
         ) {
             $description = $command->getDefinition()->getOption('broadcast')->getDescription();
             $question = new ConfirmationQuestion($description, false);
@@ -184,7 +184,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         $entityClassDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            $this->getEntityNamespace()
+            $generator->getNamespacesHelper()->getEntityNamespace(),
         );
 
         $classExists = class_exists($entityClassDetails->getFullName());

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -31,6 +31,7 @@ use Symfony\Bundle\MakerBundle\Util\ClassDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassProperty;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Bundle\MakerBundle\Util\CliOutputHelper;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\MercureBundle\DependencyInjection\MercureExtension;
 use Symfony\Component\Console\Command\Command;
@@ -66,7 +67,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         if (null === $generator) {
             @trigger_error(\sprintf('Passing a "%s" instance as 4th argument is mandatory since version 1.5.', Generator::class), \E_USER_DEPRECATED);
-            $this->generator = new Generator($fileManager, 'App\\');
+            $this->generator = new Generator($fileManager, new NamespacesHelper());
         } else {
             $this->generator = $generator;
         }
@@ -142,7 +143,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (
             !$input->getOption('api-resource')
             && class_exists(ApiResource::class)
-            && !class_exists($this->generator->createClassNameDetails($entityClassName, 'Entity\\')->getFullName())
+            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->getEntityNamespace())->getFullName())
         ) {
             $description = $command->getDefinition()->getOption('api-resource')->getDescription();
             $question = new ConfirmationQuestion($description, false);
@@ -154,7 +155,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (
             !$input->getOption('broadcast')
             && class_exists(Broadcast::class)
-            && !class_exists($this->generator->createClassNameDetails($entityClassName, 'Entity\\')->getFullName())
+            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->getEntityNamespace())->getFullName())
         ) {
             $description = $command->getDefinition()->getOption('broadcast')->getDescription();
             $question = new ConfirmationQuestion($description, false);
@@ -183,7 +184,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         $entityClassDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Entity\\'
+            $this->getEntityNamespace()
         );
 
         $classExists = class_exists($entityClassDetails->getFullName());

--- a/src/Maker/MakeFixtures.php
+++ b/src/Maker/MakeFixtures.php
@@ -53,7 +53,7 @@ final class MakeFixtures extends AbstractMaker
     {
         $fixturesClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('fixtures-class'),
-            'DataFixtures\\'
+            $generator->getNamespacesHelper()->getFixturesNamespace()
         );
 
         $useStatements = new UseStatementGenerator([

--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -79,7 +79,7 @@ final class MakeForm extends AbstractMaker
     {
         $formClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Form\\',
+            $generator->getNamespacesHelper()->getFormNamespace(),
             'Type'
         );
 
@@ -91,7 +91,7 @@ final class MakeForm extends AbstractMaker
         if (null !== $boundClass) {
             $boundClassDetails = $generator->createClassNameDetails(
                 $boundClass,
-                'Entity\\'
+                $generator->getNamespacesHelper()->getEntityNamespace()
             );
 
             $doctrineEntityDetails = $this->entityHelper->createDoctrineDetails($boundClassDetails->getFullName());

--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -58,7 +58,7 @@ class MakeFunctionalTest extends AbstractMaker
     {
         $testClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Tests\\',
+            $generator->getNamespacesHelper()->getTestNamespace(),
             'Test'
         );
 

--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -191,7 +191,7 @@ final class MakeListener extends AbstractMaker
     {
         $subscriberClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'EventSubscriber\\',
+            $generator->getNamespacesHelper()->getSubscriberNamespace(),
             'Subscriber'
         );
 
@@ -220,7 +220,7 @@ final class MakeListener extends AbstractMaker
     {
         $listenerClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'EventListener\\',
+            $generator->getNamespacesHelper()->getListenerNamespace(),
             'Listener'
         );
 

--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -88,12 +88,12 @@ final class MakeMessage extends AbstractMaker
     {
         $messageClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Message\\'
+            $generator->getNamespacesHelper()->getMessageNamespace()
         );
 
         $handlerClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name').'Handler',
-            'MessageHandler\\',
+            $generator->getNamespacesHelper()->getMessageHandlerNamespace(),
             'Handler'
         );
 

--- a/src/Maker/MakeMessengerMiddleware.php
+++ b/src/Maker/MakeMessengerMiddleware.php
@@ -53,7 +53,7 @@ final class MakeMessengerMiddleware extends AbstractMaker
     {
         $middlewareClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Middleware\\',
+            $generator->getNamespacesHelper()->getMiddlewareNamespace(),
             'Middleware'
         );
 

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -215,7 +215,7 @@ final class MakeRegistrationForm extends AbstractMaker
     {
         $userClassNameDetails = $generator->createClassNameDetails(
             '\\'.$this->userClass,
-            'Entity\\'
+            $generator->getNamespacesHelper()->getEntityNamespace()
         );
 
         $userDoctrineDetails = $this->doctrineHelper->createDoctrineDetails($userClassNameDetails->getFullName());
@@ -229,7 +229,11 @@ final class MakeRegistrationForm extends AbstractMaker
         $userRepository = $userDoctrineDetails->getRepositoryClass();
 
         if (null !== $userRepository) {
-            $userRepoClassDetails = $generator->createClassNameDetails('\\'.$userRepository, 'Repository\\', 'Repository');
+            $userRepoClassDetails = $generator->createClassNameDetails(
+                '\\'.$userRepository,
+                $generator->getNamespacesHelper()->getRepositoryNamespace(),
+                'Repository'
+            );
 
             $userRepoVars = [
                 'repository_full_class_name' => $userRepoClassDetails->getFullName(),
@@ -240,7 +244,7 @@ final class MakeRegistrationForm extends AbstractMaker
 
         $verifyEmailServiceClassNameDetails = $generator->createClassNameDetails(
             'EmailVerifier',
-            'Security\\'
+            $generator->getNamespacesHelper()->getSecurityNamespace()
         );
 
         $verifyEmailVars = ['will_verify_email' => $this->willVerifyEmail];
@@ -297,7 +301,7 @@ final class MakeRegistrationForm extends AbstractMaker
         // 2) Generate the controller
         $controllerClassNameDetails = $generator->createClassNameDetails(
             'RegistrationController',
-            'Controller\\'
+            $generator->getNamespacesHelper()->getControllerNamespace()
         );
 
         $useStatements = new UseStatementGenerator([
@@ -417,7 +421,7 @@ final class MakeRegistrationForm extends AbstractMaker
         if ($this->shouldGenerateTests()) {
             $testClassDetails = $generator->createClassNameDetails(
                 'RegistrationControllerTest',
-                'Test\\'
+                $generator->getNamespacesHelper()->getTestNamespace()
             );
 
             $useStatements = new UseStatementGenerator([
@@ -549,7 +553,7 @@ final class MakeRegistrationForm extends AbstractMaker
     {
         $formClassDetails = $generator->createClassNameDetails(
             'RegistrationFormType',
-            'Form\\'
+            $generator->getNamespacesHelper()->getFormNamespace()
         );
 
         $formFields = [

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -37,6 +37,7 @@ use Symfony\Bundle\MakerBundle\Util\ClassDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Bundle\MakerBundle\Util\CliOutputHelper;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
@@ -91,6 +92,7 @@ final class MakeRegistrationForm extends AbstractMaker
         private FileManager $fileManager,
         private FormTypeRenderer $formTypeRenderer,
         private DoctrineHelper $doctrineHelper,
+        private NamespacesHelper $namespacesHelper,
         private ?RouterInterface $router = null,
     ) {
     }
@@ -116,7 +118,7 @@ final class MakeRegistrationForm extends AbstractMaker
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
-        $interactiveSecurityHelper = new InteractiveSecurityHelper();
+        $interactiveSecurityHelper = new InteractiveSecurityHelper($this->namespacesHelper);
 
         if (null === $this->router) {
             throw new RuntimeCommandException('Router have been explicitly disabled in your configuration. This command needs to use the router.');

--- a/src/Maker/MakeSchedule.php
+++ b/src/Maker/MakeSchedule.php
@@ -107,7 +107,7 @@ final class MakeSchedule extends AbstractMaker
     {
         $scheduleClassDetails = $generator->createClassNameDetails(
             $this->scheduleName,
-            'Scheduler\\',
+            $generator->getNamespacesHelper()->getSchedulerNamespace(),
         );
 
         $useStatements = new UseStatementGenerator([
@@ -119,7 +119,13 @@ final class MakeSchedule extends AbstractMaker
         ]);
 
         if (null !== $this->message) {
-            $useStatements->addUseStatement('App\\Message\\'.$this->message);
+            $messageClass = \sprintf(
+                $generator->getRootNamespace(),
+                $generator->getNamespacesHelper()->getMessageNamespace(),
+                '%s\\%s\\%s', $this->message
+            );
+
+            $useStatements->addUseStatement($messageClass);
         }
 
         $generator->generateClass(

--- a/src/Maker/MakeSchedule.php
+++ b/src/Maker/MakeSchedule.php
@@ -120,9 +120,10 @@ final class MakeSchedule extends AbstractMaker
 
         if (null !== $this->message) {
             $messageClass = \sprintf(
+                '%s\\%s\\%s',
                 $generator->getRootNamespace(),
                 $generator->getNamespacesHelper()->getMessageNamespace(),
-                '%s\\%s\\%s', $this->message
+                $this->message
             );
 
             $useStatements->addUseStatement($messageClass);

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -52,7 +52,7 @@ final class MakeSerializerEncoder extends AbstractMaker
     {
         $encoderClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Serializer\\',
+            $generator->getNamespacesHelper()->getSerializerNamespace(),
             'Encoder'
         );
         $format = $input->getArgument('format');

--- a/src/Maker/MakeSerializerNormalizer.php
+++ b/src/Maker/MakeSerializerNormalizer.php
@@ -62,19 +62,24 @@ final class MakeSerializerNormalizer extends AbstractMaker
     {
         $normalizerClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Serializer\\Normalizer\\',
+            $generator->getNamespacesHelper()->getSerializerNamespace().'\\Normalizer\\',
             \Normalizer::class
         );
 
         $useStatements = new UseStatementGenerator([
             NormalizerInterface::class,
             Autowire::class,
-            \sprintf('App\Entity\%s', str_replace('Normalizer', '', $normalizerClassNameDetails->getShortName())),
+            \sprintf(
+                '%s\%s\%s',
+                $generator->getRootNamespace(),
+                $generator->getNamespacesHelper()->getEntityNamespace(),
+                str_replace('Normalizer', '', $normalizerClassNameDetails->getShortName())
+            ),
         ]);
 
         $entityDetails = $generator->createClassNameDetails(
             str_replace('Normalizer', '', $normalizerClassNameDetails->getShortName()),
-            'Entity\\',
+            $generator->getNamespacesHelper()->getEntityNamespace(),
         );
 
         if ($entityExists = class_exists($entityDetails->getFullName())) {

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -80,7 +80,7 @@ final class MakeSubscriber extends AbstractMaker
     {
         $subscriberClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'EventSubscriber\\',
+            $generator->getNamespacesHelper()->getSubscriberNamespace(),
             'Subscriber'
         );
 

--- a/src/Maker/MakeTest.php
+++ b/src/Maker/MakeTest.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputAwareMakerInterface;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\Console\Command\Command;
@@ -48,6 +49,10 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
         'ApiTestCase' => 'https://api-platform.com/docs/distribution/testing/',
         'PantherTestCase' => 'https://github.com/symfony/panther#testing-usage',
     ];
+
+    public function __construct(private NamespacesHelper $namespacesHelper)
+    {
+    }
 
     public static function getCommandName(): string
     {
@@ -125,7 +130,11 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
                 'Choose a class name for your test, like:',
                 ' * <fg=yellow>UtilTest</> (to create tests/UtilTest.php)',
                 ' * <fg=yellow>Service\\UtilTest</> (to create tests/Service/UtilTest.php)',
-                ' * <fg=yellow>\\App\Tests\\Service\\UtilTest</> (to create tests/Service/UtilTest.php)',
+                \sprintf(
+                    ' * <fg=yellow>\\%s\\%s\\Service\\UtilTest</> (to create tests/Service/UtilTest.php)',
+                    $this->namespacesHelper->getRootNamespace(),
+                    $this->namespacesHelper->getTestNamespace()
+                ),
             ]);
 
             $nameArgument = $command->getDefinition()->getArgument('name');
@@ -138,7 +147,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
     {
         $testClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Tests\\',
+            $generator->getNamespacesHelper()->getTestNamespace(),
             'Test'
         );
 

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -30,7 +30,7 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
  */
 final class MakeTwigComponent extends AbstractMaker
 {
-    private string $namespace = 'Twig\\Components';
+    private ?string $namespace = null;
 
     public function __construct(private FileManager $fileManager)
     {
@@ -68,6 +68,8 @@ final class MakeTwigComponent extends AbstractMaker
         if ($live && !class_exists(AsLiveComponent::class)) {
             throw new \RuntimeException('You must install symfony/ux-live-component to create a live component (composer require symfony/ux-live-component)');
         }
+
+        $this->namespace ??= \sprintf('%s\\Components\\', $generator->getNamespacesHelper()->getTwigNamespace());
 
         $factory = $generator->createClassNameDetails(
             $name,

--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -54,13 +54,13 @@ final class MakeTwigExtension extends AbstractMaker
 
         $extensionClassNameDetails = $generator->createClassNameDetails(
             $name,
-            'Twig\\Extension\\',
+            \sprintf('%s\\Extension\\', $generator->getNamespacesHelper()->getTwigNamespace()),
             'Extension'
         );
 
         $runtimeClassNameDetails = $generator->createClassNameDetails(
             $name,
-            'Twig\\Runtime\\',
+            \sprintf('%s\\Runtime\\', $generator->getNamespacesHelper()->getTwigNamespace()),
             'Runtime'
         );
 

--- a/src/Maker/MakeUnitTest.php
+++ b/src/Maker/MakeUnitTest.php
@@ -53,7 +53,7 @@ final class MakeUnitTest extends AbstractMaker
     {
         $testClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Tests\\',
+            $generator->getNamespacesHelper()->getTestNamespace(),
             'Test'
         );
 

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -130,7 +130,9 @@ final class MakeUser extends AbstractMaker
 
         $userClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            $userClassConfiguration->isEntity() ? 'Entity\\' : 'Security\\'
+            $userClassConfiguration->isEntity()
+                ? $generator->getNamespacesHelper()->getEntityNamespace()
+                : $generator->getNamespacesHelper()->getSecurityNamespace()
         );
 
         // A) Generate the User class
@@ -168,7 +170,11 @@ final class MakeUser extends AbstractMaker
 
         // C) Generate a custom user provider, if necessary
         if (!$userClassConfiguration->isEntity()) {
-            $userClassConfiguration->setUserProviderClass($generator->getRootNamespace().'\\Security\\UserProvider');
+            $userClassConfiguration->setUserProviderClass(\sprintf(
+                '%s\\%s\\UserProvider',
+                $generator->getRootNamespace(),
+                $generator->getNamespacesHelper()->getSecurityNamespace()
+            ));
 
             $useStatements = new UseStatementGenerator([
                 UnsupportedUserException::class,

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -53,7 +53,8 @@ final class MakeValidator extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         $validatorClassData = ClassData::create(
-            class: \sprintf('Validator\\%s', $input->getArgument('name')),
+            class: \sprintf('%s\\%s', $generator->getNamespacesHelper()->getValidatorNamespace(), $input->getArgument('name')),
+            rootNamespace: $generator->getRootNamespace(),
             suffix: 'Validator',
             extendsClass: ConstraintValidator::class,
             useStatements: [
@@ -62,7 +63,8 @@ final class MakeValidator extends AbstractMaker
         );
 
         $constraintDataClass = ClassData::create(
-            class: \sprintf('Validator\\%s', Str::removeSuffix($validatorClassData->getClassName(), 'Validator')),
+            class: \sprintf('%s\\%s', $generator->getNamespacesHelper()->getValidatorNamespace(), Str::removeSuffix($validatorClassData->getClassName(), 'Validator')),
+            rootNamespace: $generator->getRootNamespace(),
             extendsClass: Constraint::class,
         );
 

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -50,7 +50,8 @@ final class MakeVoter extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $voterClassData = ClassData::create(
-            class: \sprintf('Security\Voter\%s', $input->getArgument('name')),
+            class: \sprintf('%s\Voter\%s', $generator->getNamespacesHelper()->getSecurityNamespace(), $input->getArgument('name')),
+            rootNamespace: $generator->getRootNamespace(),
             suffix: 'Voter',
             extendsClass: Voter::class,
             useStatements: [

--- a/src/Maker/MakeWebhook.php
+++ b/src/Maker/MakeWebhook.php
@@ -148,11 +148,11 @@ final class MakeWebhook extends AbstractMaker implements InputAwareMakerInterfac
     {
         $requestParserDetails = $this->generator->createClassNameDetails(
             Str::asClassName($this->name.'RequestParser'),
-            'Webhook\\'
+            $generator->getNamespacesHelper()->getWebhookNamespace()
         );
         $remoteEventConsumerDetails = $this->generator->createClassNameDetails(
             Str::asClassName($this->name.'WebhookConsumer'),
-            'RemoteEvent\\'
+            $generator->getNamespacesHelper()->getRemoteEventNamespace()
         );
 
         $this->addToYamlConfig($this->name, $requestParserDetails);

--- a/src/Maker/Security/MakeFormLogin.php
+++ b/src/Maker/Security/MakeFormLogin.php
@@ -29,6 +29,7 @@ use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
 use Symfony\Bundle\MakerBundle\Security\SecurityControllerBuilder;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
@@ -67,6 +68,7 @@ final class MakeFormLogin extends AbstractMaker
         private FileManager $fileManager,
         private SecurityConfigUpdater $securityConfigUpdater,
         private SecurityControllerBuilder $securityControllerBuilder,
+        private NamespacesHelper $namespacesHelper,
     ) {
     }
 
@@ -126,7 +128,7 @@ final class MakeFormLogin extends AbstractMaker
             Validator::validateClassName(...)
         );
 
-        $securityHelper = new InteractiveSecurityHelper();
+        $securityHelper = new InteractiveSecurityHelper($this->namespacesHelper);
         $this->firewallToUpdate = $securityHelper->guessFirewallName($io, $securityData);
         $this->userClass = $securityHelper->guessUserClass($io, $securityData['security']['providers']);
         $this->userNameField = $securityHelper->guessUserNameField($io, $this->userClass, $securityData['security']['providers']);

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -28,7 +28,7 @@ final class ClassData
         public readonly bool $isEntity,
         private UseStatementGenerator $useStatementGenerator,
         private bool $isFinal = true,
-        private string $rootNamespace = 'App',
+        private string $rootNamespace,
         private ?string $classSuffix = null,
     ) {
         if (str_starts_with(haystack: $this->namespace, needle: $this->rootNamespace)) {
@@ -36,8 +36,14 @@ final class ClassData
         }
     }
 
-    public static function create(string $class, ?string $suffix = null, ?string $extendsClass = null, bool $isEntity = false, array $useStatements = []): self
-    {
+    public static function create(
+        string $class,
+        string $rootNamespace,
+        ?string $suffix = null,
+        ?string $extendsClass = null,
+        bool $isEntity = false,
+        array $useStatements = [],
+    ): self {
         $className = Str::getShortClassName($class);
 
         if (null !== $suffix && !str_ends_with($className, $suffix)) {
@@ -56,6 +62,7 @@ final class ClassData
             extends: null === $extendsClass ? null : Str::getShortClassName($extendsClass),
             isEntity: $isEntity,
             useStatementGenerator: $useStatements,
+            rootNamespace: $rootNamespace,
             classSuffix: $suffix,
         );
     }

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -27,8 +27,8 @@ final class ClassData
         public readonly ?string $extends,
         public readonly bool $isEntity,
         private UseStatementGenerator $useStatementGenerator,
-        private bool $isFinal = true,
         private string $rootNamespace,
+        private bool $isFinal = true,
         private ?string $classSuffix = null,
     ) {
         if (str_starts_with(haystack: $this->namespace, needle: $this->rootNamespace)) {

--- a/src/Util/ComposerAutoloaderFinder.php
+++ b/src/Util/ComposerAutoloaderFinder.php
@@ -23,11 +23,11 @@ class ComposerAutoloaderFinder
     private array $rootNamespace;
     private ?ClassLoader $classLoader = null;
 
-    public function __construct(string $rootNamespace)
+    public function __construct(NamespacesHelper $namespacesHelper)
     {
         $this->rootNamespace = [
-            'psr0' => rtrim($rootNamespace, '\\'),
-            'psr4' => rtrim($rootNamespace, '\\').'\\',
+            'psr0' => rtrim($namespacesHelper->getRootNamespace(), '\\'),
+            'psr4' => rtrim($namespacesHelper->getRootNamespace(), '\\').'\\',
         ];
     }
 

--- a/src/Util/NamespacesHelper.php
+++ b/src/Util/NamespacesHelper.php
@@ -13,12 +13,8 @@ namespace Symfony\Bundle\MakerBundle\Util;
 
 final class NamespacesHelper
 {
-    /** @var string[] */
-    private $namespaces;
-
-    public function __construct(array $namespaces = null)
+    public function __construct(private array $namespaces = [])
     {
-        $this->namespaces = $namespaces ?? [];
     }
 
     public function getCommandNamespace(): string

--- a/src/Util/NamespacesHelper.php
+++ b/src/Util/NamespacesHelper.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Util;
+
+final class NamespacesHelper
+{
+    /** @var string[] */
+    private $namespaces;
+
+    public function __construct(array $namespaces = null)
+    {
+        $this->namespaces = $namespaces ?? [];
+    }
+
+    public function getCommandNamespace(): string
+    {
+        return $this->trim($this->namespaces['command'] ?? 'Command\\');
+    }
+
+    public function getControllerNamespace(): string
+    {
+        return $this->trim($this->namespaces['controller'] ?? 'Controller\\');
+    }
+
+    public function getEntityNamespace(): string
+    {
+        return $this->trim($this->namespaces['entity'] ?? 'Entity\\');
+    }
+
+    public function getFixturesNamespace(): string
+    {
+        return $this->trim($this->namespaces['fixtures'] ?? 'DataFixtures\\');
+    }
+
+    public function getFormNamespace(): string
+    {
+        return $this->trim($this->namespaces['form'] ?? 'Form\\');
+    }
+
+    public function getListenerNamespace(): string
+    {
+        return $this->trim($this->namespaces['listener'] ?? 'EventListener\\');
+    }
+
+    public function getMessageNamespace(): string
+    {
+        return $this->trim($this->namespaces['message'] ?? 'Message\\');
+    }
+
+    public function getMessageHandlerNamespace(): string
+    {
+        return $this->trim($this->namespaces['message_handler'] ?? 'MessageHandler\\');
+    }
+
+    public function getMiddlewareNamespace(): string
+    {
+        return $this->trim($this->namespaces['middleware'] ?? 'Middleware\\');
+    }
+
+    public function getRemoteEventNamespace(): string
+    {
+        return $this->trim($this->namespaces['remote_event'] ?? 'RemoteEvent\\');
+    }
+
+    public function getRepositoryNamespace(): string
+    {
+        return $this->trim($this->namespaces['repository'] ?? 'Repository\\');
+    }
+
+    public function getRootNamespace(): string
+    {
+        return $this->trim($this->namespaces['root'] ?? 'App\\');
+    }
+
+    public function getSchedulerNamespace(): string
+    {
+        return $this->trim($this->namespaces['scheduler'] ?? 'Scheduler\\');
+    }
+
+    public function getSecurityNamespace(): string
+    {
+        return $this->trim($this->namespaces['security'] ?? 'Security\\');
+    }
+
+    public function getSerializerNamespace(): string
+    {
+        return $this->trim($this->namespaces['serializer'] ?? 'Serializer\\');
+    }
+
+    public function getSubscriberNamespace(): string
+    {
+        return $this->trim($this->namespaces['subscriber'] ?? 'EventSubscriber\\');
+    }
+
+    public function getTestNamespace(): string
+    {
+        return $this->trim($this->namespaces['test'] ?? 'Tests\\');
+    }
+
+    public function getTwigNamespace(): string
+    {
+        return $this->trim($this->namespaces['twig'] ?? 'Twig\\');
+    }
+
+    public function getValidatorNamespace(): string
+    {
+        return $this->trim($this->namespaces['validator'] ?? 'Validator\\');
+    }
+
+    public function getWebhookNamespace(): string
+    {
+        return $this->trim($this->namespaces['webhook'] ?? 'Webhook\\');
+    }
+
+    private function trim(string $namespace): string
+    {
+        return trim($namespace, '\\');
+    }
+}

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -23,7 +23,7 @@ final class TemplateComponentGenerator
     public function __construct(
         private bool $generateFinalClasses,
         private bool $generateFinalEntities,
-        private string $rootNamespace,
+        private NamespacesHelper $namespacesHelper,
     ) {
     }
 
@@ -62,7 +62,7 @@ final class TemplateComponentGenerator
 
     public function configureClass(ClassData $classMetadata): ClassData
     {
-        $classMetadata->setRootNamespace($this->rootNamespace);
+        $classMetadata->setRootNamespace($this->namespacesHelper->getRootNamespace());
 
         if ($classMetadata->isEntity) {
             return $classMetadata->setIsFinal($this->generateFinalEntities);

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\MakerInterface;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Bundle\MakerBundle\Util\TemplateLinter;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -40,7 +41,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'), new TemplateLinter());
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, new NamespacesHelper()), new TemplateLinter());
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);
@@ -53,7 +54,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'), new TemplateLinter());
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, new NamespacesHelper(['root' => 'Unknown'])), new TemplateLinter());
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -98,10 +99,11 @@ class EntityRegeneratorTest extends TestCase
                 return $tmpDir.'/src/'.str_replace('\\', '/', $shortClassName).'.php';
             });
 
+        $namespacesHelper = new NamespacesHelper();
         $fileManager = new FileManager($fs, $autoloaderUtil, new MakerFileLinkFormatter(null), $tmpDir);
-        $doctrineHelper = new DoctrineHelper('App\\Entity', $container->get('doctrine'));
-        $templateComponentGenerator = new TemplateComponentGenerator(false, false, 'App');
-        $generator = new Generator(fileManager: $fileManager, namespacePrefix: 'App\\', templateComponentGenerator: $templateComponentGenerator);
+        $doctrineHelper = new DoctrineHelper($namespacesHelper, $container->get('doctrine'));
+        $templateComponentGenerator = new TemplateComponentGenerator(false, false, $namespacesHelper);
+        $generator = new Generator(fileManager: $fileManager, namespacesHelper: $namespacesHelper, templateComponentGenerator: $templateComponentGenerator);
         $entityClassGenerator = new EntityClassGenerator($generator, $doctrineHelper);
         $regenerator = new EntityRegenerator(
             $doctrineHelper,

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -14,20 +14,27 @@ namespace Symfony\Bundle\MakerBundle\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 
 class GeneratorTest extends TestCase
 {
     /**
      * @dataProvider getClassNameDetailsTests
      */
-    public function testCreateClassNameDetails(string $name, string $prefix, string $suffix, string $expectedFullClassName, string $expectedRelativeClassName): void
-    {
+    public function testCreateClassNameDetails(
+        string $name,
+        string $prefix,
+        string $suffix,
+        string $expectedFullClassName,
+        string $expectedRelativeClassName,
+        array $namespaces = []
+    ): void {
         $fileManager = $this->createMock(FileManager::class);
         $fileManager->expects($this->any())
             ->method('getNamespacePrefixForClass')
             ->willReturn('Foo');
 
-        $generator = new Generator($fileManager, 'App\\');
+        $generator = new Generator($fileManager, new NamespacesHelper($namespaces));
 
         $classNameDetails = $generator->createClassNameDetails($name, $prefix, $suffix);
 
@@ -99,6 +106,24 @@ class GeneratorTest extends TestCase
             '',
             'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
             'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
+        ];
+
+        yield 'simple_custom_namespace' => [
+            'foo',
+            'Controller\\',
+            '',
+            'Custom\\Controller\\Foo',
+            'Foo',
+            ['root' => 'Custom\\'],
+        ];
+
+        yield 'multilevel_custom_namespace' => [
+            'foo',
+            'Controller\\',
+            '',
+            'Custom\\Root\\Controller\\Foo',
+            'Foo',
+            ['root' => 'Custom\\Root\\'],
         ];
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -27,7 +27,7 @@ class GeneratorTest extends TestCase
         string $suffix,
         string $expectedFullClassName,
         string $expectedRelativeClassName,
-        array $namespaces = []
+        array $namespaces = [],
     ): void {
         $fileManager = $this->createMock(FileManager::class);
         $fileManager->expects($this->any())

--- a/tests/Security/InteractiveSecurityHelperTest.php
+++ b/tests/Security/InteractiveSecurityHelperTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
 use Symfony\Bundle\MakerBundle\Security\Model\Authenticator;
 use Symfony\Bundle\MakerBundle\Security\Model\AuthenticatorType;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 class InteractiveSecurityHelperTest extends TestCase
@@ -30,7 +31,7 @@ class InteractiveSecurityHelperTest extends TestCase
             ->method('choice')
             ->willReturn($expectedFirewallName);
 
-        $helper = new InteractiveSecurityHelper();
+        $helper = new InteractiveSecurityHelper(new NamespacesHelper());
         $this->assertEquals(
             $expectedFirewallName,
             $helper->guessFirewallName($io, $securityData)
@@ -88,7 +89,7 @@ class InteractiveSecurityHelperTest extends TestCase
             ->method('ask')
             ->willReturn($expectedUserClass);
 
-        $helper = new InteractiveSecurityHelper();
+        $helper = new InteractiveSecurityHelper(new NamespacesHelper());
         $this->assertEquals(
             $expectedUserClass,
             $helper->guessUserClass($io, $securityData)
@@ -128,7 +129,7 @@ class InteractiveSecurityHelperTest extends TestCase
             ->with(\sprintf('Which field on your <fg=yellow>%s</> class will people enter when logging in?', $class), $choices, 'username')
             ->willReturn($expectedUsernameField);
 
-        $interactiveSecurityHelper = new InteractiveSecurityHelper();
+        $interactiveSecurityHelper = new InteractiveSecurityHelper(new NamespacesHelper());
         $this->assertEquals(
             $expectedUsernameField,
             $interactiveSecurityHelper->guessUserNameField($io, $class, $providers)
@@ -185,7 +186,7 @@ class InteractiveSecurityHelperTest extends TestCase
             ->with(\sprintf('Which field on your <fg=yellow>%s</> class holds the email address?', $class), $choices, null)
             ->willReturn($expectedEmailField);
 
-        $interactiveSecurityHelper = new InteractiveSecurityHelper();
+        $interactiveSecurityHelper = new InteractiveSecurityHelper(new NamespacesHelper());
         $this->assertEquals(
             $expectedEmailField,
             $interactiveSecurityHelper->guessEmailField($io, $class)
@@ -211,7 +212,7 @@ class InteractiveSecurityHelperTest extends TestCase
     /** @dataProvider authenticatorClassProvider */
     public function testGetAuthenticatorsFromConfig(array $firewalls, array $expectedResults): void
     {
-        $helper = new InteractiveSecurityHelper();
+        $helper = new InteractiveSecurityHelper(new NamespacesHelper());
         $result = $helper->getAuthenticatorsFromConfig($firewalls);
 
         self::assertEquals($expectedResults, $result);
@@ -287,7 +288,7 @@ class InteractiveSecurityHelperTest extends TestCase
             ->with(\sprintf('Which method on your <fg=yellow>%s</> class can be used to set the encoded password (e.g. setPassword())?', $class), $choices, null)
             ->willReturn($expectedPasswordSetter);
 
-        $interactiveSecurityHelper = new InteractiveSecurityHelper();
+        $interactiveSecurityHelper = new InteractiveSecurityHelper(new NamespacesHelper());
         $this->assertEquals(
             $expectedPasswordSetter,
             $interactiveSecurityHelper->guessPasswordSetter($io, $class)
@@ -322,7 +323,7 @@ class InteractiveSecurityHelperTest extends TestCase
             ->with(\sprintf('Which method on your <fg=yellow>%s</> class can be used to get the email address (e.g. getEmail())?', $class), $choices, null)
             ->willReturn($expectedEmailGetter);
 
-        $interactiveSecurityHelper = new InteractiveSecurityHelper();
+        $interactiveSecurityHelper = new InteractiveSecurityHelper(new NamespacesHelper());
         $this->assertEquals(
             $expectedEmailGetter,
             $interactiveSecurityHelper->guessEmailGetter($io, $class, $emailAttribute)

--- a/tests/Util/AutoloaderUtilTest.php
+++ b/tests/Util/AutoloaderUtilTest.php
@@ -15,6 +15,7 @@ use Composer\Autoload\ClassLoader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\ComposerAutoloaderFinder;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Component\Filesystem\Filesystem;
 
 class AutoloaderUtilTest extends TestCase
@@ -96,7 +97,7 @@ class AutoloaderUtilTest extends TestCase
         /** @var \PHPUnit_Framework_MockObject_MockObject|ComposerAutoloaderFinder $finder */
         $finder = $this
             ->getMockBuilder(ComposerAutoloaderFinder::class)
-            ->setConstructorArgs(['App\\'])
+            ->setConstructorArgs([new NamespacesHelper()])
             ->getMock();
 
         $finder

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -20,7 +20,7 @@ class ClassDataTest extends TestCase
 {
     public function testStaticConstructor(): void
     {
-        $meta = ClassData::create(MakerBundle::class, 'App\\');
+        $meta = ClassData::create(MakerBundle::class, 'App');
 
         // Sanity check in case Maker's NS changes
         self::assertSame('Symfony\Bundle\MakerBundle\MakerBundle', MakerBundle::class);
@@ -32,14 +32,14 @@ class ClassDataTest extends TestCase
 
     public function testGetClassDeclaration(): void
     {
-        $meta = ClassData::create(MakerBundle::class, 'App\\');
+        $meta = ClassData::create(MakerBundle::class, 'App');
 
         self::assertSame('final class MakerBundle', $meta->getClassDeclaration());
     }
 
     public function testIsFinal(): void
     {
-        $meta = ClassData::create(MakerBundle::class, 'App\\');
+        $meta = ClassData::create(MakerBundle::class, 'App');
 
         // Default - isFinal - true
         self::assertSame('final class MakerBundle', $meta->getClassDeclaration());
@@ -51,7 +51,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassDeclarationWithExtends(): void
     {
-        $meta = ClassData::create(class: MakerBundle::class, rootNamespace: 'App\\', extendsClass: MakerTestKernel::class);
+        $meta = ClassData::create(class: MakerBundle::class, rootNamespace: 'App', extendsClass: MakerTestKernel::class);
 
         self::assertSame('final class MakerBundle extends MakerTestKernel', $meta->getClassDeclaration());
     }
@@ -59,7 +59,7 @@ class ClassDataTest extends TestCase
     /** @dataProvider suffixDataProvider */
     public function testSuffix(?string $suffix, string $expectedResult): void
     {
-        $data = ClassData::create(class: MakerBundle::class, rootNamespace: 'App\\', suffix: $suffix);
+        $data = ClassData::create(class: MakerBundle::class, rootNamespace: 'App', suffix: $suffix);
 
         self::assertSame($expectedResult, $data->getClassName());
     }
@@ -74,7 +74,7 @@ class ClassDataTest extends TestCase
     /** @dataProvider namespaceDataProvider */
     public function testNamespace(string $class, ?string $rootNamespace, string $expectedNamespace, string $expectedFullClassName): void
     {
-        $class = ClassData::create($class, 'App\\');
+        $class = ClassData::create($class, 'App');
 
         if (null !== $rootNamespace) {
             $class->setRootNamespace($rootNamespace);
@@ -94,7 +94,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassName(): void
     {
-        $class = ClassData::create(class: 'Controller\\Foo', rootNamespace: 'App\\', suffix: 'Controller');
+        $class = ClassData::create(class: 'Controller\\Foo', rootNamespace: 'App', suffix: 'Controller');
         self::assertSame('FooController', $class->getClassName());
         self::assertSame('Foo', $class->getClassName(relative: false, withoutSuffix: true));
         self::assertSame('FooController', $class->getClassName(relative: true, withoutSuffix: false));
@@ -104,7 +104,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassNameRelativeNamespace(): void
     {
-        $class = ClassData::create(class: 'Controller\\Admin\\Foo', rootNamespace: 'App\\', suffix: 'Controller');
+        $class = ClassData::create(class: 'Controller\\Admin\\Foo', rootNamespace: 'App', suffix: 'Controller');
         self::assertSame('FooController', $class->getClassName());
         self::assertSame('Foo', $class->getClassName(relative: false, withoutSuffix: true));
         self::assertSame('Admin\FooController', $class->getClassName(relative: true, withoutSuffix: false));
@@ -114,7 +114,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassNameWithAbsoluteNamespace(): void
     {
-        $class = ClassData::create(class: '\\Foo\\Bar\\Admin\\Baz', rootNamespace: 'App\\', suffix: 'Controller');
+        $class = ClassData::create(class: '\\Foo\\Bar\\Admin\\Baz', rootNamespace: 'App', suffix: 'Controller');
         self::assertSame('BazController', $class->getClassName());
         self::assertSame('Foo\Bar\Admin', $class->getNamespace());
         self::assertSame('Foo\Bar\Admin\BazController', $class->getFullClassName());
@@ -123,7 +123,7 @@ class ClassDataTest extends TestCase
     /** @dataProvider fullClassNameProvider */
     public function testGetFullClassName(string $class, ?string $rootNamespace, bool $withoutRootNamespace, bool $withoutSuffix, string $expectedFullClassName): void
     {
-        $class = ClassData::create($class, rootNamespace: 'App\\', suffix: 'Controller');
+        $class = ClassData::create($class, rootNamespace: 'App', suffix: 'Controller');
 
         if (null !== $rootNamespace) {
             $class->setRootNamespace($rootNamespace);

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -20,7 +20,7 @@ class ClassDataTest extends TestCase
 {
     public function testStaticConstructor(): void
     {
-        $meta = ClassData::create(MakerBundle::class);
+        $meta = ClassData::create(MakerBundle::class, 'App\\');
 
         // Sanity check in case Maker's NS changes
         self::assertSame('Symfony\Bundle\MakerBundle\MakerBundle', MakerBundle::class);
@@ -32,14 +32,14 @@ class ClassDataTest extends TestCase
 
     public function testGetClassDeclaration(): void
     {
-        $meta = ClassData::create(MakerBundle::class);
+        $meta = ClassData::create(MakerBundle::class, 'App\\');
 
         self::assertSame('final class MakerBundle', $meta->getClassDeclaration());
     }
 
     public function testIsFinal(): void
     {
-        $meta = ClassData::create(MakerBundle::class);
+        $meta = ClassData::create(MakerBundle::class, 'App\\');
 
         // Default - isFinal - true
         self::assertSame('final class MakerBundle', $meta->getClassDeclaration());
@@ -51,7 +51,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassDeclarationWithExtends(): void
     {
-        $meta = ClassData::create(class: MakerBundle::class, extendsClass: MakerTestKernel::class);
+        $meta = ClassData::create(class: MakerBundle::class, rootNamespace: 'App\\', extendsClass: MakerTestKernel::class);
 
         self::assertSame('final class MakerBundle extends MakerTestKernel', $meta->getClassDeclaration());
     }
@@ -59,7 +59,7 @@ class ClassDataTest extends TestCase
     /** @dataProvider suffixDataProvider */
     public function testSuffix(?string $suffix, string $expectedResult): void
     {
-        $data = ClassData::create(class: MakerBundle::class, suffix: $suffix);
+        $data = ClassData::create(class: MakerBundle::class, rootNamespace: 'App\\', suffix: $suffix);
 
         self::assertSame($expectedResult, $data->getClassName());
     }
@@ -74,7 +74,7 @@ class ClassDataTest extends TestCase
     /** @dataProvider namespaceDataProvider */
     public function testNamespace(string $class, ?string $rootNamespace, string $expectedNamespace, string $expectedFullClassName): void
     {
-        $class = ClassData::create($class);
+        $class = ClassData::create($class, 'App\\');
 
         if (null !== $rootNamespace) {
             $class->setRootNamespace($rootNamespace);
@@ -94,7 +94,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassName(): void
     {
-        $class = ClassData::create(class: 'Controller\\Foo', suffix: 'Controller');
+        $class = ClassData::create(class: 'Controller\\Foo', rootNamespace: 'App\\', suffix: 'Controller');
         self::assertSame('FooController', $class->getClassName());
         self::assertSame('Foo', $class->getClassName(relative: false, withoutSuffix: true));
         self::assertSame('FooController', $class->getClassName(relative: true, withoutSuffix: false));
@@ -104,7 +104,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassNameRelativeNamespace(): void
     {
-        $class = ClassData::create(class: 'Controller\\Admin\\Foo', suffix: 'Controller');
+        $class = ClassData::create(class: 'Controller\\Admin\\Foo', rootNamespace: 'App\\', suffix: 'Controller');
         self::assertSame('FooController', $class->getClassName());
         self::assertSame('Foo', $class->getClassName(relative: false, withoutSuffix: true));
         self::assertSame('Admin\FooController', $class->getClassName(relative: true, withoutSuffix: false));
@@ -114,7 +114,7 @@ class ClassDataTest extends TestCase
 
     public function testGetClassNameWithAbsoluteNamespace(): void
     {
-        $class = ClassData::create(class: '\\Foo\\Bar\\Admin\\Baz', suffix: 'Controller');
+        $class = ClassData::create(class: '\\Foo\\Bar\\Admin\\Baz', rootNamespace: 'App\\', suffix: 'Controller');
         self::assertSame('BazController', $class->getClassName());
         self::assertSame('Foo\Bar\Admin', $class->getNamespace());
         self::assertSame('Foo\Bar\Admin\BazController', $class->getFullClassName());
@@ -123,7 +123,7 @@ class ClassDataTest extends TestCase
     /** @dataProvider fullClassNameProvider */
     public function testGetFullClassName(string $class, ?string $rootNamespace, bool $withoutRootNamespace, bool $withoutSuffix, string $expectedFullClassName): void
     {
-        $class = ClassData::create($class, suffix: 'Controller');
+        $class = ClassData::create($class, rootNamespace: 'App\\', suffix: 'Controller');
 
         if (null !== $rootNamespace) {
             $class->setRootNamespace($rootNamespace);

--- a/tests/Util/ComposerAutoloaderFinderTest.php
+++ b/tests/Util/ComposerAutoloaderFinderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Util;
 use Composer\Autoload\ClassLoader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Util\ComposerAutoloaderFinder;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 
 class ComposerAutoloaderFinderTest extends TestCase
 {
@@ -42,7 +43,7 @@ class ComposerAutoloaderFinderTest extends TestCase
     public function testGetClassLoader($psr0, $psr4)
     {
         $this->setupAutoloadFunctions($psr0, $psr4);
-        $loader = (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
+        $loader = (new ComposerAutoloaderFinder(new NamespacesHelper(['root' => static::$rootNamespace])))->getClassLoader();
 
         $this->assertInstanceOf(ClassLoader::class, $loader, 'Wrong ClassLoader found');
     }
@@ -56,7 +57,7 @@ class ComposerAutoloaderFinderTest extends TestCase
         };
 
         // throws \Exception
-        (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
+        (new ComposerAutoloaderFinder(new NamespacesHelper(['root' => static::$rootNamespace])))->getClassLoader();
     }
 
     /**

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Util;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+use Symfony\Bundle\MakerBundle\Util\NamespacesHelper;
 use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 
 /**
@@ -23,7 +24,7 @@ class TemplateComponentGeneratorTest extends TestCase
 {
     public function testRouteAttributes(): void
     {
-        $generator = new TemplateComponentGenerator(false, false, 'App');
+        $generator = new TemplateComponentGenerator(false, false, new NamespacesHelper());
 
         $expected = "    #[Route('/', name: 'app_home')]\n";
 
@@ -35,7 +36,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteMethods(string $expected, array $methods): void
     {
-        $generator = new TemplateComponentGenerator(false, false, 'App');
+        $generator = new TemplateComponentGenerator(false, false, new NamespacesHelper());
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -55,7 +56,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteIndentation(string $expected): void
     {
-        $generator = new TemplateComponentGenerator(false, false, 'App');
+        $generator = new TemplateComponentGenerator(false, false, new NamespacesHelper());
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -75,7 +76,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteTrailingNewLine(string $expected): void
     {
-        $generator = new TemplateComponentGenerator(false, false, 'App');
+        $generator = new TemplateComponentGenerator(false, false, new NamespacesHelper());
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -96,7 +97,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testGetFinalClassDeclaration(bool $finalClass, bool $finalEntity, bool $isEntity, string $expectedResult): void
     {
-        $generator = new TemplateComponentGenerator($finalClass, $finalEntity, 'App');
+        $generator = new TemplateComponentGenerator($finalClass, $finalEntity, new NamespacesHelper());
 
         $classData = ClassData::create(MakerBundle::class, isEntity: $isEntity);
 
@@ -119,7 +120,7 @@ class TemplateComponentGeneratorTest extends TestCase
 
     public function testConfiguresClassDataWithRootNamespace(): void
     {
-        $generator = new TemplateComponentGenerator(false, false, 'MakerTest');
+        $generator = new TemplateComponentGenerator(false, false, new NamespacesHelper(['root' => 'MakerTest']));
 
         $classData = ClassData::create(MakerBundle::class);
 

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -99,7 +99,7 @@ class TemplateComponentGeneratorTest extends TestCase
     {
         $generator = new TemplateComponentGenerator($finalClass, $finalEntity, new NamespacesHelper());
 
-        $classData = ClassData::create(MakerBundle::class, isEntity: $isEntity);
+        $classData = ClassData::create(MakerBundle::class, rootNamespace: 'App\\', isEntity: $isEntity);
 
         $generator->configureClass($classData);
 
@@ -122,7 +122,7 @@ class TemplateComponentGeneratorTest extends TestCase
     {
         $generator = new TemplateComponentGenerator(false, false, new NamespacesHelper(['root' => 'MakerTest']));
 
-        $classData = ClassData::create(MakerBundle::class);
+        $classData = ClassData::create(MakerBundle::class, 'App\\');
 
         $generator->configureClass($classData);
 


### PR DESCRIPTION
Hi there,

I'm working on projects which have the convention to put all the entities and repositories under `App\Database\Entity` and `App\Database\Repository`.

I've had a quick look at the issues and the PRs and I've seen other people asking for the same thing so I've decided to give it a go :)

Here is a simple solution to implement a helper to hold all the different namespaces, give it to the generator so it can be used in all makers.

This solution changes the constructor signatures of:
- `Symfony\Bundle\MakerBundle\Generator`
- `Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper`

Those objects are used with DI so it doesn't impact the existing makers but if anyone has extended them in their project it would then be a BC.

I leave this PR here and I'm looking forward to hearing from you.