### PR TITLE
Fixed make:auth when using a custom repository method as UserProvider

### DIFF
--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -114,7 +114,7 @@ authenticators will be ignored, and can be blank.',
 
     public function guessUserNameField(SymfonyStyle $io, string $userClass, array $providers): string
     {
-        if (1 === \count($providers) && isset(current($providers)['entity'])) {
+        if (1 === \count($providers) && isset(current($providers)['entity']) && isset(current($providers)['entity']['property'])) {
             $entityProvider = current($providers);
 
             return $entityProvider['entity']['property'];

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -438,6 +438,8 @@ class FunctionalTest extends MakerTestCase
                     'AppCustomAuthenticator',
                     // controller name
                     'SecurityController',
+                    // field name
+                    'userEmail',
                     "no"
                 ]
             )

--- a/tests/Security/InteractiveSecurityHelperTest.php
+++ b/tests/Security/InteractiveSecurityHelperTest.php
@@ -187,6 +187,13 @@ class InteractiveSecurityHelperTest extends TestCase
             true
         ];
 
+        yield 'guess_with_providers_and_custom_repository_method' => [
+            'providers' => ['app_provider' => ['entity' => null]],
+            'expectedUsernameField' => 'email',
+            true,
+            FixtureClass::class
+        ];
+
         yield 'guess_fixture_class' => [
             'providers' => [],
             'expectedUsernameField' => 'email',


### PR DESCRIPTION
Hello,

It is possible in vanilla Symfony to change how the User is retrieved by the `entity` user provider, so you use your own repository - [https://symfony.com/doc/current/security/user_provider.html#using-a-custom-query-to-load-the-user](https://symfony.com/doc/current/security/user_provider.html#using-a-custom-query-to-load-the-user). Then you remove `providers.xxxx.entity.property` key.

Unfortunately, it causes `make:auth` command to crash:
![image](https://user-images.githubusercontent.com/919405/64244498-6fde3680-cf09-11e9-8edb-79db50b3936e.png)

This PR patches `InteractiveSecurityHelper`, so it checks `property` key exists before reading from it. No BC break.
I added a test for that very specific use case. 