### PR TITLE
fixed minor issues failing test on master

### DIFF
--- a/src/Maker/MakeForgottenPassword.php
+++ b/src/Maker/MakeForgottenPassword.php
@@ -15,23 +15,23 @@ use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\ORMDependencyBuilder;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Renderer\FormTypeRenderer;
 use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Bundle\MakerBundle\FileManager;
-use Symfony\Bundle\MakerBundle\Renderer\FormTypeRenderer;
 use Symfony\Component\Validator\Validation;
-use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 
 /**
  * @author Romaric Drigon <romaric.drigon@gmail.com>

--- a/src/Renderer/FormTypeRenderer.php
+++ b/src/Renderer/FormTypeRenderer.php
@@ -42,6 +42,9 @@ final class FormTypeRenderer
             $fields[$name] = $fieldTypeOptions;
         }
 
+        $mergedTypeUseStatements = array_merge($fieldTypeUseStatements, $extraUseClasses);
+        sort($mergedTypeUseStatements);
+
         $this->generator->generateClass(
             $formClassDetails->getFullName(),
             'form/Type.tpl.php',
@@ -49,7 +52,7 @@ final class FormTypeRenderer
                 'bounded_full_class_name' => $boundClassDetails ? $boundClassDetails->getFullName() : null,
                 'bounded_class_name' => $boundClassDetails ? $boundClassDetails->getShortName() : null,
                 'form_fields' => $fields,
-                'field_type_use_statements' => array_merge($fieldTypeUseStatements, $extraUseClasses),
+                'field_type_use_statements' => $mergedTypeUseStatements,
                 'constraint_use_statements' => $constraintClasses,
             ]
         );

--- a/tests/Maker/MakeForgottenPasswordTest.php
+++ b/tests/Maker/MakeForgottenPasswordTest.php
@@ -21,6 +21,7 @@ class MakeForgottenPasswordTest extends MakerTestCase
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeForgottenPassword')
             ->configureDatabase()
             ->updateSchemaAfterCommand()
+            ->addExtraDependencies('symfony/swiftmailer-bundle')
         ];
     }
 }


### PR DESCRIPTION
Primarily related to `MakeForgottenPassword::class` & associated test suite.

fixed missing `symfony/swiftmailer` test dependency
fixed used statements that were not sorted alphabetically

As related to `FormTypeRenderer::class` caused by `MakeForgottenPassword::class`:
fixed unsorted `'field_type_use_statements'` that triggered php-cs-fixer

Directly related to issue #496 Fix Test Suite