### PR TITLE
Fixing Travis - lowest deps was not working correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,32 +14,33 @@ matrix:
     fast_finish: true
     include:
         - php: 7.1
-          env: SYMFONY_PHPUNIT_VERSION=7.4
-        - php: 7.1
-          env: deps=high SYMFONY_PHPUNIT_VERSION=7.4
+        - php: 7.2
+        - php: 7.3
         - php: 7.1
           env: MAKER_TEST_VERSION=stable-dev
         - php: 7.1
           env: MAKER_TEST_VERSION=dev
-        - php: 7.2
+        - php: 7.1
           env: deps=low
-        - php: 7.3
 
     allow_failures:
           # Dev-master is allowed to fail.
         - env: STABILITY="dev"
 
 before_install:
-    - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
-    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
-    - composer install
+    - |
+      if [[ $deps = low ]]; then
+          composer update --prefer-lowest
+      else
+          composer update
+      fi
 
 install:
     - |
       # Install symfony/flex
       if [[ $deps = low ]]; then
-          export SYMFONY_REQUIRE='>=2.8'
+          export SYMFONY_REQUIRE='>=3.4'
       fi
       composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
     - ./vendor/bin/simple-phpunit install

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.8",
-        "friendsoftwig/twigcs": "^3.0",
+        "friendsoftwig/twigcs": "^3.1.2",
         "symfony/http-client": "^4.3",
-        "symfony/phpunit-bridge": "^3.4|^4.0",
+        "symfony/phpunit-bridge": "^3.4.19|^4.0",
         "symfony/process": "^3.4|^4.0",
         "symfony/security-core": "^3.4|^4.0",
         "symfony/yaml": "^3.4|^4.0"

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -87,7 +87,7 @@ final class MakeSubscriber extends AbstractMaker
                 'event' => class_exists($event) ? sprintf('%s::class', $eventClassName) : sprintf('\'%s\'', $event),
                 'event_full_class_name' => $eventFullClassName,
                 'event_arg' => $eventClassName ? sprintf('%s $event', $eventClassName) : '$event',
-                'method_name' => class_exists($event) ?  Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
+                'method_name' => class_exists($event) ? Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
             ]
         );
 


### PR DESCRIPTION
This may still not be perfect - mostly relying on `--prefer-lowest` from Composer, as I think most of the complexity of Symfony's Travis setup we do not need.