### PR TITLE
Fix Replace Route Name variable by Templates Path variable for include path into twig template 

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -171,7 +171,7 @@ final class MakeCrud extends AbstractMaker
                 'entity_twig_var_singular' => $entityTwigVarSingular,
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                 'route_name' => $routeName,
-                'templates_path' => $templatesPath
+                'templates_path' => $templatesPath,
             ],
             'index' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
@@ -184,7 +184,7 @@ final class MakeCrud extends AbstractMaker
             'new' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
                 'route_name' => $routeName,
-                'templates_path' => $templatesPath
+                'templates_path' => $templatesPath,
             ],
             'show' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -171,6 +171,7 @@ final class MakeCrud extends AbstractMaker
                 'entity_twig_var_singular' => $entityTwigVarSingular,
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath
             ],
             'index' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
@@ -183,6 +184,7 @@ final class MakeCrud extends AbstractMaker
             'new' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath
             ],
             'show' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
@@ -190,6 +192,7 @@ final class MakeCrud extends AbstractMaker
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                 'entity_fields' => $entityDoctrineDetails->getDisplayFields(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath,
             ],
         ];
 

--- a/src/Resources/skeleton/crud/templates/edit.tpl.php
+++ b/src/Resources/skeleton/crud/templates/edit.tpl.php
@@ -3,9 +3,9 @@
 {% block body %}
     <h1>Edit <?= $entity_class_name ?></h1>
 
-    {{ include('<?= $route_name ?>/_form.html.twig', {'button_label': 'Update'}) }}
+    {{ include('<?= $templates_path ?>/_form.html.twig', {'button_label': 'Update'}) }}
 
     <a href="{{ path('<?= $route_name ?>_index') }}">back to list</a>
 
-    {{ include('<?= $route_name ?>/_delete_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_delete_form.html.twig') }}
 {% endblock %}

--- a/src/Resources/skeleton/crud/templates/new.tpl.php
+++ b/src/Resources/skeleton/crud/templates/new.tpl.php
@@ -3,7 +3,7 @@
 {% block body %}
     <h1>Create new <?= $entity_class_name ?></h1>
 
-    {{ include('<?= $route_name ?>/_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_form.html.twig') }}
 
     <a href="{{ path('<?= $route_name ?>_index') }}">back to list</a>
 {% endblock %}

--- a/src/Resources/skeleton/crud/templates/show.tpl.php
+++ b/src/Resources/skeleton/crud/templates/show.tpl.php
@@ -18,5 +18,5 @@
 
     <a href="{{ path('<?= $route_name ?>_edit', {'<?= $entity_identifier ?>': <?= $entity_twig_var_singular ?>.<?= $entity_identifier ?>}) }}">edit</a>
 
-    {{ include('<?= $route_name ?>/_delete_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_delete_form.html.twig') }}
 {% endblock %}

--- a/tests/fixtures/MakeAuthenticatorLoginFormExistingController/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormExistingController/src/Entity/User.php
@@ -33,6 +33,8 @@ class User implements UserInterface
      */
     private $password;
 
