### PR TITLE
Removed Panther dependency from the functional test maker

### DIFF
--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -84,11 +84,5 @@ class MakeFunctionalTest extends AbstractMaker
             true,
             true
         );
-        $dependencies->addClassDependency(
-            PantherTestCaseTrait::class,
-            'panther',
-            false,
-            true
-        );
     }
 }


### PR DESCRIPTION
This fixes #483.

We'll re-add Panther dependency when/if we create a maker for e2e tests.