### PR TITLE
More robust autoloader detection

### DIFF
--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -39,6 +39,9 @@ class MakerExtension extends Extension
 
         $rootNamespace = trim($config['root_namespace'], '\\');
 
+        $autoloaderFinderDefinition = $container->getDefinition('maker.autoloader_finder');
+        $autoloaderFinderDefinition->replaceArgument(0, $rootNamespace);
+
         $makeCommandDefinition = $container->getDefinition('maker.generator');
         $makeCommandDefinition->replaceArgument(1, $rootNamespace);
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,7 +13,9 @@
                 <argument>%kernel.project_dir%</argument>
             </service>
 
-            <service id="maker.autoloader_finder" class="Symfony\Bundle\MakerBundle\Util\ComposerAutoloaderFinder" />
+            <service id="maker.autoloader_finder" class="Symfony\Bundle\MakerBundle\Util\ComposerAutoloaderFinder" >
+                <argument /> <!-- root namespace -->
+            </service>
 
             <service id="maker.autoloader_util" class="Symfony\Bundle\MakerBundle\Util\AutoloaderUtil">
                 <argument type="service" id="maker.autoloader_finder" />

--- a/src/Util/ComposerAutoloaderFinder.php
+++ b/src/Util/ComposerAutoloaderFinder.php
@@ -20,9 +20,19 @@ use Symfony\Component\Debug\DebugClassLoader;
 class ComposerAutoloaderFinder
 {
     /**
+     * @var string
+     */
+    private $rootNamespace;
+
+    /**
      * @var ClassLoader|null
      */
     private $classLoader = null;
+
+    public function __construct(string $rootNamespace = 'App\\')
+    {
+        $this->rootNamespace = rtrim($rootNamespace, '\\').'\\';
+    }
 
     public function getClassLoader(): ClassLoader
     {
@@ -46,13 +56,15 @@ class ComposerAutoloaderFinder
 
         foreach ($autoloadFunctions as $autoloader) {
             if (\is_array($autoloader) && isset($autoloader[0]) && \is_object($autoloader[0])) {
-                if ($autoloader[0] instanceof ClassLoader) {
+                if ($autoloader[0] instanceof ClassLoader
+                    && isset($autoloader[0]->getPrefixesPsr4()[$this->rootNamespace])) {
                     return $autoloader[0];
                 }
 
                 if ($autoloader[0] instanceof DebugClassLoader
                     && \is_array($autoloader[0]->getClassLoader())
-                    && $autoloader[0]->getClassLoader()[0] instanceof ClassLoader) {
+                    && $autoloader[0]->getClassLoader()[0] instanceof ClassLoader
+                    && isset($autoloader[0]->getClassLoader()[0]->getPrefixesPsr4()[$this->rootNamespace])) {
                     return $autoloader[0]->getClassLoader()[0];
                 }
             }

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -205,7 +205,7 @@ class FunctionalTest extends MakerTestCase
             ])
             ->addExtraDependencies('orm')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeFormForEntity')
-		];
+        ];
 
         yield 'form_for_non_entity_dto' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeForm::class),

--- a/tests/Util/AutoloaderUtilTest.php
+++ b/tests/Util/AutoloaderUtilTest.php
@@ -87,6 +87,7 @@ class AutoloaderUtilTest extends TestCase
         /** @var \PHPUnit_Framework_MockObject_MockObject|ComposerAutoloaderFinder $finder */
         $finder = $this
             ->getMockBuilder(ComposerAutoloaderFinder::class)
+            ->setConstructorArgs(['App\\'])
             ->getMock();
 
         $finder

--- a/tests/Util/ComposerAutoloaderFinderTest.php
+++ b/tests/Util/ComposerAutoloaderFinderTest.php
@@ -10,6 +10,8 @@ class ComposerAutoloaderFinderTest extends TestCase
 {
     public static $getSplAutoloadFunctions = 'spl_autoload_functions';
 
+    private static $rootNamespace = 'Symfony\\Bundle\\MakerBundle\\';
+
     /**
      * @after
      */
@@ -20,7 +22,7 @@ class ComposerAutoloaderFinderTest extends TestCase
 
     public function testGetClassLoader()
     {
-        $loader = (new ComposerAutoloaderFinder())->getClassLoader();
+        $loader = (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
 
         $this->assertInstanceOf(ClassLoader::class, $loader, 'Wrong ClassLoader found');
     }
@@ -35,7 +37,7 @@ class ComposerAutoloaderFinderTest extends TestCase
         };
 
         // throws \Exception
-        (new ComposerAutoloaderFinder())->getClassLoader();
+        (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
     }
 }
 


### PR DESCRIPTION
When the project, or dependent package, adds a custom autoloader, e.g. PhpStan, the added autoloader will be returned instead of the one containing the project's autoloader when `ComposerAutoloaderFinder` iterates the autoloader list leading to the mysterious error:

```
Could not determine where to locate the new class "App\Controller\DeliciousPuppyController", maybe try with a full namespace like "\My\Full\Namespace\DeliciousPuppyController"
```

Fixes #196
Fixes #231
Fixes #313

Related #378