+    private $userEmail;
+
     public function getId()
     {
         return $this->id;
@@ -100,6 +102,21 @@ class User implements UserInterface
     public function getSalt()
     {
         // not needed when using the "bcrypt" algorithm in security.yaml
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserEmail(): string
+    {
+        return $this->userEmail;
+    }
+
+    public function setUserEmail(string $userEmail): self
+    {
+        $this->userEmail = $userEmail;
+
+        return $this;
     }
 
     /**

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntityLogout/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntityLogout/src/Entity/User.php
@@ -22,6 +22,8 @@ class User implements UserInterface
      */
     private $userEmail;
 
+    private $email;
+
     /**
      * @ORM\Column(type="array")
      */
@@ -46,6 +48,18 @@ class User implements UserInterface
     public function setUserEmail(string $userEmail): self
     {
         $this->userEmail = $userEmail;
+
+        return $this;
+    }
+
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
 
         return $this;
     }

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntityNoEncoder/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntityNoEncoder/src/Entity/User.php
@@ -33,6 +33,8 @@ class User implements UserInterface
      */
     private $password;
 
+    private $userEmail;
+
     public function getId()
     {
         return $this->id;
@@ -100,6 +102,21 @@ class User implements UserInterface
     public function getSalt()
     {
         // not needed when using the "bcrypt" algorithm in security.yaml
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserEmail(): string
+    {
+        return $this->userEmail;
+    }
+
+    public function setUserEmail(string $userEmail): self
+    {
+        $this->userEmail = $userEmail;
+
+        return $this;
     }
 
     /**

--- a/tests/fixtures/MakeEntityManyToMany/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToMany/src/Entity/User.php
@@ -21,6 +21,8 @@ class User
      */
     private $firstName;
 
+    private $photos = [];
+
     /**
      * @ORM\Column(type="datetime", nullable=true)
      */
@@ -39,6 +41,18 @@ class User
     public function setFirstName(?string $firstName)
     {
         $this->firstName = $firstName;
+    }
+
+    public function getPhotos(): array
+    {
+        return $this->photos;
+    }
+
+    public function setPhotos(array $photos): self
+    {
+        $this->photos = $photos;
+
+        return $this;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface

--- a/tests/fixtures/MakeEntityManyToMany/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToMany/src/Entity/User.php
@@ -21,6 +21,9 @@ class User
      */
     private $firstName;
 
+    /**
+     * @ORM\OneToMany(targetEntity="UserAvatarPhoto", mappedBy="user")
+     */
     private $photos = [];
 
     /**

--- a/tests/fixtures/MakeEntityManyToMany/src/Entity/UserAvatarPhoto.php
+++ b/tests/fixtures/MakeEntityManyToMany/src/Entity/UserAvatarPhoto.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class UserAvatarPhoto
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/fixtures/MakeEntityManyToMany/src/Entity/UserAvatarPhoto.php
+++ b/tests/fixtures/MakeEntityManyToMany/src/Entity/UserAvatarPhoto.php
@@ -16,8 +16,24 @@ class UserAvatarPhoto
      */
     private $id;
 
+    /**
+     * @ORM\ManyToOne(targetEntity="User", inversedBy="photos", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $user;
+
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    public function setUser($user)
+    {
+        $this->user = $user;
     }
 }

--- a/tests/fixtures/MakeEntityManyToOne/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToOne/src/Entity/User.php
@@ -26,6 +26,8 @@ class User
      */
     private $name;
 
+    private $userAvatarPhotos = [];
+
     /**
      * @ORM\Column(type="datetime", nullable=true)
      */
@@ -54,6 +56,18 @@ class User
     public function setName(?string $name)
     {
         $this->name = $name;
+    }
+
+    public function getUserAvatarPhotos(): array
+    {
+        return $this->userAvatarPhotos;
+    }
+
+    public function setUserAvatarPhotos(array $userAvatarPhotos): self
+    {
+        $this->userAvatarPhotos = $userAvatarPhotos;
+
+        return $this;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface

--- a/tests/fixtures/MakeEntityManyToOne/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToOne/src/Entity/User.php
@@ -24,9 +24,12 @@ class User
     /**
      * @ORM\Column(type="string", length=255, nullable=true)
      */
-    private $name;
+    private $lastName;
 
-    private $userAvatarPhotos = [];
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $name;
 
     /**
      * @ORM\Column(type="datetime", nullable=true)
@@ -48,6 +51,18 @@ class User
         $this->firstName = $firstName;
     }
 
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName($lastName): self
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
     public function getName(): string
     {
         return $this->name;
@@ -56,18 +71,6 @@ class User
     public function setName(?string $name)
     {
         $this->name = $name;
-    }
-
-    public function getUserAvatarPhotos(): array
-    {
-        return $this->userAvatarPhotos;
-    }
-
-    public function setUserAvatarPhotos(array $userAvatarPhotos): self
-    {
-        $this->userAvatarPhotos = $userAvatarPhotos;
-
-        return $this;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface

--- a/tests/fixtures/MakeEntityManyToOne/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToOne/src/Entity/User.php
@@ -22,6 +22,11 @@ class User
     private $firstName;
 
     /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $name;
+
+    /**
      * @ORM\Column(type="datetime", nullable=true)
      */
     private $createdAt;
@@ -39,6 +44,16 @@ class User
     public function setFirstName(?string $firstName)
     {
         $this->firstName = $firstName;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name)
+    {
+        $this->name = $name;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface

--- a/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
@@ -16,8 +16,23 @@ class User
      */
     private $id;
 
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $name;
+
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name)
+    {
+        $this->name = $name;
     }
 }

--- a/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
@@ -27,6 +27,11 @@ class User
     private $firstName;
 
     /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $lastName;
+
+    /**
      * @ORM\Column(type="datetime", nullable=true)
      */
     private $createdAt;
@@ -54,6 +59,18 @@ class User
     public function setFirstName(?string $firstName): self
     {
         $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName($lastName): self
+    {
+        $this->lastName = $lastName;
 
         return $this;
     }

--- a/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
@@ -21,6 +21,11 @@ class User
      */
     private $name;
 
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $firstName;
+
     public function getId()
     {
         return $this->id;
@@ -34,5 +39,17 @@ class User
     public function setName(?string $name)
     {
         $this->name = $name;
+    }
+
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+
+        return $this;
     }
 }

--- a/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityManyToOneNoInverse/src/Entity/User.php
@@ -26,6 +26,11 @@ class User
      */
     private $firstName;
 
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $createdAt;
+
     public function getId()
     {
         return $this->id;
@@ -51,5 +56,15 @@ class User
         $this->firstName = $firstName;
 
         return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeInterface $createdAt)
+    {
+        $this->createdAt = $createdAt;
     }
 }

--- a/tests/fixtures/MakeEntityOneToOne/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityOneToOne/src/Entity/User.php
@@ -21,6 +21,8 @@ class User
      */
     private $firstName;
 
+    private $photos = [];
+
     /**
      * @ORM\Column(type="datetime", nullable=true)
      */
@@ -39,6 +41,18 @@ class User
     public function setFirstName(?string $firstName)
     {
         $this->firstName = $firstName;
+    }
+
+    public function getPhotos(): array
+    {
+        return $this->photos;
+    }
+
+    public function setPhotos(array $photos): self
+    {
+        $this->photos = $photos;
+
+        return $this;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface

--- a/tests/fixtures/MakeEntityOneToOne/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityOneToOne/src/Entity/User.php
@@ -21,6 +21,8 @@ class User
      */
     private $firstName;
 
+    private $courses;
+
     private $photos = [];
 
     /**
@@ -51,6 +53,18 @@ class User
     public function setPhotos(array $photos): self
     {
         $this->photos = $photos;
+
+        return $this;
+    }
+
+    public function getCourses()
+    {
+        return $this->courses;
+    }
+
+    public function setCourses($courses): self
+    {
+        $this->courses = $courses;
 
         return $this;
     }

--- a/tests/fixtures/MakeEntityOneToOne/src/Entity/UserAvatarPhoto.php
+++ b/tests/fixtures/MakeEntityOneToOne/src/Entity/UserAvatarPhoto.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class UserAvatarPhoto
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/fixtures/MakeEntityRegenerate/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityRegenerate/src/Entity/User.php
@@ -21,6 +21,8 @@ class User
      */
     private $firstName;
 
+    private $photos = [];
+
     /**
      * @ORM\Column(type="datetime", nullable=true)
      */
@@ -39,6 +41,18 @@ class User
     public function getFirstName()
     {
         return $this->firstName;
+    }
+
+    public function getPhotos(): array
+    {
+        return $this->photos;
+    }
+
+    public function setPhotos(array $photos): self
+    {
+        $this->photos = $photos;
+
+        return $this;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface

--- a/tests/fixtures/MakeEntityRegenerate/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityRegenerate/src/Entity/User.php
@@ -23,6 +23,8 @@ class User
 
     private $photos = [];
 
+    private $courses;
+
     /**
      * @ORM\Column(type="datetime", nullable=true)
      */
@@ -43,6 +45,14 @@ class User
         return $this->firstName;
     }
 
+    /**
+     * @param mixed $firstName
+     */
+    public function setFirstName($firstName)
+    {
+        $this->firstName = $firstName;
+    }
+
     public function getPhotos(): array
     {
         return $this->photos;
@@ -55,8 +65,44 @@ class User
         return $this;
     }
 
+    public function getCourses()
+    {
+        return $this->courses;
+    }
+
+    public function setCourses($courses)
+    {
+        $this->courses = $courses;
+
+        return $this;
+    }
+
     public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
+    }
+
+    /**
+     * @param mixed $createdAt
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAvatars()
+    {
+        return $this->avatars;
+    }
+
+    /**
+     * @param mixed $avatars
+     */
+    public function setAvatars($avatars)
+    {
+        $this->avatars = $avatars;
     }
 }

--- a/tests/fixtures/MakeEntityRegenerate/src/Entity/UserAvatarPhoto.php
+++ b/tests/fixtures/MakeEntityRegenerate/src/Entity/UserAvatarPhoto.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class UserAvatarPhoto
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/User.php
@@ -17,6 +17,16 @@ class User
     private $id;
 
     /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $firstName;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $lastName;
+
+    /**
      * @ORM\OneToMany(targetEntity="UserAvatarPhoto", mappedBy="user")
      */
     private $photos = [];
@@ -24,6 +34,28 @@ class User
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): self
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName($lastName)
+    {
+        $this->lastName = $lastName;
     }
 
     public function getPhotos(): array

--- a/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/User.php
@@ -16,8 +16,22 @@ class User
      */
     private $id;
 
+    private $photos = [];
+
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getPhotos(): array
+    {
+        return $this->photos;
+    }
+
+    public function setPhotos(array $photos): self
+    {
+        $this->photos = $photos;
+
+        return $this;
     }
 }

