### PR TITLE
[WIP] adding DisableAutoMapping code to registration form

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -252,7 +252,8 @@ final class MakeRegistrationForm extends AbstractMaker
             );
             $userManipulator->setIo($io);
 
-            $userManipulator->addAnnotationToClass(
+            $userManipulator->addValidationAnnotation(
+                'password',
                 DisableAutoMapping::class,
                 []
             );

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -35,6 +35,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Validator\Constraints\DisableAutoMapping;
 use Symfony\Component\Validator\Validation;
 
 /**
@@ -240,6 +241,20 @@ final class MakeRegistrationForm extends AbstractMaker
                     'fields' => [$usernameField],
                     'message' => sprintf('There is already an account with this '.$usernameField),
                 ]
+            );
+            $this->fileManager->dumpFile($classDetails->getPath(), $userManipulator->getSourceCode());
+        }
+
+        if (class_exists(DisableAutoMapping::class)) {
+            $classDetails = new ClassDetails($userClass);
+            $userManipulator = new ClassSourceManipulator(
+                file_get_contents($classDetails->getPath())
+            );
+            $userManipulator->setIo($io);
+
+            $userManipulator->addAnnotationToClass(
+                DisableAutoMapping::class,
+                []
             );
             $this->fileManager->dumpFile($classDetails->getPath(), $userManipulator->getSourceCode());
         }

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Security;
 use PhpParser\Node;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints\DisableAutoMapping;
 
 /**
  * Adds logic to implement UserInterface to an existing User class.
@@ -190,6 +191,13 @@ final class UserClassBuilder
                 ],
                 [$propertyDocs]
             );
+
+            if (class_exists(DisableAutoMapping::class)) {
+                $manipulator->addValidationAnnotation(
+                    'password',
+                    DisableAutoMapping::class
+                );
+            }
         } else {
             // add normal property
             $manipulator->addProperty('password', [$propertyDocs]);

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -195,7 +195,8 @@ final class UserClassBuilder
             if (class_exists(DisableAutoMapping::class)) {
                 $manipulator->addValidationAnnotation(
                     'password',
-                    DisableAutoMapping::class
+                    DisableAutoMapping::class,
+                    []
                 );
             }
         } else {

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -689,7 +689,7 @@ final class ClassSourceManipulator
     /**
      * @return string The alias to use when referencing this class
      */
-    public function addUseStatementIfNecessary(string $class): string
+    public function addUseStatementIfNecessary(string $class, string $desiredAlias = null): string
     {
         $shortClassName = Str::getShortClassName($class);
         if ($this->isInSameNamespace($class)) {
@@ -751,7 +751,14 @@ final class ClassSourceManipulator
             throw new \Exception('Could not find a class!');
         }
 
-        $newUseNode = (new Builder\Use_($class, Node\Stmt\Use_::TYPE_NORMAL))->getNode();
+        $newUserBuilder = (new Builder\Use_($class, Node\Stmt\Use_::TYPE_NORMAL));
+        $newAlias = $shortClassName;
+        if (null !== $desiredAlias) {
+            $newUserBuilder->as($desiredAlias);
+            $newAlias = $desiredAlias;
+        }
+
+        $newUseNode = $newUserBuilder->getNode();
         array_splice(
             $namespaceNode->stmts,
             $targetIndex,
@@ -761,7 +768,7 @@ final class ClassSourceManipulator
 
         $this->updateSourceCodeFromNewStmts();
 
-        return $shortClassName;
+        return $newAlias;
     }
 
     private function updateSourceCodeFromNewStmts()

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -317,6 +317,18 @@ final class ClassSourceManipulator
         $this->updateSourceCodeFromNewStmts();
     }
 
+    /**
+     * Helper to add a validation annotation that is aware of the preferred "as Assert" alias
+     */
+    public function addValidationAnnotation(string $propertyName, string $annotationClass, array $options)
+    {
+        if (strpos($annotationClass, 'Symfony\Component\Validator\Constraints') !== 0) {
+            throw new \Exception('addValidationAnnotation is meant only for use with constraints in the Symfony\Component\Validator\Constraints namespace. Use addAnnotationToProperty() instead.');
+        }
+
+        $this->addAnnotationToProperty($propertyName, $annotationClass, $options, true, 'Assert');
+    }
+
     private function addNewLineToComments(string $existingCommentsText, string $newDocLine): Doc
     {
         $docLines = $existingCommentsText ? explode("\n", $existingCommentsText) : [];

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -783,4 +783,92 @@ EOF
         $this->assertSame('Assert', $alias);
         $this->assertEquals($expected, $manipulator->getSourceCode());
     }
+
+    public function testAddAnnotationToPropertyTraditional()
+    {
+        $source = <<<EOF
+<?php
+
+namespace Acme;
+
+class Foo
+{
+    private \$bar;
+}
+EOF
+        ;
+
+        $expected = <<<EOF
+<?php
+
+namespace Acme;
+
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class Foo
+{
+    /**
+     * @NotBlank()
+     */
+    private \$bar;
+}
+EOF
+        ;
+
+        $manipulator = new ClassSourceManipulator($source);
+        $manipulator->addAnnotationToProperty(
+            'bar',
+            'Symfony\Component\Validator\Constraints\NotBlank',
+            []
+        );
+
+        $this->assertSame($expected, $manipulator->getSourceCode());
+    }
+
+    public function testAddAnnotationToPropertyWithNamespaceUseAndAlias()
+    {
+        $source = <<<EOF
+<?php
+
+namespace Acme;
+
+class Foo
+{
+    /**
+     * A property!
+     */
+    private \$bar;
+}
+EOF
+        ;
+
+        $expected = <<<EOF
+<?php
+
+namespace Acme;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Foo
+{
+    /**
+     * A property!
+     * @Assert\NotBlank()
+     */
+    private \$bar;
+}
+EOF
+        ;
+
+        $manipulator = new ClassSourceManipulator($source);
+        $manipulator->addAnnotationToProperty(
+            'bar',
+            'Symfony\Component\Validator\Constraints\NotBlank',
+            [],
+            true,
+            'Assert'
+        );
+
+        $this->assertSame($expected, $manipulator->getSourceCode());
+    }
 }

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -728,4 +728,59 @@ class Foo
 EOF
         ];
     }
+
+    public function testAddUseStatementIfNecessaryRespectsAliasedUseStatements()
+    {
+        $source = <<<EOF
+<?php
+
+namespace Acme;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Foo
+{
+}
+EOF
+        ;
+
+        $manipulator = new ClassSourceManipulator($source);
+        $alias = $manipulator->addUseStatementIfNecessary('Symfony\Component\Validator\Constraints');
+
+        $this->assertSame('Assert', $alias);
+        $this->assertEquals($source, $manipulator->getSourceCode());
+    }
+
+    public function testAddUseStatementIfNecessaryWithAlias()
+    {
+        $source = <<<EOF
+<?php
+
+namespace Acme;
+
+class Foo
+{
+}
+EOF
+        ;
+
+        $expected = <<<EOF
+<?php
+
+namespace Acme;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Foo
+{
+}
+EOF
+        ;
+
+        $manipulator = new ClassSourceManipulator($source);
+        $alias = $manipulator->addUseStatementIfNecessary('Symfony\Component\Validator\Constraints', 'Assert');
+
+        $this->assertSame('Assert', $alias);
+        $this->assertEquals($expected, $manipulator->getSourceCode());
+    }
 }


### PR DESCRIPTION
If/when we merge the auto-validation recipe, the `make:registration-form` should disable validation on the `password` field. We could/should also try to add the annotation in `make:user` (but it's only possible if you already have the validator installed).