### PR TITLE
[Voter] [Normalizer] Turn off generated Voter and Normalizer by default, also fix failed test

### DIFF
--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -10,10 +10,13 @@ class <?= $class_name ?> extends Voter
 {
     protected function supports($attribute, $subject)
     {
-        // replace with your own logic
-        // https://symfony.com/doc/current/security/voters.html
-        return in_array($attribute, ['POST_EDIT', 'POST_VIEW'])
-            && $subject instanceof \App\Entity\BlogPost;
+        // Replace with your own logic
+        // See https://symfony.com/doc/current/security/voters.html
+        //
+        // return in_array($attribute, ['POST_EDIT', 'POST_VIEW'])
+        //     && $subject instanceof \App\Entity\YourEntity;
+
+        return false;
     }
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)

--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -25,6 +25,11 @@ class <?= $class_name ?> implements NormalizerInterface
 
     public function supportsNormalization($data, $format = null): bool
     {
-        return $data instanceof \App\Entity\BlogPost;
+        // Replace with your own logic
+        // See https://symfony.com/doc/current/serializer/custom_normalizer.html
+        //
+        // return $data instanceof \App\Entity\YourEntity;
+
+        return false;
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -66,7 +66,9 @@ class ValidatorTest extends TestCase
     public function testInvalidEncodingInClassName()
     {
         $this->expectException(RuntimeCommandException::class);
-        $this->expectExceptionMessage('"�Controller" is not a UTF-8-encoded string.');
-        Validator::validateClassName(mb_convert_encoding('Ś', 'ISO-8859-2', 'UTF-8'));
+        $invalidName = mb_convert_encoding('Fôö', 'ISO-8859-2', 'UTF-8');
+        $this->expectExceptionMessage(sprintf('"%s" is not a UTF-8-encoded string.', $invalidName));
+        Validator::validateClassName($invalidName);
+
     }
 }


### PR DESCRIPTION
It fixes #395.
There are hardcoded non-existent classes for Voter and Normalizer.
Also, it fixes one failed test of Validator.

@lyrixx Sorry, I had to recreate the previous PR — https://github.com/symfony/maker-bundle/pull/414.