### PR TITLE
Add access_control rule for form login auth

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -226,7 +226,8 @@ final class MakeAuthenticator extends AbstractMaker
                 $entryPoint,
                 $input->getArgument('authenticator-class'),
                 $input->hasArgument('logout-setup') ? $input->getArgument('logout-setup') : false,
-                $this->useSecurity52
+                $this->useSecurity52,
+                self::AUTH_TYPE_FORM_LOGIN === $input->getArgument('authenticator-type')
             );
             $generator->dumpFile($path, $newYaml);
             $securityYamlUpdated = true;

--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -137,7 +137,7 @@ final class SecurityConfigUpdater
         $accessControlRules = $newData['security']['access_control'] ?? [];
 
         foreach ($accessControlRules as $rule) {
-            if ('^/login$' === $rule['path']) {
+            if (0 === strpos($rule['path'], '^/login')) {
                 $addAccessControlRule = false;
                 break;
             }

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -193,7 +193,7 @@ class SecurityConfigUpdaterTest extends TestCase
             'simple_security_with_access_control.yaml',
             false,
             false,
-            true
+            true,
         ];
 
         yield 'simple_security_without_access_control' => [
@@ -203,7 +203,7 @@ class SecurityConfigUpdaterTest extends TestCase
             'simple_security.yaml',
             false,
             false,
-            true
+            true,
         ];
     }
 

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -100,13 +100,13 @@ class SecurityConfigUpdaterTest extends TestCase
     /**
      * @dataProvider getAuthenticatorTests
      */
-    public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename, bool $logoutSetup, bool $useSecurity51)
+    public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename, bool $logoutSetup, bool $useSecurity51, bool $addAccessControl = false)
     {
         $this->createLogger();
 
         $updater = new SecurityConfigUpdater($this->ysmLogger);
         $source = file_get_contents(__DIR__.'/yaml_fixtures/source/'.$startingSourceFilename);
-        $actualSource = $updater->updateForAuthenticator($source, $firewallName, $entryPoint, 'App\\Security\\AppCustomAuthenticator', $logoutSetup, $useSecurity51);
+        $actualSource = $updater->updateForAuthenticator($source, $firewallName, $entryPoint, 'App\\Security\\AppCustomAuthenticator', $logoutSetup, $useSecurity51, $addAccessControl);
         $expectedSource = file_get_contents(__DIR__.'/yaml_fixtures/expected_authenticator/'.$expectedSourceFilename);
 
         $this->assertSame($expectedSource, $actualSource);
@@ -184,6 +184,26 @@ class SecurityConfigUpdaterTest extends TestCase
             'security_52_with_multiple_authenticators.yaml',
             false,
             true,
+        ];
+
+        yield 'simple_security_with_access_control' => [
+            'main',
+            null,
+            'simple_security_with_access_control.yaml',
+            'simple_security_with_access_control.yaml',
+            false,
+            false,
+            true
+        ];
+
+        yield 'simple_security_without_access_control' => [
+            'main',
+            null,
+            'simple_security_with_added_access_control.yaml',
+            'simple_security.yaml',
+            false,
+            false,
+            true
         ];
     }
 

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_access_control.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_access_control.yaml
@@ -6,10 +6,11 @@ security:
     firewalls:
         dev: ~
         main:
-            anonymous: true
+            anonymous: lazy
             guard:
                 authenticators:
                     - App\Security\AppCustomAuthenticator
+
 
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_access_control.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_access_control.yaml
@@ -1,0 +1,17 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main:
+            anonymous: true
+            guard:
+                authenticators:
+                    - App\Security\AppCustomAuthenticator
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+        - { path: ^/login$, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_added_access_control.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_added_access_control.yaml
@@ -1,0 +1,16 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main:
+            anonymous: true
+            guard:
+                authenticators:
+                    - App\Security\AppCustomAuthenticator
+    access_control:
+        -
+            path: ^/login$
+            roles: IS_AUTHENTICATED_ANONYMOUSLY

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_added_access_control.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_added_access_control.yaml
@@ -6,7 +6,7 @@ security:
     firewalls:
         dev: ~
         main:
-            anonymous: true
+            anonymous: lazy
             guard:
                 authenticators:
                     - App\Security\AppCustomAuthenticator

--- a/tests/Security/yaml_fixtures/source/simple_security_with_access_control.yaml
+++ b/tests/Security/yaml_fixtures/source/simple_security_with_access_control.yaml
@@ -1,0 +1,13 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main: ~
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+        - { path: ^/login$, roles: IS_AUTHENTICATED_ANONYMOUSLY }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #396 
| License       | MIT


Add `access_control` rule when `make:auth` command is used with login form authenticator