### PR TITLE
[Entity] Add getReference to generated Repository to give correct type hint

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -22,6 +22,19 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
         parent::__construct($registry, <?= $entity_class_name; ?>::class);
     }
 
+    /**
+     * Obtain a reference to an entity for which the identifier is known, 
+     * without loading that entity from the database.
+     * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/advanced-configuration.html#reference-proxies
+     * @param mixed $id
+     * @return <?= $class_name; ?>
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function getReference($id)
+    {
+        return $this->getEntityManager()->getReference(<?= $entity_class_name; ?>::class, $id);
+    }
+
 <?php if ($with_password_upgrade): ?>
     /**
      * Used to upgrade (rehash) the user's password automatically over time.

--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -27,7 +27,7 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
      * without loading that entity from the database.
      * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/advanced-configuration.html#reference-proxies
      * @param mixed $id
-     * @return <?= $entity_class_name . "\n"; ?>
+     * @return <?= $entity_class_name."\n"; ?>
      * @throws \Doctrine\ORM\ORMException
      */
     public function getReference($id)

--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -27,7 +27,7 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
      * without loading that entity from the database.
      * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/advanced-configuration.html#reference-proxies
      * @param mixed $id
-     * @return <?= $class_name; ?>
+     * @return <?= $entity_class_name . "\n"; ?>
      * @throws \Doctrine\ORM\ORMException
      */
     public function getReference($id)

--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -23,7 +23,7 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
     }
 
     /**
-     * Obtain a reference to an entity for which the identifier is known, 
+     * Obtain a reference to an entity for which the identifier is known,
      * without loading that entity from the database.
      * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/advanced-configuration.html#reference-proxies
      * @param mixed $id

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
@@ -19,6 +19,19 @@ class UserRepository extends ServiceEntityRepository
         parent::__construct($registry, UserXml::class);
     }
 
+    /**
+     * Obtain a reference to an entity for which the identifier is known,
+     * without loading that entity from the database.
+     * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/advanced-configuration.html#reference-proxies
+     * @param mixed $id
+     * @return UserXml
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function getReference($id)
+    {
+        return $this->getEntityManager()->getReference(UserXml::class, $id);
+    }
+
     // /**
     //  * @return UserXml[] Returns an array of UserXml objects
     //  */

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
@@ -19,6 +19,19 @@ class XOtherRepository extends ServiceEntityRepository
         parent::__construct($registry, XOther::class);
     }
 
+    /**
+     * Obtain a reference to an entity for which the identifier is known,
+     * without loading that entity from the database.
+     * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/advanced-configuration.html#reference-proxies
+     * @param mixed $id
+     * @return XOther
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function getReference($id)
+    {
+        return $this->getEntityManager()->getReference(XOther::class, $id);
+    }
+
     // /**
     //  * @return XOther[] Returns an array of XOther objects
     //  */


### PR DESCRIPTION
When using Psalm I need to implement this in every Repository, otherwise an `ArgumentTypeCoercion` Error is reported when I use `$entityManger->getReference()`, as "expects App\Entity\Foo|null, parent type object|null provided".

I'd originally generated my entities and repositories using the Maker bundle, so thought this would be helpful to other developers.