### PR TITLE
Fixed error message when class is unknown on creating relation

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -477,9 +477,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             } elseif (class_exists($answeredEntityClass)) {
                 $targetEntityClass = $answeredEntityClass;
             } else {
-                $io->error(sprintf('Unknown class "%s"', $targetEntityClass));
-                $targetEntityClass = null;
-
+                $io->error(sprintf('Unknown class "%s"', $answeredEntityClass));
                 continue;
             }
         }


### PR DESCRIPTION
When creating a new relation, if the requested class is not found, the error message should refer to the answered class, not to the $targetEntityClass variable, as it is now, because this variable is always null at this point in the code, as per while condition, and it always prints an empty string in the message for the class. 