### PR TITLE
Do not use (deprecated) class, to be removed in future releases.

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -4,7 +4,7 @@ namespace <?= $namespace; ?>;
 
 use <?= $entity_full_class_name; ?>;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 <?= $with_password_upgrade ? "use Symfony\Component\Security\Core\Exception\UnsupportedUserException;\n" : '' ?>
 <?= $with_password_upgrade ? "use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;\n" : '' ?>
 <?= $with_password_upgrade ? "use Symfony\Component\Security\Core\User\UserInterface;\n" : '' ?>


### PR DESCRIPTION
Since doctrine itself recommends to use `Doctrine\Persistence\ManagerRegistry`, lets not use `Doctrine\Common\Persistence\ManagerRegistry`. This should be an easy merge as they seem to be signature compatible.