### PR TITLE
[make:entity] Change arguments of adder and remover to variadic and iterate over them

### DIFF
--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
@@ -68,19 +68,23 @@ class Client extends BaseClient
         return $this->tags;
     }
 
-    public function addTag(Tag $tag): self
+    public function addTag(Tag ...$tags): self
     {
-        if (!$this->tags->contains($tag)) {
-            $this->tags[] = $tag;
+        foreach ($tags as $tag) {
+            if (!$this->tags->contains($tag)) {
+                $this->tags[] = $tag;
+            }
         }
 
         return $this;
     }
 
-    public function removeTag(Tag $tag): self
+    public function removeTag(Tag ...$tags): self
     {
-        if ($this->tags->contains($tag)) {
-            $this->tags->removeElement($tag);
+        foreach ($tags as $tag) {
+            if ($this->tags->contains($tag)) {
+                $this->tags->removeElement($tag);
+            }
         }
 
         return $this;

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
@@ -63,23 +63,27 @@ class User
         return $this->avatars;
     }
 
-    public function addAvatar(UserAvatar $avatar): self
+    public function addAvatar(UserAvatar ...$avatars): self
     {
-        if (!$this->avatars->contains($avatar)) {
-            $this->avatars[] = $avatar;
-            $avatar->setUser($this);
+        foreach ($avatars as $avatar) {
+            if (!$this->avatars->contains($avatar)) {
+                $this->avatars[] = $avatar;
+                $avatar->setUser($this);
+            }
         }
 
         return $this;
     }
 
-    public function removeAvatar(UserAvatar $avatar): self
+    public function removeAvatar(UserAvatar ...$avatars): self
     {
-        if ($this->avatars->contains($avatar)) {
-            $this->avatars->removeElement($avatar);
-            // set the owning side to null (unless already changed)
-            if ($avatar->getUser() === $this) {
-                $avatar->setUser(null);
+        foreach ($avatars as $avatar) {
+            if ($this->avatars->contains($avatar)) {
+                $this->avatars->removeElement($avatar);
+                // set the owning side to null (unless already changed)
+                if ($avatar->getUser() === $this) {
+                    $avatar->setUser(null);
+                }
             }
         }
 
@@ -99,19 +103,23 @@ class User
         return $this->tags;
     }
 
-    public function addTag(Tag $tag): self
+    public function addTag(Tag ...$tags): self
     {
-        if (!$this->tags->contains($tag)) {
-            $this->tags[] = $tag;
+        foreach ($tags as $tag) {
+            if (!$this->tags->contains($tag)) {
+                $this->tags[] = $tag;
+            }
         }
 
         return $this;
     }
 
-    public function removeTag(Tag $tag): self
+    public function removeTag(Tag ...$tags): self
     {
-        if ($this->tags->contains($tag)) {
-            $this->tags->removeElement($tag);
+        foreach ($tags as $tag) {
+            if ($this->tags->contains($tag)) {
+                $this->tags->removeElement($tag);
+            }
         }
 
         return $this;

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
@@ -68,19 +68,23 @@ class Client extends BaseClient
         return $this->tags;
     }
 
-    public function addTag(Tag $tag): self
+    public function addTag(Tag ...$tags): self
     {
-        if (!$this->tags->contains($tag)) {
-            $this->tags[] = $tag;
+        foreach ($tags as $tag) {
+            if (!$this->tags->contains($tag)) {
+                $this->tags[] = $tag;
+            }
         }
 
         return $this;
     }
 
-    public function removeTag(Tag $tag): self
+    public function removeTag(Tag ...$tags): self
     {
-        if ($this->tags->contains($tag)) {
-            $this->tags->removeElement($tag);
+        foreach ($tags as $tag) {
+            if ($this->tags->contains($tag)) {
+                $this->tags->removeElement($tag);
+            }
         }
 
         return $this;

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
@@ -70,23 +70,27 @@ class User
         return $this->avatars;
     }
 
-    public function addAvatar(UserAvatar $avatar): self
+    public function addAvatar(UserAvatar ...$avatars): self
     {
-        if (!$this->avatars->contains($avatar)) {
-            $this->avatars[] = $avatar;
-            $avatar->setUser($this);
+        foreach ($avatars as $avatar) {
+            if (!$this->avatars->contains($avatar)) {
+                $this->avatars[] = $avatar;
+                $avatar->setUser($this);
+            }
         }
 
         return $this;
     }
 
-    public function removeAvatar(UserAvatar $avatar): self
+    public function removeAvatar(UserAvatar ...$avatars): self
     {
-        if ($this->avatars->contains($avatar)) {
-            $this->avatars->removeElement($avatar);
-            // set the owning side to null (unless already changed)
-            if ($avatar->getUser() === $this) {
-                $avatar->setUser(null);
+        foreach ($avatars as $avatar) {
+            if ($this->avatars->contains($avatar)) {
+                $this->avatars->removeElement($avatar);
+                // set the owning side to null (unless already changed)
+                if ($avatar->getUser() === $this) {
+                    $avatar->setUser(null);
+                }
             }
         }
 
@@ -106,19 +110,23 @@ class User
         return $this->tags;
     }
 
-    public function addTag(Tag $tag): self
+    public function addTag(Tag ...$tags): self
     {
-        if (!$this->tags->contains($tag)) {
-            $this->tags[] = $tag;
+        foreach ($tags as $tag) {
+            if (!$this->tags->contains($tag)) {
+                $this->tags[] = $tag;
+            }
         }
 
         return $this;
     }
 
-    public function removeTag(Tag $tag): self
+    public function removeTag(Tag ...$tags): self
     {
-        if ($this->tags->contains($tag)) {
-            $this->tags->removeElement($tag);
+        foreach ($tags as $tag) {
+            if ($this->tags->contains($tag)) {
+                $this->tags->removeElement($tag);
+            }
         }
 
         return $this;

--- a/tests/Doctrine/fixtures/expected_xml/src/Entity/UserXml.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Entity/UserXml.php
@@ -44,23 +44,27 @@ class UserXml
         return $this->avatars;
     }
 
-    public function addAvatar(UserAvatar $avatar): self
+    public function addAvatar(UserAvatar ...$avatars): self
     {
-        if (!$this->avatars->contains($avatar)) {
-            $this->avatars[] = $avatar;
-            $avatar->setUser($this);
+        foreach ($avatars as $avatar) {
+            if (!$this->avatars->contains($avatar)) {
+                $this->avatars[] = $avatar;
+                $avatar->setUser($this);
+            }
         }
 
         return $this;
     }
 
-    public function removeAvatar(UserAvatar $avatar): self
+    public function removeAvatar(UserAvatar ...$avatars): self
     {
-        if ($this->avatars->contains($avatar)) {
-            $this->avatars->removeElement($avatar);
-            // set the owning side to null (unless already changed)
-            if ($avatar->getUser() === $this) {
-                $avatar->setUser(null);
+        foreach ($avatars as $avatar) {
+            if ($this->avatars->contains($avatar)) {
+                $this->avatars->removeElement($avatar);
+                // set the owning side to null (unless already changed)
+                if ($avatar->getUser() === $this) {
+                    $avatar->setUser(null);
+                }
             }
         }
 

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse.php
@@ -41,21 +41,25 @@ class User
         return $this->recipes;
     }
 
-    public function addRecipe(Recipe $recipe): self
+    public function addRecipe(Recipe ...$recipes): self
     {
-        if (!$this->recipes->contains($recipe)) {
-            $this->recipes[] = $recipe;
-            $recipe->addFood($this);
+        foreach ($recipes as $recipe) {
+            if (!$this->recipes->contains($recipe)) {
+                $this->recipes[] = $recipe;
+                $recipe->addFood($this);
+            }
         }
 
         return $this;
     }
 
-    public function removeRecipe(Recipe $recipe): self
+    public function removeRecipe(Recipe ...$recipes): self
     {
-        if ($this->recipes->contains($recipe)) {
-            $this->recipes->removeElement($recipe);
-            $recipe->removeFood($this);
+        foreach ($recipes as $recipe) {
+            if ($this->recipes->contains($recipe)) {
+                $this->recipes->removeElement($recipe);
+                $recipe->removeFood($this);
+            }
         }
 
         return $this;

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_no_inverse.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_no_inverse.php
@@ -41,19 +41,23 @@ class User
         return $this->recipes;
     }
 
-    public function addRecipe(Recipe $recipe): self
+    public function addRecipe(Recipe ...$recipes): self
     {
-        if (!$this->recipes->contains($recipe)) {
-            $this->recipes[] = $recipe;
+        foreach ($recipes as $recipe) {
+            if (!$this->recipes->contains($recipe)) {
+                $this->recipes[] = $recipe;
+            }
         }
 
         return $this;
     }
 
-    public function removeRecipe(Recipe $recipe): self
+    public function removeRecipe(Recipe ...$recipes): self
     {
-        if ($this->recipes->contains($recipe)) {
-            $this->recipes->removeElement($recipe);
+        foreach ($recipes as $recipe) {
+            if ($this->recipes->contains($recipe)) {
+                $this->recipes->removeElement($recipe);
+            }
         }
 
         return $this;

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_owning.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_owning.php
@@ -41,19 +41,23 @@ class User
         return $this->recipes;
     }
 
-    public function addRecipe(Recipe $recipe): self
+    public function addRecipe(Recipe ...$recipes): self
     {
-        if (!$this->recipes->contains($recipe)) {
-            $this->recipes[] = $recipe;
+        foreach ($recipes as $recipe) {
+            if (!$this->recipes->contains($recipe)) {
+                $this->recipes[] = $recipe;
+            }
         }
 
         return $this;
     }
 
-    public function removeRecipe(Recipe $recipe): self
+    public function removeRecipe(Recipe ...$recipes): self
     {
-        if ($this->recipes->contains($recipe)) {
-            $this->recipes->removeElement($recipe);
+        foreach ($recipes as $recipe) {
+            if ($this->recipes->contains($recipe)) {
+                $this->recipes->removeElement($recipe);
+            }
         }
 
         return $this;

--- a/tests/Util/fixtures/add_one_to_many_relation/User_simple.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_simple.php
@@ -41,23 +41,27 @@ class User
         return $this->avatarPhotos;
     }
 
-    public function addAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    public function addAvatarPhoto(UserAvatarPhoto ...$avatarPhotos): self
     {
-        if (!$this->avatarPhotos->contains($avatarPhoto)) {
-            $this->avatarPhotos[] = $avatarPhoto;
-            $avatarPhoto->setUser($this);
+        foreach ($avatarPhotos as $avatarPhoto) {
+            if (!$this->avatarPhotos->contains($avatarPhoto)) {
+                $this->avatarPhotos[] = $avatarPhoto;
+                $avatarPhoto->setUser($this);
+            }
         }
 
         return $this;
     }
 
-    public function removeAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    public function removeAvatarPhoto(UserAvatarPhoto ...$avatarPhotos): self
     {
-        if ($this->avatarPhotos->contains($avatarPhoto)) {
-            $this->avatarPhotos->removeElement($avatarPhoto);
-            // set the owning side to null (unless already changed)
-            if ($avatarPhoto->getUser() === $this) {
-                $avatarPhoto->setUser(null);
+        foreach ($avatarPhotos as $avatarPhoto) {
+            if ($this->avatarPhotos->contains($avatarPhoto)) {
+                $this->avatarPhotos->removeElement($avatarPhoto);
+                // set the owning side to null (unless already changed)
+                if ($avatarPhoto->getUser() === $this) {
+                    $avatarPhoto->setUser(null);
+                }
             }
         }
 

--- a/tests/Util/fixtures/add_one_to_many_relation/User_simple_orphan_removal.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_simple_orphan_removal.php
@@ -41,23 +41,27 @@ class User
         return $this->avatarPhotos;
     }
 
-    public function addAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    public function addAvatarPhoto(UserAvatarPhoto ...$avatarPhotos): self
     {
-        if (!$this->avatarPhotos->contains($avatarPhoto)) {
-            $this->avatarPhotos[] = $avatarPhoto;
-            $avatarPhoto->setUser($this);
+        foreach ($avatarPhotos as $avatarPhoto) {
+            if (!$this->avatarPhotos->contains($avatarPhoto)) {
+                $this->avatarPhotos[] = $avatarPhoto;
+                $avatarPhoto->setUser($this);
+            }
         }
 
         return $this;
     }
 
-    public function removeAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    public function removeAvatarPhoto(UserAvatarPhoto ...$avatarPhotos): self
     {
-        if ($this->avatarPhotos->contains($avatarPhoto)) {
-            $this->avatarPhotos->removeElement($avatarPhoto);
-            // set the owning side to null (unless already changed)
-            if ($avatarPhoto->getUser() === $this) {
-                $avatarPhoto->setUser(null);
+        foreach ($avatarPhotos as $avatarPhoto) {
+            if ($this->avatarPhotos->contains($avatarPhoto)) {
+                $this->avatarPhotos->removeElement($avatarPhoto);
+                // set the owning side to null (unless already changed)
+                if ($avatarPhoto->getUser() === $this) {
+                    $avatarPhoto->setUser(null);
+                }
             }
         }
 

--- a/tests/Util/fixtures/add_one_to_many_relation/User_with_use_statements.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_with_use_statements.php
@@ -43,23 +43,27 @@ class User
         return $this->avatarPhotos;
     }
 
-    public function addAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    public function addAvatarPhoto(UserAvatarPhoto ...$avatarPhotos): self
     {
-        if (!$this->avatarPhotos->contains($avatarPhoto)) {
-            $this->avatarPhotos[] = $avatarPhoto;
-            $avatarPhoto->setUser($this);
+        foreach ($avatarPhotos as $avatarPhoto) {
+            if (!$this->avatarPhotos->contains($avatarPhoto)) {
+                $this->avatarPhotos[] = $avatarPhoto;
+                $avatarPhoto->setUser($this);
+            }
         }
 
         return $this;
     }
 
-    public function removeAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    public function removeAvatarPhoto(UserAvatarPhoto ...$avatarPhotos): self
     {
-        if ($this->avatarPhotos->contains($avatarPhoto)) {
-            $this->avatarPhotos->removeElement($avatarPhoto);
-            // set the owning side to null (unless already changed)
-            if ($avatarPhoto->getUser() === $this) {
-                $avatarPhoto->setUser(null);
+        foreach ($avatarPhotos as $avatarPhoto) {
+            if ($this->avatarPhotos->contains($avatarPhoto)) {
+                $this->avatarPhotos->removeElement($avatarPhoto);
+                // set the owning side to null (unless already changed)
+                if ($avatarPhoto->getUser() === $this) {
+                    $avatarPhoto->setUser(null);
+                }
             }
         }
 


### PR DESCRIPTION
Hi,

The goal of this PR is to use the powerful variadic operator with the arguments of generated adders and removers in entities.

Example :
``` php
public function addTag(Tag ...$tags): self
{
    foreach ($tags as $tag) {
        if (!$this->tags->contains($tag)) {
            $this->tags[] = $tag;
        }
    }

    return $this;
}
```

This is something we already do in my company and I really like this approach. It allows to quickly add an array of entity in the collection without iterating over it.

Something really great with this change is that it allows to continue using them the old way :

``` php
// This will still works
$article->addTag($tag);

// Or in order to add an array like before
foreach ($tags as $tag) {
    $article->addTag($tag);
}

// Add an array without iterate over items
$article->addTag(...$tags);

// Or even
$article->addTag($firstTag, $secondTag);
```

The generated code is already ok but I didn't write test yet. This is something I think is necessary but 
I'm not used to doing. If someone could lead me in the right file to do it or even contribute, it will be great.

I tried to edit the "tests/Util/fixtures/" files to pass the tests but it didn't change anything. Is it necessary?

Thanks you in advance!

---

**Edit :**
I changed the files used to compare the generated code. Now tests pass, but I should  also add test in order to check if we can use the variadic operator features combine with array unpacking.