### PR TITLE
Testing the unreleased patch and minor versions of Symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
           env: SYMFONY_PHPUNIT_VERSION=7.4
         - php: 7.1
           env: deps=high SYMFONY_PHPUNIT_VERSION=7.4
+        - php: 7.1
+          env: MAKER_TEST_VERSION=stable-dev
+        - php: 7.1
+          env: MAKER_TEST_VERSION=dev
         - php: 7.2
           env: deps=low
         - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,11 @@
         "symfony/http-kernel": "^3.4|^4.0"
     },
     "require-dev": {
-        "friendsoftwig/twigcs": "^3.0",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.8",
+        "friendsoftwig/twigcs": "^3.0",
+        "symfony/http-client": "^4.3",
         "symfony/phpunit-bridge": "^3.4|^4.0",
         "symfony/process": "^3.4|^4.0",
         "symfony/yaml": "^3.4|^4.0"

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -195,7 +195,7 @@ final class MakeCrud extends AbstractMaker
 
         foreach ($templates as $template => $variables) {
             $generator->generateTemplate(
-                $template.'.html.twig',
+                $templatesPath.'/'.$template.'.html.twig',
                 'crud/templates/'.$template.'.tpl.php',
                 $variables
             );

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -128,7 +128,14 @@ final class MakerTestEnvironment
         if (!$this->fs->exists($this->path)) {
             try {
                 // lets do some magic here git is faster than copy
-                MakerTestProcess::create(sprintf('git clone "%s" "%s"', $this->flexPath, $this->path), \dirname($this->flexPath))
+                MakerTestProcess::create(
+                    'git clone "$FLEX_PATH" "$APP_PATH"',
+                    \dirname($this->flexPath),
+                    [
+                        'FLEX_PATH' => $this->flexPath,
+                        'APP_PATH' => $this->path
+                    ]
+                )
                     ->run();
 
                 // install any missing dependencies
@@ -201,12 +208,11 @@ final class MakerTestEnvironment
         $testProcess = MakerTestProcess::create(
             sprintf('php bin/console %s %s --no-ansi', $this->testDetails->getMaker()::getCommandName(), $this->testDetails->getArgumentsString()),
             $this->path,
+            [
+                'SHELL_INTERACTIVE' => '1',
+            ],
             10
         );
-
-        $testProcess->setEnv([
-            'SHELL_INTERACTIVE' => '1',
-        ]);
 
         if ($userInputs = $this->testDetails->getInputs()) {
             $inputStream = new InputStream();

--- a/src/Test/MakerTestProcess.php
+++ b/src/Test/MakerTestProcess.php
@@ -22,24 +22,18 @@ final class MakerTestProcess
 {
     private $process;
 
-    private function __construct($commandLine, $cwd, $timeout)
+    private function __construct($commandLine, $cwd, array $envVars, $timeout)
     {
         $this->process = method_exists(Process::class, 'fromShellCommandline')
             ? Process::fromShellCommandline($commandLine, $cwd, null, null, $timeout)
             : new Process($commandLine, $cwd, null, null, $timeout);
-        $this->process->inheritEnvironmentVariables();
+
+        $this->process->setEnv($envVars);
     }
 
-    public static function create($commandLine, $cwd, $timeout = null): self
+    public static function create($commandLine, $cwd, array $envVars = [], $timeout = null): self
     {
-        return new self($commandLine, $cwd, $timeout);
-    }
-
-    public function setEnv($env): self
-    {
-        $this->process->setEnv($env);
-
-        return $this;
+        return new self($commandLine, $cwd, $envVars, $timeout);
     }
 
     public function setInput($input): self
@@ -49,9 +43,9 @@ final class MakerTestProcess
         return $this;
     }
 
-    public function run($allowToFail = false): self
+    public function run($allowToFail = false, array $envVars = []): self
     {
-        $this->process->run();
+        $this->process->run(null, $envVars);
 
         if (!$allowToFail && !$this->process->isSuccessful()) {
             throw new \Exception(sprintf(


### PR DESCRIPTION
Because the MakerBundle test suite actually creates new projects, generates code, and runs tests, it can often detect new bugs inside Symfony itself. In this PR, we will now test:

* test using Symfony's current version branch (e.g. `4.3`), to detect any possible issues with the next patch release (eg. 4.3.2)

* test using Symfony's next/dev branch (e.g. `4.4`), to detect any possible issues with the next minor release (4.4.0)

I've also activated a nightly CRON to execute the master branch. MakerBundle should accidentally help validate the Symfony experience :).

Cheers!