### PR TITLE
Multiuse patch

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -729,6 +729,30 @@ final class ClassSourceManipulator
                 }
 
                 $lastUseStmtIndex = $index;
+            } elseif ($stmt instanceof Node\Stmt\GroupUse) {
+                foreach ($stmt->uses as $use) {
+                    $alias = $use->alias ? $use->alias->name : $use->name->getLast();
+
+                    $fqcn = $stmt->prefix.'\\'.$use->name;
+                    if ($class === $fqcn) {
+                        return $alias;
+                    }
+
+                    if ($alias === $shortClassName) {
+                        // we have a conflicting alias!
+                        // to be safe, use the fully-qualified class name
+                        // everywhere and do not add another use statement
+                        return '\\'.$class;
+                    }
+                }
+
+                // if $class is alphabetically before this use statement, place it before
+                // only set $targetIndex the first time you find it
+                if (null === $targetIndex && Str::areClassesAlphabetical($class, (string) $stmt->prefix)) {
+                    $targetIndex = $index;
+                }
+
+                $lastUseStmtIndex = $index;
             } elseif ($stmt instanceof Node\Stmt\Class_) {
                 if (null !== $targetIndex) {
                     // we already found where to place the use statement

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -730,6 +730,9 @@ final class ClassSourceManipulator
 
                 $lastUseStmtIndex = $index;
             } elseif ($stmt instanceof Node\Stmt\GroupUse) {
+                // cezar77: this if-case should handle group use statements
+                // TO-DO: it is repeating a lot of parts of the previous if-statement
+                // to be refactored later
                 foreach ($stmt->uses as $use) {
                     $alias = $use->alias ? $use->alias->name : $use->name->getLast();
 

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -365,6 +365,18 @@ class ClassSourceManipulatorTest extends TestCase
                 ->setOrphanRemoval(false),
         ];
 
+        // interesting also becaue the source file has
+        // multiple use statements
+        yield 'one_to_many_simple_multiple_use' => [
+            'User_with_multiple_use_statements.php',
+            'User_with_multiple_use_statements.php',
+            (new RelationOneToMany())
+                ->setPropertyName('avatarPhotos')
+                ->setTargetClassName('App\Entity\UserAvatarPhoto')
+                ->setTargetPropertyName('user')
+                ->setOrphanRemoval(false),
+        ];
+
         yield 'one_to_many_orphan_removal' => [
             'User_simple.php',
             'User_simple_orphan_removal.php',

--- a/tests/Util/fixtures/add_one_to_many_relation/User_with_multiple_use_statements.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_with_multiple_use_statements.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\{
+    ArrayCollection,
+    Collection
+};
+use Some\Other\{
+    UserProfile,
+    FooCategory as Category
+};
+
+/**
+ * @ORM\Entity()
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\UserAvatarPhoto", mappedBy="user")
+     */
+    private $avatarPhotos;
+
+    public function __construct()
+    {
+        $this->avatarPhotos = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Collection|UserAvatarPhoto[]
+     */
+    public function getAvatarPhotos(): Collection
+    {
+        return $this->avatarPhotos;
+    }
+
+    public function addAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    {
+        if (!$this->avatarPhotos->contains($avatarPhoto)) {
+            $this->avatarPhotos[] = $avatarPhoto;
+            $avatarPhoto->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removeAvatarPhoto(UserAvatarPhoto $avatarPhoto): self
+    {
+        if ($this->avatarPhotos->contains($avatarPhoto)) {
+            $this->avatarPhotos->removeElement($avatarPhoto);
+            // set the owning side to null (unless already changed)
+            if ($avatarPhoto->getUser() === $this) {
+                $avatarPhoto->setUser(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/tests/Util/fixtures/source/User_with_multiple_use_statements.php
+++ b/tests/Util/fixtures/source/User_with_multiple_use_statements.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\{
+    ArrayCollection,
+    Collection
+};
+use Some\Other\{
+    UserProfile,
+    FooCategory as Category
+};
+
+/**
+ * @ORM\Entity()
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
#SymfonyHackday

The MakerBundle throws a very cryptic error report when altering an entity class with group use statements.

This patch solves the issue and prevents insertion of use statement if the class is already imported within a group use statement.

Official documentation: [group use declarations](https://www.php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.group)