--- a/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/User.php
@@ -16,6 +16,9 @@ class User
      */
     private $id;
 
+    /**
+     * @ORM\OneToMany(targetEntity="UserAvatarPhoto", mappedBy="user")
+     */
     private $photos = [];
 
     public function getId()

--- a/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/UserAvatarPhoto.php
+++ b/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/UserAvatarPhoto.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class UserAvatarPhoto
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/UserAvatarPhoto.php
+++ b/tests/fixtures/MakeEntityRelationVendorTarget/src/Entity/UserAvatarPhoto.php
@@ -16,8 +16,26 @@ class UserAvatarPhoto
      */
     private $id;
 
+    /**
+     * @ORM\ManyToOne(targetEntity="User", inversedBy="photos", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $user;
+
     public function getId()
     {
         return $this->id;
+    }
+
+    public function setUser($user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getUser()
+    {
+        return $this->user;
     }
 }

--- a/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
+++ b/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
@@ -41,9 +41,11 @@ class User
         return $this->firstName;
     }
 
-    public function setFirstName(?string $firstName)
+    public function setFirstName(?string $firstName): self
     {
         $this->firstName = $firstName;
+
+        return $this;
     }
 
     public function getName(): string

--- a/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
+++ b/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
@@ -24,6 +24,11 @@ class User
     /**
      * @ORM\Column(type="string", length=255, nullable=true)
      */
