### PR TITLE
[make:*] Fluent setters bundle configuration option

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('root_namespace')->defaultValue('App')->end()
+                ->booleanNode('fluent_setters')->defaultValue(true)->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -38,12 +38,14 @@ class MakerExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $rootNamespace = trim($config['root_namespace'], '\\');
+        $fluentSetters = $config['fluent_setters'];
 
         $autoloaderFinderDefinition = $container->getDefinition('maker.autoloader_finder');
         $autoloaderFinderDefinition->replaceArgument(0, $rootNamespace);
 
         $makeCommandDefinition = $container->getDefinition('maker.generator');
         $makeCommandDefinition->replaceArgument(1, $rootNamespace);
+        $makeCommandDefinition->replaceArgument(2, $fluentSetters);
 
         $doctrineHelperDefinition = $container->getDefinition('maker.doctrine_helper');
         $doctrineHelperDefinition->replaceArgument(0, $rootNamespace.'\\Entity');

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -25,12 +25,14 @@ class Generator
     private $twigHelper;
     private $pendingOperations = [];
     private $namespacePrefix;
+    private $fluentSetters;
 
-    public function __construct(FileManager $fileManager, string $namespacePrefix)
+    public function __construct(FileManager $fileManager, string $namespacePrefix, bool $fluentSetters)
     {
         $this->fileManager = $fileManager;
         $this->twigHelper = new GeneratorTwigHelper($fileManager);
         $this->namespacePrefix = trim($namespacePrefix, '\\');
+        $this->fluentSetters = $fluentSetters;
     }
 
     /**
@@ -212,6 +214,11 @@ class Generator
     public function getRootNamespace(): string
     {
         return $this->namespacePrefix;
+    }
+
+    public function getFluentSetters(): bool
+    {
+        return $this->fluentSetters;
     }
 
     public function generateController(string $controllerClassName, string $controllerTemplatePath, array $parameters = []): string

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -283,7 +283,12 @@ final class MakeAuthenticator extends AbstractMaker
             throw new RuntimeCommandException(sprintf('Method "login" already exists on class %s', $controllerClassNameDetails->getFullName()));
         }
 
-        $manipulator = new ClassSourceManipulator($controllerSourceCode, true);
+        $manipulator = new ClassSourceManipulator(
+            $controllerSourceCode,
+            true,
+            true,
+            $this->generator->getFluentSetters()
+        );
 
         $securityControllerBuilder = new SecurityControllerBuilder();
         $securityControllerBuilder->addLoginMethod($manipulator);

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -56,7 +56,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         if (null === $generator) {
             @trigger_error(sprintf('Passing a "%s" instance as 4th argument is mandatory since version 1.5.', Generator::class), E_USER_DEPRECATED);
-            $this->generator = new Generator($fileManager, 'App\\');
+            $this->generator = new Generator($fileManager, 'App\\', true);
         } else {
             $this->generator = $generator;
         }

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -740,7 +740,12 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
     private function createClassManipulator(string $path, ConsoleStyle $io, bool $overwrite): ClassSourceManipulator
     {
-        $manipulator = new ClassSourceManipulator($this->fileManager->getFileContents($path), $overwrite);
+        $manipulator = new ClassSourceManipulator(
+            $this->fileManager->getFileContents($path),
+            $overwrite,
+            true,
+            $this->generator->getFluentSetters()
+        );
         $manipulator->setIo($io);
 
         return $manipulator;

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -48,11 +48,14 @@ final class MakeUser extends AbstractMaker
 
     private $configUpdater;
 
-    public function __construct(FileManager $fileManager, UserClassBuilder $userClassBuilder, SecurityConfigUpdater $configUpdater)
+    private $generator;
+
+    public function __construct(FileManager $fileManager, UserClassBuilder $userClassBuilder, SecurityConfigUpdater $configUpdater, Generator $generator)
     {
         $this->fileManager = $fileManager;
         $this->userClassBuilder = $userClassBuilder;
         $this->configUpdater = $configUpdater;
+        $this->generator = $generator;
     }
 
     public static function getCommandName(): string
@@ -149,7 +152,9 @@ final class MakeUser extends AbstractMaker
         // B) Implement UserInterface
         $manipulator = new ClassSourceManipulator(
             $this->fileManager->getFileContents($classPath),
-            true
+            true,
+            true,
+            $this->generator->getFluentSetters()
         );
         $manipulator->setIo($io);
         $this->userClassBuilder->addUserInterfaceImplementation(

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -92,6 +92,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.user_class_builder" />
                 <argument type="service" id="maker.security_config_updater" />
+                <argument type="service" id="maker.generator" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -44,6 +44,7 @@
             <service id="maker.generator" class="Symfony\Bundle\MakerBundle\Generator">
                 <argument type="service" id="maker.file_manager" />
                 <argument /> <!-- root namespace -->
+                <argument /> <!-- fluent setters -->
             </service>
 
             <service id="maker.entity_class_generator" class="Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator">

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -42,6 +42,8 @@ final class MakerTestDetails
 
     private $rootNamespace = 'App';
 
+    private $fluentSetters = true;
+
     private $requiredPhpVersion;
 
     private $guardAuthenticators = [];
@@ -78,6 +80,18 @@ final class MakerTestDetails
     public function changeRootNamespace(string $rootNamespace): self
     {
         $this->rootNamespace = trim($rootNamespace, '\\');
+
+        return $this;
+    }
+
+    public function getFluentSetters()
+    {
+        return $this->fluentSetters;
+    }
+
+    public function changeFluentSetters(bool $fluentSetters): self
+    {
+        $this->fluentSetters = $fluentSetters;
 
         return $this;
     }

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -27,7 +27,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'));
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App', true));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);
@@ -40,7 +40,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'));
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown', true));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -93,7 +93,7 @@ class EntityRegeneratorTest extends TestCase
         $regenerator = new EntityRegenerator(
             $doctrineHelper,
             $fileManager,
-            new Generator($fileManager, 'App\\'),
+            new Generator($fileManager, 'App\\', true),
             $overwrite
         );
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -17,7 +17,7 @@ class GeneratorTest extends TestCase
         $fileManager->expects($this->any())
             ->method('getNamespacePrefixForClass')
             ->willReturn('Foo');
-        $generator = new Generator($fileManager, 'App\\');
+        $generator = new Generator($fileManager, 'App\\', true);
         $classNameDetails = $generator->createClassNameDetails($name, $prefix, $suffix);
 
         $this->assertSame($expectedFullClassName, $classNameDetails->getFullName());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #297   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Based on #297

At the moment we cannot decide that we want to generate fluent or not setters.

I read the discussion in an issue and I added global configuration option:
```
maker:
  fluent_setters: false // default: true
```
