### PR TITLE
Changed placeholder to real label

### DIFF
--- a/src/Resources/skeleton/authenticator/login_form.tpl.php
+++ b/src/Resources/skeleton/authenticator/login_form.tpl.php
@@ -17,10 +17,10 @@
 <?php endif; ?>
 
     <h1 class="h3 mb-3 font-weight-normal">Please sign in</h1>
-    <label for="input<?= ucfirst($username_field); ?>" class="sr-only"><?= $username_label; ?></label>
-    <input type="<?= $username_is_email ? 'email' : 'text'; ?>" value="{{ last_username }}" name="<?= $username_field; ?>" id="input<?= ucfirst($username_field); ?>" class="form-control" placeholder="<?= $username_label; ?>" required autofocus>
-    <label for="inputPassword" class="sr-only">Password</label>
-    <input type="password" name="password" id="inputPassword" class="form-control" placeholder="Password" required>
+    <label for="input<?= ucfirst($username_field); ?>"><?= $username_label; ?></label>
+    <input type="<?= $username_is_email ? 'email' : 'text'; ?>" value="{{ last_username }}" name="<?= $username_field; ?>" id="input<?= ucfirst($username_field); ?>" class="form-control" required autofocus>
+    <label for="inputPassword">Password</label>
+    <input type="password" name="password" id="inputPassword" class="form-control" required>
 
     <input type="hidden" name="_csrf_token"
            value="{{ csrf_token('authenticate') }}"


### PR DESCRIPTION
Although common, placing the label into the placeholder is bad practice and reduces usability and accessibility. If people wanna do it this way, they still can; but it shouldn't be suggested :-)

If you merge it, I'll update the docs at https://symfony.com/doc/current/security/form_login_setup.html#generating-the-login-form too.