### PR TITLE
[make:*-test] Use the new WebTestAssertionsTrait methods in the generated functional tests

### DIFF
--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\CssSelector\CssSelectorConverter;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestAssertionsTrait;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -52,7 +53,9 @@ class MakeFunctionalTest extends AbstractMaker
         $generator->generateClass(
             $testClassNameDetails->getFullName(),
             'test/Functional.tpl.php',
-            []
+            [
+                'web_assertions_are_available' => class_exists(WebTestAssertionsTrait::class),
+            ]
         );
 
         $generator->writeChanges();

--- a/src/Resources/skeleton/test/Functional.tpl.php
+++ b/src/Resources/skeleton/test/Functional.tpl.php
@@ -11,7 +11,12 @@ class <?= $class_name ?> extends WebTestCase
         $client = static::createClient();
         $crawler = $client->request('GET', '/');
 
+<?php if($web_assertions_are_available) { ?>
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Hello World');
+<?php } else { ?>
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertContains('Hello World', $crawler->filter('h1')->text());
+<?php } ?>
     }
 }


### PR DESCRIPTION
Hi, this PR is to fix the way of calling the assertions static methods of PHPunit in the generated unit and functional tests.

[First commit](https://github.com/symfony/maker-bundle/commit/8f4af140015f6e30fe871fbacbc8c066901e0a25) : As pointed out in [this article](https://arkadiuszkondas.com/the-right-way-to-call-assertion-in-phpunit/), we should not be calling the assertions using `$this->assert*` but instead with `static::assert*`.

[Second commit](https://github.com/symfony/maker-bundle/commit/cfb0715dc99fb6cac45f08a6c3daefc3bafba542) : To go further, we can use [the new assertion API](https://github.com/symfony/symfony/pull/30813) provided by the `WebTestCase`.

I don't kown if this could be considered a BC break... but i hope not.