### PR TITLE
[make:command] Use the initialize method to instantiate SymfonyStyle

### DIFF
--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -13,6 +13,11 @@ class <?= $class_name; ?> extends Command
 {
     protected static $defaultName = '<?= $command_name; ?>';
 
+    /**
+    * @var SymfonyStyle
+    */
+    private $io;
+
     protected function configure()
     {
         $this
@@ -22,19 +27,23 @@ class <?= $class_name; ?> extends Command
         ;
     }
 
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $io = new SymfonyStyle($input, $output);
         $arg1 = $input->getArgument('arg1');
 
         if ($arg1) {
-            $io->note(sprintf('You passed an argument: %s', $arg1));
+            $this->io->note(sprintf('You passed an argument: %s', $arg1));
         }
 
         if ($input->getOption('option1')) {
             // ...
         }
 
-        $io->success('You have a new command! Now make it your own! Pass --help to see your options.');
+        $this->io->success('You have a new command! Now make it your own! Pass --help to see your options.');
     }
 }

--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -14,8 +14,8 @@ class <?= $class_name; ?> extends Command
     protected static $defaultName = '<?= $command_name; ?>';
 
     /**
-    * @var SymfonyStyle
-    */
+     * @var SymfonyStyle
+     */
     private $io;
 
     protected function configure()


### PR DESCRIPTION
Hi, I'm back with a new PR. Hopefully this one will be more lucky!

The goal of this PR is to modify the command skeleton in order to use the initialize method to instantiate SymfonyStyle.

This is something I discovered in the symfony demo repository and I was surprised to not see it here.

https://github.com/symfony/demo/blob/master/src/Command/AddUserCommand.php#L95

Moreover, the $io variable is now a class property making it easier to use it in others methods added by the developer.

Once again, I didn't write/modify tests yet, but it will come if you tell me it is necessary.

Open to feedback!