### PR TITLE
Use trait_exists when trying to figure out if a dependency is missing or not.

### DIFF
--- a/src/DependencyBuilder.php
+++ b/src/DependencyBuilder.php
@@ -136,7 +136,7 @@ final class DependencyBuilder
         $missingPackages = [];
         $missingOptionalPackages = [];
         foreach ($dependencies as $package) {
-            if (class_exists($package['class']) || interface_exists($package['class'])) {
+            if (class_exists($package['class']) || interface_exists($package['class']) || trait_exists($package['class'])) {
                 continue;
             }
             if (true === $package['required']) {

--- a/tests/DependencyBuilderTest.php
+++ b/tests/DependencyBuilderTest.php
@@ -42,6 +42,22 @@ class DependencyBuilderTest extends TestCase
         $this->assertSame([], $actualDeps);
     }
 
+    public function testGetMissingDependenciesBasedOnTraitsAndInterfaces()
+    {
+        $depBuilder = new DependencyBuilder();
+        $depBuilder->addClassDependency('DummyInterface', 'dummy-interface-package');
+        $depBuilder->addClassDependency('DummyTrait', 'dummy-trait-package');
+
+        $actualDeps = $depBuilder->getMissingDependencies();
+        $this->assertSame(['dummy-interface-package', 'dummy-trait-package'], $actualDeps);
+
+        eval('interface DummyInterface{}');
+        eval('trait DummyTrait{}');
+
+        $actualDeps = $depBuilder->getMissingDependencies();
+        $this->assertSame([], $actualDeps);
+    }
+
     /**
      * @dataProvider getMissingPackagesMessageTests
      */


### PR DESCRIPTION
This is related to [this comment](https://github.com/symfony/maker-bundle/pull/417#discussion_r293936255) by @weaverryan  
Let me know if this is not the way to go, or if the PR is missing something.