+    private $lastName;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
     private $name;
 
     /**
@@ -46,6 +51,16 @@ class User
         $this->firstName = $firstName;
 
         return $this;
+    }
+
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName($lastName)
+    {
+        $this->lastName = $lastName;
     }
 
     public function getName(): string

--- a/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
+++ b/tests/fixtures/MakeEntitySelfReferencing/src/Entity/User.php
@@ -22,6 +22,11 @@ class User
     private $firstName;
 
     /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $name;
+
+    /**
      * @ORM\Column(type="datetime", nullable=true)
      */
     private $createdAt;
@@ -39,6 +44,16 @@ class User
     public function setFirstName(?string $firstName)
     {
         $this->firstName = $firstName;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name)
+    {
+        $this->name = $name;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface

--- a/tests/fixtures/MakeEntitySelfReferencing/src/Entity/UserAvatarPhoto.php
+++ b/tests/fixtures/MakeEntitySelfReferencing/src/Entity/UserAvatarPhoto.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class UserAvatarPhoto
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="User", inversedBy="avatars", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $user;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    public function setUser($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/tests/fixtures/MakeEntityUpdate/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityUpdate/src/Entity/User.php
@@ -26,6 +26,11 @@ class User
      */
     private $name;
 
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $createdAt;
+
     public function getId()
     {
         return $this->id;

--- a/tests/fixtures/MakeEntityUpdate/src/Entity/User.php
+++ b/tests/fixtures/MakeEntityUpdate/src/Entity/User.php
@@ -21,6 +21,11 @@ class User
      */
     private $firstName;
 
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $name;
+
     public function getId()
     {
         return $this->id;
@@ -34,6 +39,16 @@ class User
     public function setFirstName(?string $firstName)
     {
         $this->firstName = $firstName;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name)
+    {
+        $this->name = $name;
     }
 
     public function getCreatedAt(): ?\DateTimeInterface


### PR DESCRIPTION
For this [issue](https://github.com/symfony/maker-bundle/issues/463)

When i use command make:crud and my entity is under a directory (Admin/Article for example), lot of twig generate by this command don't have got a good path for include file.

Example from [issue](https://github.com/symfony/maker-bundle/issues/463)  :  

But the includes inside those files are like :

{{ include('community_comment/edit.html.twig') }}

Instead of :

{{ include('community/comment/edit.html.twig') }}