### PR TITLE
Update success message in MakeMigration

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -256,7 +256,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         $this->writeSuccessMessage($io);
         $io->text([
-            'Next: When you\'re ready, create a migration with <comment>make:migration</comment>',
+            'Next: When you\'re ready, create a migration with <info>php bin/console make:migration</info>',
             '',
         ]);
     }


### PR DESCRIPTION
I've always found annoying and frustrating that running `make:entity` the output is 

>  Next: When you're ready, create a migration with `make:migration `

instead of 

>  Next: When you're ready, create a migration with `php bin/console make:migration `

As ` make:migration` does

>  Then: Run the migration with `php bin/console doctrine:migrations:migrate`
