### PR TITLE
Fixing tests for Symfony5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ env:
 matrix:
     fast_finish: true
     include:
+        - php: 7.1.33
         - php: 7.3
-        - php: 7.2
-          env: MAKER_TEST_VERSION=stable-dev
-        - php: 7.2
+        - php: 7.3
+          env: MAKER_TEST_VERSION=dev
+    allow_failures:
+        - php: 7.3
           env: MAKER_TEST_VERSION=dev
 
 before_install:

--- a/src/EventRegistry.php
+++ b/src/EventRegistry.php
@@ -149,6 +149,11 @@ class EventRegistry
                     return Event::class;
                 }
 
+                // ignore an "object" type-hint
+                if ('object' === $type) {
+                    continue;
+                }
+
                 return $type;
             }
         }

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -289,6 +289,7 @@ final class MakerTestEnvironment
             $yaml = file_get_contents($this->path.'/config/packages/security.yaml');
             $manipulator = new YamlSourceManipulator($yaml);
             $data = $manipulator->getData();
+
             foreach ($guardAuthenticators as $firewallName => $id) {
                 if (!isset($data['security']['firewalls'][$firewallName])) {
                     throw new \Exception(sprintf('Could not find firewall "%s"', $firewallName));
@@ -320,9 +321,9 @@ final class MakerTestEnvironment
 
         $rootPath = str_replace('\\', '\\\\', realpath(__DIR__.'/../..'));
 
-        // allow dev dependencies
+        // dev deps already will allow dev deps, but we should prefer stable
         if (false !== strpos($targetVersion, 'dev')) {
-            MakerTestProcess::create('composer config minimum-stability dev', $this->flexPath)
+            MakerTestProcess::create('composer config prefer-stable true', $this->flexPath)
                 ->run();
         }
 
@@ -449,10 +450,7 @@ echo json_encode($missingDependencies);
 
                     break;
                 case 'dev':
-                    $version = $data['dev'];
-                    $parts = explode('.', $version);
-
-                    $this->targetFlexVersion = sprintf('%s.%s.x-dev', $parts[0], $parts[1]);
+                    $this->targetFlexVersion = 'dev-master';
 
                     break;
                 default:

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -217,7 +217,7 @@ class YamlSourceManipulator
             }
 
             // 3b) value DID change
-            $this->log(sprintf('updating value to {%s}', is_array($newVal) ? '<array>' : $newVal));
+            $this->log(sprintf('updating value to {%s}', \is_array($newVal) ? '<array>' : $newVal));
             $this->changeValueInYaml($newVal);
         }
 
@@ -465,7 +465,7 @@ class YamlSourceManipulator
         $newPosition = $this->currentPosition + \strlen($newYamlValue);
         $isNextContentComment = $this->isPreviousLineComment($newPosition);
         if ($isNextContentComment) {
-            $newPosition++;
+            ++$newPosition;
         }
 
         $newContents = substr($this->contents, 0, $this->currentPosition)
@@ -785,7 +785,7 @@ class YamlSourceManipulator
 
             // a value like "foo:" can simply end a file
             // this means the value is null
-            if ($offset === strlen($this->contents)) {
+            if ($offset === \strlen($this->contents)) {
                 return $offset;
             }
 

--- a/tests/EventRegistryTest.php
+++ b/tests/EventRegistryTest.php
@@ -23,15 +23,25 @@ class EventRegistryTest extends TestCase
     {
         $eventObj = new DummyEvent();
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $listenersMap = [
+            'someFunctionToSkip',
+            [$eventObj, 'methodNoArg'],
+            [$eventObj, 'methodNoType'],
+            [$eventObj, 'methodObjectType'],
+            [$eventObj, 'methodWithType'],
+        ];
+
+        // less than PHP 7.2, unset object type-hint example
+        // otherwise, it looks like a class in this namespace
+        if (PHP_VERSION_ID < 70200) {
+            unset($listenersMap[3]);
+        }
+
         $dispatcher->expects($this->once())
             ->method('getListeners')
             ->with('foo.bar')
-            ->willReturn([
-                'someFunctionToSkip',
-                [$eventObj, 'methodNoArg'],
-                [$eventObj, 'methodNoType'],
-                [$eventObj, 'methodWithType'],
-            ]);
+            ->willReturn($listenersMap);
 
         $registry = new EventRegistry($dispatcher);
         $this->assertSame(GetResponseForExceptionEvent::class, $registry->getEventClassName('foo.bar'));
@@ -82,6 +92,10 @@ class DummyEvent
     }
 
     public function methodNoType($event)
+    {
+    }
+
+    public function methodObjectType(object $event)
     {
     }
 

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -665,7 +665,9 @@ class FunctionalTest extends MakerTestCase
             ->assert(function (string $output, string $directory) {
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
                 $this->assertStringContainsString('created: src/Form/SweetFoodType.php', $output);
-            }),
+            })
+            // workaround for segfault in PHP 7.1 CI :/
+            ->setRequiredPhpVersion(70200)
         ];
 
         yield 'crud_basic_in_custom_root_namespace' => [MakerTestDetails::createTest(
@@ -681,7 +683,9 @@ class FunctionalTest extends MakerTestCase
             ->assert(function (string $output, string $directory) {
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
                 $this->assertStringContainsString('created: src/Form/SweetFoodType.php', $output);
-            }),
+            })
+            // workaround for segfault in PHP 7.1 CI :/
+            ->setRequiredPhpVersion(70200)
         ];
 
         yield 'crud_repository' => [MakerTestDetails::createTest(
@@ -713,7 +717,9 @@ class FunctionalTest extends MakerTestCase
             ->assert(function (string $output, string $directory) {
                 $this->assertStringContainsString('created: src/Controller/SweetFoodController.php', $output);
                 $this->assertStringContainsString('created: src/Form/SweetFoodType.php', $output);
-            }),
+            })
+            // workaround for segfault in PHP 7.1 CI :/
+            ->setRequiredPhpVersion(70200)
         ];
 
         yield 'registration_form_entity_guard_authenticate' => [MakerTestDetails::createTest(
@@ -729,7 +735,12 @@ class FunctionalTest extends MakerTestCase
             ])
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeRegistrationFormEntity')
             ->configureDatabase()
