### PR TITLE
[Validator] Add encoding test to validateClassName

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -47,6 +47,12 @@ final class Validator
         ];
 
         foreach ($pieces as $piece) {
+            if (!mb_check_encoding($piece, 'UTF-8')) {
+                $errorMessage = $errorMessage ?: sprintf('"%s" is not a UTF-8-encoded string.', $piece);
+
+                throw new RuntimeCommandException($errorMessage);
+            }
+
             if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $piece)) {
                 $errorMessage = $errorMessage ?: sprintf('"%s" is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores)', $className);
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -62,4 +62,11 @@ class ValidatorTest extends TestCase
         $this->expectExceptionMessage('"Class" is a reserved keyword and thus cannot be used as class name in PHP.');
         Validator::validateClassName('App\Entity\Class');
     }
+
+    public function testInvalidEncodingInClassName()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('"�Controller" is not a UTF-8-encoded string.');
+        Validator::validateClassName(mb_convert_encoding('Ś', 'ISO-8859-2', 'UTF-8'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets    | #249
| Deprecations? | no
| License       | MIT

This checks if the input string is a UTF-8-encoded, and throws an exception if not.