### PR TITLE
[Bug] Potential error of Composer Autoloader Finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,9 @@
         "symfony/phpunit-bridge": "^4.3|^5.0",
         "symfony/process": "^3.4|^4.0|^5.0",
         "symfony/security-core": "^3.4|^4.0|^5.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0"
+        "symfony/yaml": "^3.4|^4.0|^5.0",
+        "symfony/debug": "^3.4|^4.0",
+        "symfony/error-handler": "^4.4|^5.0"
     },
     "config": {
         "preferred-install": "dist",

--- a/src/Util/ComposerAutoloaderFinder.php
+++ b/src/Util/ComposerAutoloaderFinder.php
@@ -77,18 +77,13 @@ class ComposerAutoloaderFinder
     /**
      * @return ClassLoader|null
      */
-    private function extractComposerClassLoader(array $autoloader)
+    private function extractComposerClassLoader(array $autoloaders)
     {
-        if (isset($autoloader[0]) && \is_object($autoloader[0])) {
-            if ($autoloader[0] instanceof ClassLoader) {
-                return $autoloader[0];
-            }
-            if (
-                ($autoloader[0] instanceof DebugClassLoader
-                    || $autoloader[0] instanceof ErrorHandlerDebugClassLoader)
-                && \is_array($autoloader[0]->getClassLoader())
-                && $autoloader[0]->getClassLoader()[0] instanceof ClassLoader) {
-                return $autoloader[0]->getClassLoader()[0];
+        foreach ($autoloaders as $autoloader) {
+            if (($autoloader instanceof DebugClassLoader || $autoloader instanceof ErrorHandlerDebugClassLoader) && \is_array($autoloader->getClassLoader())) {
+                return $this->extractComposerClassLoader($autoloader->getClassLoader());
+            } elseif ($autoloader instanceof ClassLoader) {
+                return $autoloader;
             }
         }
 

--- a/src/Util/ComposerAutoloaderFinder.php
+++ b/src/Util/ComposerAutoloaderFinder.php
@@ -82,7 +82,9 @@ class ComposerAutoloaderFinder
         foreach ($autoloaders as $autoloader) {
             if (($autoloader instanceof DebugClassLoader || $autoloader instanceof ErrorHandlerDebugClassLoader) && \is_array($autoloader->getClassLoader())) {
                 return $this->extractComposerClassLoader($autoloader->getClassLoader());
-            } elseif ($autoloader instanceof ClassLoader) {
+            }
+            
+            if ($autoloader instanceof ClassLoader) {
                 return $autoloader;
             }
         }

--- a/src/Util/ComposerAutoloaderFinder.php
+++ b/src/Util/ComposerAutoloaderFinder.php
@@ -83,7 +83,7 @@ class ComposerAutoloaderFinder
             if (($autoloader instanceof DebugClassLoader || $autoloader instanceof ErrorHandlerDebugClassLoader) && \is_array($autoloader->getClassLoader())) {
                 return $this->extractComposerClassLoader($autoloader->getClassLoader());
             }
-            
+
             if ($autoloader instanceof ClassLoader) {
                 return $autoloader;
             }

--- a/tests/Util/ComposerAutoloaderFinderTest.php
+++ b/tests/Util/ComposerAutoloaderFinderTest.php
@@ -59,10 +59,15 @@ class ComposerAutoloaderFinderTest extends TestCase
         (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
     }
 
-    public function testGetClassLoaderAfterEnabledDebug()
+    public function testGetClassLoaderAfterEnabledSymfonyDebug()
     {
-        \Symfony\Component\Debug\Debug::enable();
-        \Symfony\Component\ErrorHandler\DebugClassLoader::enable();
+        if (\class_exists('Symfony\Component\Debug\Debug')) {
+            \Symfony\Component\Debug\Debug::enable();
+        }
+
+        if (\class_exists('Symfony\Component\ErrorHandler\DebugClassLoader')) {
+            \Symfony\Component\ErrorHandler\DebugClassLoader::enable();
+        }
 
         $loader = (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
 

--- a/tests/Util/ComposerAutoloaderFinderTest.php
+++ b/tests/Util/ComposerAutoloaderFinderTest.php
@@ -59,6 +59,16 @@ class ComposerAutoloaderFinderTest extends TestCase
         (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
     }
 
+    public function testGetClassLoaderAfterEnabledDebug()
+    {
+        \Symfony\Component\Debug\Debug::enable();
+        \Symfony\Component\ErrorHandler\DebugClassLoader::enable();
+
+        $loader = (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
+
+        $this->assertInstanceOf(ClassLoader::class, $loader, 'Wrong ClassLoader found');
+    }
+
     /**
      * @param string|null $psr0
      * @param string|null $psr4

--- a/tests/Util/ComposerAutoloaderFinderTest.php
+++ b/tests/Util/ComposerAutoloaderFinderTest.php
@@ -64,6 +64,9 @@ class ComposerAutoloaderFinderTest extends TestCase
      */
     public function testGetClassLoaderAfterEnabledSymfonyDebug()
     {
+        // Backup of actual error handler
+        $handler = set_error_handler(static function ($errno, $errstr, $errfile, $errline){});
+
         if (\class_exists('Symfony\Component\Debug\Debug')) {
             \Symfony\Component\Debug\Debug::enable();
         }
@@ -75,6 +78,9 @@ class ComposerAutoloaderFinderTest extends TestCase
         $loader = (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
 
         $this->assertInstanceOf(ClassLoader::class, $loader, 'Wrong ClassLoader found');
+
+        // Restore of previous error handler
+        set_error_handler($handler);
     }
 
     /**

--- a/tests/Util/ComposerAutoloaderFinderTest.php
+++ b/tests/Util/ComposerAutoloaderFinderTest.php
@@ -59,6 +59,9 @@ class ComposerAutoloaderFinderTest extends TestCase
         (new ComposerAutoloaderFinder(static::$rootNamespace))->getClassLoader();
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetClassLoaderAfterEnabledSymfonyDebug()
     {
         if (\class_exists('Symfony\Component\Debug\Debug')) {


### PR DESCRIPTION
Hi,
I am very pleased to help you develop this component.
An error occurred while generating additional methods for the entity in #513 
Loader has always been searched strictly at the second level. My patch searches for this `ClassLoader` class through a recursive function.