### PR TITLE
Turn off generated Voter and Normalizer by default

### DIFF
--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\CssSelector\CssSelectorConverter;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestAssertionsTrait;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -52,7 +53,9 @@ class MakeFunctionalTest extends AbstractMaker
         $generator->generateClass(
             $testClassNameDetails->getFullName(),
             'test/Functional.tpl.php',
-            []
+            [
+                'web_assertions_are_available' => class_exists(WebTestAssertionsTrait::class),
+            ]
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -32,6 +32,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validation;
@@ -313,6 +314,17 @@ final class MakeRegistrationForm extends AbstractMaker
                 ],
 EOF
             ],
+            'agreeTerms' => [
+                'type' => CheckboxType::class,
+                'options_code' => <<<EOF
+                'mapped' => false,
+                'constraints' => [
+                    new IsTrue([
+                        'message' => 'You should agree to our terms.',
+                    ]),
+                ],
+EOF
+            ],
         ];
 
         $this->formTypeRenderer->render(
@@ -322,6 +334,7 @@ EOF
             [
                 'Symfony\Component\Validator\Constraints\NotBlank',
                 'Symfony\Component\Validator\Constraints\Length',
+                'Symfony\Component\Validator\Constraints\IsTrue',
             ]
         );
 

--- a/src/Resources/skeleton/registration/twig_template.tpl.php
+++ b/src/Resources/skeleton/registration/twig_template.tpl.php
@@ -6,6 +6,7 @@
     {{ form_start(registrationForm) }}
         {{ form_row(registrationForm.<?= $username_field ?>) }}
         {{ form_row(registrationForm.plainPassword) }}
+        {{ form_row(registrationForm.agreeTerms) }}
 
         <button class="btn">Register</button>
     {{ form_end(registrationForm) }}

--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -10,10 +10,13 @@ class <?= $class_name ?> extends Voter
 {
     protected function supports($attribute, $subject)
     {
-        // replace with your own logic
-        // https://symfony.com/doc/current/security/voters.html
-        return in_array($attribute, ['POST_EDIT', 'POST_VIEW'])
-            && $subject instanceof \App\Entity\BlogPost;
+        // Replace with your own logic
+        // See https://symfony.com/doc/current/security/voters.html
+        //
+        // return in_array($attribute, ['POST_EDIT', 'POST_VIEW'])
+        //     && $subject instanceof \App\Entity\YourEntity;
+
+        return false;
     }
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)

--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -25,6 +25,11 @@ class <?= $class_name ?> implements NormalizerInterface
 
     public function supportsNormalization($data, $format = null): bool
     {
-        return $data instanceof \App\Entity\BlogPost;
+        // Replace with your own logic
+        // See https://symfony.com/doc/current/serializer/custom_normalizer.html
+        //
+        // return $data instanceof \App\Entity\YourEntity;
+
+        return false;
     }
 }

--- a/src/Resources/skeleton/test/Functional.tpl.php
+++ b/src/Resources/skeleton/test/Functional.tpl.php
@@ -11,7 +11,12 @@ class <?= $class_name ?> extends WebTestCase
         $client = static::createClient();
         $crawler = $client->request('GET', '/');
 
+<?php if($web_assertions_are_available) { ?>
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Hello World');
+<?php } else { ?>
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertContains('Hello World', $crawler->filter('h1')->text());
+<?php } ?>
     }
 }

--- a/src/Resources/skeleton/validator/Validator.tpl.php
+++ b/src/Resources/skeleton/validator/Validator.tpl.php
@@ -11,6 +11,11 @@ class <?= $class_name ?> extends ConstraintValidator
     {
         /* @var $constraint \<?= $constraint_class_name ?> */
 
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        // TODO: implement the validation here
         $this->context->buildViolation($constraint->message)
             ->setParameter('{{ value }}', $value)
             ->addViolation();

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -404,7 +404,7 @@ final class ClassSourceManipulator
             return 'null';
         }
 
