### PR TITLE
[CRUD] Prefix route names

### DIFF
--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -13,12 +13,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("<?= $route_path ?>")
+ * @Route("<?= $route_path ?>", name="<?= $route_name ?>_")
  */
 class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
     /**
-     * @Route("/", name="<?= $route_name ?>_index", methods={"GET"})
+     * @Route("/", name="index", methods={"GET"})
      */
 <?php if (isset($repository_full_class_name)): ?>
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>): Response
@@ -41,7 +41,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 <?php endif ?>
 
     /**
-     * @Route("/new", name="<?= $route_name ?>_new", methods={"GET","POST"})
+     * @Route("/new", name="new", methods={"GET","POST"})
      */
     public function new(Request $request): Response
     {
@@ -64,7 +64,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 
     /**
-     * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_show", methods={"GET"})
+     * @Route("/{<?= $entity_identifier ?>}", name="show", methods={"GET"})
      */
     public function show(<?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
@@ -74,7 +74,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 
     /**
-     * @Route("/{<?= $entity_identifier ?>}/edit", name="<?= $route_name ?>_edit", methods={"GET","POST"})
+     * @Route("/{<?= $entity_identifier ?>}/edit", name="edit", methods={"GET","POST"})
      */
     public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
@@ -94,7 +94,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 
     /**
-     * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_delete", methods={"DELETE"})
+     * @Route("/{<?= $entity_identifier ?>}", name="delete", methods={"DELETE"})
      */
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {


### PR DESCRIPTION
See https://symfony.com/blog/new-in-symfony-4-1-prefix-imported-route-names

> In Symfony 3.4 and 4.0 we added the possibility of prefixing the names of all the routes defined in a controller class with the name option in the main @Route annotation. In the following example, the route names will be blog_index and blog_post:
```php
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;

/** @Route("/blog", name="blog_") */
class BlogController extends Controller
{
    /** @Route("/", name="index") */
    public function indexAction() { ... }

    /** @Route("/posts/{slug}", name="post") */
    public function showAction(Post $post) { ... }
}
```