### PR TITLE
Make Entity -  Convert snake-case to camel-case for entity fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "symfony/filesystem": "^3.4|^4.0|^5.0",
         "symfony/finder": "^3.4|^4.0|^5.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
-        "symfony/http-kernel": "^3.4|^4.0|^5.0"
+        "symfony/http-kernel": "^3.4|^4.0|^5.0",
+        "symfony/string": "^5.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.8|^2.0",

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Security;
 use PhpParser\Node;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\String\UnicodeString;
 
 /**
  * Adds logic to implement UserInterface to an existing User class.
@@ -69,7 +70,7 @@ final class UserClassBuilder
 
         // define getUsername (if it was defined above, this will override)
         $manipulator->addAccessorMethod(
-            $userClassConfig->getIdentityPropertyName(),
+            (new UnicodeString($userClassConfig->getIdentityPropertyName()))->camel(),
             'getUsername',
             'string',
             false,

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -29,6 +29,7 @@ use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToOne;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToMany;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToOne;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Component\String\UnicodeString;
 
 /**
  * @internal
@@ -85,6 +86,14 @@ final class ClassSourceManipulator
 
     public function addEntityField(string $propertyName, array $columnOptions, array $comments = [])
     {
+        $camelizedPropertyName = (string) (new UnicodeString($propertyName))->camel();
+
+        if ($camelizedPropertyName !== $propertyName) {
+            $columnOptions['name'] = $propertyName;
+
+            $propertyName = $camelizedPropertyName;
+        }
+
         $typeHint = $this->getEntityTypeHint($columnOptions['type']);
         $nullable = $columnOptions['nullable'] ?? false;
         $isId = (bool) ($columnOptions['id'] ?? false);

--- a/tests/Security/fixtures/expected/UserEntityUser_nameWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityUser_nameWithPassword.php
@@ -18,9 +18,9 @@ class User implements UserInterface
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=180, unique=true)
+     * @ORM\Column(type="string", length=180, unique=true, name="user_name")
      */
-    private $user_name;
+    private $userName;
 
     /**
      * @ORM\Column(type="json")
@@ -45,12 +45,12 @@ class User implements UserInterface
      */
     public function getUsername(): string
     {
-        return (string) $this->user_name;
+        return (string) $this->userName;
     }
 
-    public function setUserName(string $user_name): self
+    public function setUserName(string $userName): self
     {
-        $this->user_name = $user_name;
+        $this->userName = $userName;
 
         return $this;
     }

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -257,6 +257,15 @@ class ClassSourceManipulatorTest extends TestCase
             ],
             'User_simple_prop_zero.php',
         ];
+
+        yield 'snake_case_property' => [
+            'User_simple.php',
+            'foo_prop',
+            [
+                'type' => 'string',
+            ],
+            'User_simple_snake_cased.php',
+        ];
     }
 
     /**

--- a/tests/Util/fixtures/add_entity_field/User_simple_snake_cased.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_snake_cased.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", name="foo_prop")
+     */
+    private $fooProp;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getFooProp(): ?string
+    {
+        return $this->fooProp;
+    }
+
+    public function setFooProp(string $fooProp): self
+    {
+        $this->fooProp = $fooProp;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
When adding a new field in snake case, convert the property name to camel case, and add the `@ORM\Column` **name** attribute