### PR TITLE
Require doctrine/annotations instead of sensio/framework-extra-bundle where sufficient

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -86,10 +86,8 @@ final class MakeController extends AbstractMaker
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
-            // we only need doctrine/annotations, which contains
-            // the recipe that loads annotation routes
             Annotation::class,
-            'annotations'
+            'doctrine/annotations'
         );
     }
 

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -254,10 +254,8 @@ final class MakeRegistrationForm extends AbstractMaker
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
-            // we only need doctrine/annotations, which contains
-            // the recipe that loads annotation routes
             Annotation::class,
-            'annotations'
+            'doctrine/annotations'
         );
 
         $dependencies->addClassDependency(


### PR DESCRIPTION
Fixes #442