### PR TITLE
Fix make:functional-test for Symfony 5

### DIFF
--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -16,7 +16,7 @@ use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\History;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -73,7 +73,7 @@ class MakeFunctionalTest extends AbstractMaker
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
-            Client::class,
+            History::class,
             'browser-kit',
             true,
             true


### PR DESCRIPTION
As of Symfony 5, the Client class has been renamed and does not exist anymore.