### PR TITLE
Fix test suite : missing dependency symfony/translation for auth tests

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -133,7 +133,7 @@ final class MakerTestEnvironment
                     \dirname($this->flexPath),
                     [
                         'FLEX_PATH' => $this->flexPath,
-                        'APP_PATH' => $this->path
+                        'APP_PATH' => $this->path,
                     ]
                 )
                     ->run();

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -432,6 +432,7 @@ class FunctionalTest extends MakerTestCase
             ->addExtraDependencies('doctrine')
             ->addExtraDependencies('twig')
             ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/translation')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorLoginFormUserEntity')
             ->configureDatabase()
             ->updateSchemaAfterCommand()
@@ -544,6 +545,7 @@ class FunctionalTest extends MakerTestCase
             ->addExtraDependencies('doctrine')
             ->addExtraDependencies('twig')
             ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/translation')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorLoginFormExistingController')
             ->configureDatabase()
             ->updateSchemaAfterCommand(),


### PR DESCRIPTION
Because of a change merged in the `symfony/twig-bridge` 13 days ago, the test-suite is KO (see https://github.com/symfony/twig-bridge/commit/52aa76480b775be0f6465b90ca9e3c2dccc8f3cd).

This solve the issue, let me know if there is a better way of doing so.