### PR TITLE
Switch to the new twigcs library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/http-kernel": "^3.4|^4.0"
     },
     "require-dev": {
-        "allocine/twigcs": "^3.0",
+        "friendsoftwig/twigcs": "^3.0",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.8",


### PR DESCRIPTION
Hello,

Since https://github.com/friendsoftwig/twigcs/pull/68, the tool moved from `allocine` to `friendsoftwig` and will receive new updates (bugfixes, new twig syntax support, ...) from here.

Here's a PR to handle this change ! 