### PR TITLE
Fix unclosed div on login form skeleton

### DIFF
--- a/src/Resources/skeleton/authenticator/login_form.tpl.php
+++ b/src/Resources/skeleton/authenticator/login_form.tpl.php
@@ -10,7 +10,9 @@
 
 <?php if ($logout_setup): ?>
     {% if app.user %}
-        <div class="checkbox mb-3">You are logged in as {{ app.user.username }}, <a href="{{ path('app_logout') }}">Logout</a>
+        <div class="mb-3">
+            You are logged in as {{ app.user.username }}, <a href="{{ path('app_logout') }}">Logout</a>
+        </div>
     {% endif %}
 <?php endif; ?>
 


### PR DESCRIPTION
A little fix when generate guard auth in login form skeleton. "checkbox" class is also useless.