### PR TITLE
Support class inheritance in UserProvider::supportsClass by default

### DIFF
--- a/src/Resources/skeleton/security/UserProvider.tpl.php
+++ b/src/Resources/skeleton/security/UserProvider.tpl.php
@@ -59,7 +59,7 @@ class <?= $class_name ?> implements UserProviderInterface<?= $password_upgrader 
      */
     public function supportsClass($class)
     {
-        return <?= $user_short_name ?>::class === $class;
+        return <?= $user_short_name ?>::class === $class || is_subclass_of($class, <?= $user_short_name ?>::class);
     }
 <?php if ($password_upgrader): ?>
 


### PR DESCRIPTION
I propose to add the check if given class name is inherited from the User class (like the EntityUserProvider implementation does) to the UserProvider template.

Also I would follow up with a documentation PR reflecting that change in https://github.com/symfony/symfony-docs/blob/master/security/user_provider.rst

Or would it better to just add a info about this additional check to the documentation?