-        if (\is_int($value)) {
+        if (\is_int($value) || '0' === $value) {
             return $value;
         }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -65,7 +65,7 @@ final class Validator
     public static function notBlank(string $value = null): string
     {
         if (null === $value || '' === $value) {
-            throw new RuntimeCommandException('This value cannot be blank');
+            throw new RuntimeCommandException('This value cannot be blank.');
         }
 
         return $value;
@@ -181,7 +181,7 @@ final class Validator
         self::notBlank($className);
 
         if (!class_exists($className)) {
-            $errorMessage = $errorMessage ?: sprintf('Class "%s" doesn\'t exists. Please enter existing full class name', $className);
+            $errorMessage = $errorMessage ?: sprintf('Class "%s" doesn\'t exist; please enter an existing full class name.', $className);
 
             throw new RuntimeCommandException($errorMessage);
         }
@@ -194,15 +194,15 @@ final class Validator
         self::notBlank($className);
 
         if (empty($entities)) {
-            throw new RuntimeCommandException('There is no registered entities. Please create entity before use this command');
+            throw new RuntimeCommandException('There is no registered entities; please create entity before use this command.');
         }
 
         if (0 === strpos($className, '\\')) {
-            self::classExists($className, sprintf('Entity "%s" doesn\'t exists. Please enter existing one or create new', $className));
+            self::classExists($className, sprintf('Entity "%s" doesn\'t exist; please enter an existing one or create a new one.', $className));
         }
 
         if (!\in_array($className, $entities)) {
-            throw new RuntimeCommandException(sprintf('Entity "%s" doesn\'t exists. Please enter existing one or create new', $className));
+            throw new RuntimeCommandException(sprintf('Entity "%s" doesn\'t exist; please enter an existing one or create a new one.', $className));
         }
 
         return $className;
@@ -213,7 +213,7 @@ final class Validator
         self::notBlank($className);
 
         if (class_exists($className)) {
-            throw new RuntimeCommandException(sprintf('Class "%s" already exists', $className));
+            throw new RuntimeCommandException(sprintf('Class "%s" already exists.', $className));
         }
 
         return $className;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -200,7 +200,7 @@ final class Validator
         self::notBlank($className);
 
         if (empty($entities)) {
-            throw new RuntimeCommandException('There is no registered entities; please create entity before use this command.');
+            throw new RuntimeCommandException('There are no registered entities; please create an entity before using this command.');
         }
 
         if (0 === strpos($className, '\\')) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -47,6 +47,12 @@ final class Validator
         ];
 
         foreach ($pieces as $piece) {
+            if (!mb_check_encoding($piece, 'UTF-8')) {
+                $errorMessage = $errorMessage ?: sprintf('"%s" is not a UTF-8-encoded string.', $piece);
+
+                throw new RuntimeCommandException($errorMessage);
+            }
+
             if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $piece)) {
                 $errorMessage = $errorMessage ?: sprintf('"%s" is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores)', $className);
 

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -237,6 +237,17 @@ class ClassSourceManipulatorTest extends TestCase
             ],
             'User_simple_prop_already_exists.php'
         ];
+
+        yield 'entity_field_property_zero' => [
+            'User_simple.php',
+            'decimal',
+            [
+                'type' => 'decimal',
+                'precision' => 6,
+                'scale' => 0,
+            ],
+            'User_simple_prop_zero.php'
+        ];
     }
 
     /**

--- a/tests/Util/fixtures/add_entity_field/User_simple_prop_zero.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_prop_zero.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="decimal", precision=6, scale=0)
+     */
+    private $decimal;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDecimal()
+    {
+        return $this->decimal;
+    }
+
+    public function setDecimal($decimal): self
+    {
+        $this->decimal = $decimal;
+
+        return $this;
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -66,7 +66,8 @@ class ValidatorTest extends TestCase
     public function testInvalidEncodingInClassName()
     {
         $this->expectException(RuntimeCommandException::class);
-        $this->expectExceptionMessage('"�Controller" is not a UTF-8-encoded string.');
-        Validator::validateClassName(mb_convert_encoding('Ś', 'ISO-8859-2', 'UTF-8'));
+        $invalidName = mb_convert_encoding('Fôö', 'ISO-8859-2', 'UTF-8');
+        $this->expectExceptionMessage(sprintf('"%s" is not a UTF-8-encoded string.', $invalidName));
+        Validator::validateClassName($invalidName);
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -62,4 +62,11 @@ class ValidatorTest extends TestCase
         $this->expectExceptionMessage('"Class" is a reserved keyword and thus cannot be used as class name in PHP.');
         Validator::validateClassName('App\Entity\Class');
     }
+
+    public function testInvalidEncodingInClassName()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('"�Controller" is not a UTF-8-encoded string.');
+        Validator::validateClassName(mb_convert_encoding('Ś', 'ISO-8859-2', 'UTF-8'));
+    }
 }

--- a/tests/fixtures/MakeRegistrationFormEntity/tests/RegistrationFormTest.php
+++ b/tests/fixtures/MakeRegistrationFormEntity/tests/RegistrationFormTest.php
@@ -5,7 +5,6 @@ namespace App\Tests;
 use Doctrine\ORM\EntityManager;
 use App\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
 
 class RegistrationFormTest extends WebTestCase
 {
@@ -24,6 +23,7 @@ class RegistrationFormTest extends WebTestCase
         $form = $crawler->selectButton('Register')->form();
         $form['registration_form[email]'] = 'ryan@symfonycasts.com';
         $form['registration_form[plainPassword]'] = '1234yaaay';
+        $form['registration_form[agreeTerms]'] = true;
         $client->submit($form);
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());
@@ -61,6 +61,10 @@ class RegistrationFormTest extends WebTestCase
         );
         $this->assertContains(
             'Your password should be at least 6 characters',
+            $client->getResponse()->getContent()
+        );
+        $this->assertContains(
+            'You should agree to our terms.',
             $client->getResponse()->getContent()
         );
     }


### PR DESCRIPTION
It fixes https://github.com/symfony/maker-bundle/issues/395. 
There are hardcoded non-existent classes for Voter and Normalizer.