### PR TITLE
Remove php-parser workaround for adding interfaces

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -174,24 +174,8 @@ final class ClassSourceManipulator
     {
         $this->addUseStatementIfNecessary($interfaceName);
 
-        /*
-         * Changing the interface with this method, causes a problem
-         * with the "diff" pretty printer: it appears to rewrite
-         * all the internal class source, which removes line breaks.
-         *
-         * For that reason, we work around:
-         *  See: https://github.com/nikic/PHP-Parser/pull/527
-         */
-        //$this->getClassNode()->implements[] = new Node\Name(Str::getShortClassName($interfaceName));
-        //$this->updateSourceCodeFromNewStmts();
-
-        // purposely only works in simple cases: no extends or implements
-        $newCode = str_replace(
-            sprintf('class %s', $this->getClassNode()->name->toString()),
-            sprintf('class %s implements %s', $this->getClassNode()->name->toString(), Str::getShortClassName($interfaceName)),
-            $this->sourceCode
-        );
-        $this->setSourceCode($newCode);
+        $this->getClassNode()->implements[] = new Node\Name(Str::getShortClassName($interfaceName));
+        $this->updateSourceCodeFromNewStmts();
     }
 
     public function addAccessorMethod(string $propertyName, string $methodName, $returnType, bool $isReturnTypeNullable, array $commentLines = [], $typeCast = null)

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -554,6 +554,17 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
     }
 
+    public function testAddInterfaceToClassWithOtherInterface()
+    {
+        $source = file_get_contents(__DIR__.'/fixtures/source/User_simple_with_interface.php');
+        $expectedSource = file_get_contents(__DIR__.'/fixtures/implements_interface/User_simple_with_interface.php');
+
+        $manipulator = new ClassSourceManipulator($source);
+        $manipulator->addInterface(UserInterface::class);
+
+        $this->assertSame($expectedSource, $manipulator->getSourceCode());
+    }
+
     public function testAddMethodWithBody()
     {
         $source = file_get_contents(__DIR__.'/fixtures/source/EmptyController.php');

--- a/tests/Util/fixtures/implements_interface/User_simple_with_interface.php
+++ b/tests/Util/fixtures/implements_interface/User_simple_with_interface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @ORM\Entity()
+ */
+class User implements DummyInterface, UserInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Util/fixtures/source/User_simple_with_interface.php
+++ b/tests/Util/fixtures/source/User_simple_with_interface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class User implements DummyInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
The bug where this workaround was needed for was fixed, so let's remove this workaround. This will make sure adding an interface to a class with another interface will also work now.

See: https://github.com/nikic/PHP-Parser/pull/527