### PR TITLE
Yaml source manipulator - fix access control

### DIFF
--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -217,7 +217,7 @@ class YamlSourceManipulator
             }
 
             // 3b) value DID change
-            $this->log('updating value');
+            $this->log(sprintf('updating value to {%s}', is_array($newVal) ? '<array>' : $newVal));
             $this->changeValueInYaml($newVal);
         }
 
@@ -764,6 +764,12 @@ class YamlSourceManipulator
             }
 
             $offset = null === $offset ? $this->currentPosition : $offset;
+
+            // a value like "foo:" can simply end a file
+            // this means the value is null
+            if ($offset === strlen($this->contents)) {
+                return $offset;
+            }
 
             preg_match(sprintf('#%s#', $pattern), $this->contents, $matches, PREG_OFFSET_CAPTURE, $offset);
             if (empty($matches)) {

--- a/tests/Util/yaml_fixtures/last_value_is_blank.test
+++ b/tests/Util/yaml_fixtures/last_value_is_blank.test
@@ -1,0 +1,7 @@
+security:
+    access_control:
+===
+$data['security']['access_control'] = 'foo';
+===
+security:
+    access_control: foo

--- a/tests/Util/yaml_fixtures/simple_sequence_add_array.test
+++ b/tests/Util/yaml_fixtures/simple_sequence_add_array.test
@@ -1,0 +1,13 @@
+# https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+security:
+    access_control:
+===
+$data['security']['access_control'] = [];
+$data['security']['access_control'][] = ['path' => '^/login$', 'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'];
+===
+# https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+security:
+    access_control:
+        -
+            path: ^/login$
+            roles: IS_AUTHENTICATED_ANONYMOUSLY

--- a/tests/Util/yaml_fixtures/simple_sequence_add_array_with_comments.test
+++ b/tests/Util/yaml_fixtures/simple_sequence_add_array_with_comments.test
@@ -1,0 +1,17 @@
+# https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+security:
+    access_control:
+        # - { path: ^/admin, roles: ROLE_ADMIN }
+        # - { path: ^/profile, roles: ROLE_USER }
+===
+$data['security']['access_control'] = [];
+$data['security']['access_control'][] = ['path' => '^/login$', 'roles' => 'IS_AUTHENTICATED_ANONYMOUSLY'];
+===
+# https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+security:
+    access_control:
+        -
+            path: ^/login$
+            roles: IS_AUTHENTICATED_ANONYMOUSLY
+        # - { path: ^/admin, roles: ROLE_ADMIN }
+        # - { path: ^/profile, roles: ROLE_USER }


### PR DESCRIPTION
This helps #460 by fixing a few bugs with YamlSourceManipulator. But, it doesn't yet allow for the `access_control` array structure to be printed in an inline format (https://github.com/symfony/maker-bundle/pull/460#issuecomment-548923526). 

Cheers!