-            ->updateSchemaAfterCommand(),
+            ->updateSchemaAfterCommand()
+            // workaround for a strange behavior where, every other
+            // test run, the UniqueEntity would not be seen, because
+            // the the validation cache was out of date. The cause
+            // is currently unknown, so this workaround was added
+            ->addPostMakeCommand('php bin/console cache:clear --env=test')
         ];
 
         // sanity check on all the interactive questions
@@ -757,7 +768,10 @@ class FunctionalTest extends MakerTestCase
             ])
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeRegistrationFormEntity')
             ->configureDatabase()
-            ->updateSchemaAfterCommand(),
+            ->updateSchemaAfterCommand()
+            // workaround for strange failure - see test case
+            // registration_form_entity_guard_authenticate for details
+            ->addPostMakeCommand('php bin/console cache:clear --env=test')
         ];
 
         yield 'auth_login_form_user_entity_with_encoder_logout' => [

--- a/tests/fixtures/MakeRegistrationFormEntity/tests/RegistrationFormTest.php
+++ b/tests/fixtures/MakeRegistrationFormEntity/tests/RegistrationFormTest.php
@@ -10,7 +10,8 @@ class RegistrationFormTest extends WebTestCase
 {
     public function testRegistrationSuccessful()
     {
-        self::bootKernel();
+        $client = static::createClient();
+
         /** @var EntityManager $em */
         $em = self::$kernel->getContainer()
             ->get('doctrine')
@@ -18,7 +19,6 @@ class RegistrationFormTest extends WebTestCase
         $em->createQuery('DELETE FROM App\\Entity\\User u')
             ->execute();
 
-        $client = static::createClient();
         $crawler = $client->request('GET', '/register');
         $form = $crawler->selectButton('Register')->form();
         $form['registration_form[email]'] = 'ryan@symfonycasts.com';
@@ -34,7 +34,8 @@ class RegistrationFormTest extends WebTestCase
 
     public function testRegistrationValidationError()
     {
-        self::bootKernel();
+        $client = static::createClient();
+
         /** @var EntityManager $em */
         $em = self::$kernel->getContainer()
             ->get('doctrine')
@@ -47,7 +48,6 @@ class RegistrationFormTest extends WebTestCase
         $em->persist($user);
         $em->flush();
 
-        $client = static::createClient();
         $crawler = $client->request('GET', '/register');
         $form = $crawler->selectButton('Register')->form();
         $form['registration_form[email]'] = 'ryan@symfonycasts.com';

--- a/tests/fixtures/MakeUserEntityPassword/tests/GeneratedEntityTest.php
+++ b/tests/fixtures/MakeUserEntityPassword/tests/GeneratedEntityTest.php
@@ -11,7 +11,8 @@ class GeneratedEntityTest extends WebTestCase
 {
     public function testGeneratedEntity()
     {
-        self::bootKernel();
+        $client = static::createClient();
+
         /** @var EntityManager $em */
         $em = self::$kernel->getContainer()
             ->get('doctrine')
@@ -31,7 +32,6 @@ class GeneratedEntityTest extends WebTestCase
         $em->flush();
 
         // login then access a protected page
-        $client = static::createClient();
         $client->request('GET', '/login?email=foo@example.com');
 
         $this->assertSame(302, $client->getResponse()->getStatusCode());


### PR DESCRIPTION
This also removes the dev-stable. That was a build to detect possible BC breaks on patch versions made in Symfony... which is rare and probably not the job of Maker :). 