### PR TITLE
Fix SecurityConfigUpdater

### DIFF
--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -72,6 +72,12 @@ class SecurityConfigUpdaterTest extends TestCase
             'empty_source_model_email_with_password.yaml',
             'empty_security.yaml',
         ];
+
+        yield 'simple_security_with_single_memory_provider_configured' => [
+            new UserClassConfiguration(true, 'email', true),
+            'simple_security_with_single_memory_provider_configured.yaml',
+            'simple_security_with_single_memory_provider_configured.yaml',
+        ];
     }
 
     /**

--- a/tests/Security/yaml_fixtures/expected_user_class/simple_security_with_single_memory_provider_configured.yaml
+++ b/tests/Security/yaml_fixtures/expected_user_class/simple_security_with_single_memory_provider_configured.yaml
@@ -1,0 +1,18 @@
+security:
+    encoders:
+        App\Entity\User:
+            algorithm: {BCRYPT_OR_AUTO}
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        # used to reload user from session & other features (e.g. switch_user)
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
+
+    firewalls:
+        dev: ~
+        main:
+            anonymous: true
+            provider: app_user_provider

--- a/tests/Security/yaml_fixtures/source/simple_security_with_single_memory_provider_configured.yaml
+++ b/tests/Security/yaml_fixtures/source/simple_security_with_single_memory_provider_configured.yaml
@@ -1,0 +1,10 @@
+security:
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main:
+            anonymous: true
+            provider: in_memory


### PR DESCRIPTION
this fixes the bug which occurs presently on master

since we remove memory provider in "make:user" if it is the only
provider, we need to remove this memory provider from firewalls.

And the tests were failing now because the security bundle's recipe has been updated recently, and the memory provider has been added to main firewall