### PR TITLE
Missing return statement in example

### DIFF
--- a/src/Security/SecurityControllerBuilder.php
+++ b/src/Security/SecurityControllerBuilder.php
@@ -36,7 +36,7 @@ final class SecurityControllerBuilder
         $manipulator->addMethodBody($loginMethodBuilder, <<<'CODE'
 <?php
 // if ($this->getUser()) {
-//    $this->redirectToRoute('target_path');
+//     return $this->redirectToRoute('target_path');
 // }
 CODE
         );

--- a/tests/Security/fixtures/expected/SecurityController_login.php
+++ b/tests/Security/fixtures/expected/SecurityController_login.php
@@ -15,7 +15,7 @@ class SecurityController extends AbstractController
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         // if ($this->getUser()) {
-        //    $this->redirectToRoute('target_path');
+        //     return $this->redirectToRoute('target_path');
         // }
 
         // get the login error if there is one

--- a/tests/Security/fixtures/expected/SecurityController_login_logout.php
+++ b/tests/Security/fixtures/expected/SecurityController_login_logout.php
@@ -15,7 +15,7 @@ class SecurityController extends AbstractController
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
         // if ($this->getUser()) {
-        //    $this->redirectToRoute('target_path');
+        //     return $this->redirectToRoute('target_path');
         // }
 
         // get the login error if there is one


### PR DESCRIPTION
Missing return statement in example SecurityController.  Added a missing space as well.