### PR TITLE
MakeForm - Remove hard dependency on Doctrine

### DIFF
--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -53,7 +53,7 @@ final class MakeForm extends AbstractMaker
         $command
             ->setDescription('Creates a new form class')
             ->addArgument('name', InputArgument::OPTIONAL, sprintf('The name of the form class (e.g. <fg=yellow>%sType</>)', Str::asClassName(Str::getRandomTerm())))
-            ->addArgument('bound-class', InputArgument::OPTIONAL, 'The name of Entity or fully qualified model class name that the new form will be bound to (empty for none)')
+            ->addArgument('bound-class', InputArgument::OPTIONAL, 'The name of Entity or fully qualified model class name (prefixed with a "\") that the new form will be bound to (empty for none)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeForm.txt'))
         ;
 
@@ -95,7 +95,14 @@ final class MakeForm extends AbstractMaker
                 'Entity\\'
             );
 
-            $doctrineEntityDetails = $this->entityHelper->createDoctrineDetails($boundClassDetails->getFullName());
+            try {
+                $doctrineEntityDetails = $this->entityHelper->createDoctrineDetails($boundClassDetails->getFullName());
+            } catch (\Exception $e) {
+                // DoctrineBundle isn't installed
+                $io->comment($e->getMessage());
+
+                $doctrineEntityDetails = null;
+            }
 
             if (null !== $doctrineEntityDetails) {
                 $formFields = $doctrineEntityDetails->getFormFields();


### PR DESCRIPTION
Currently, if you try to generate a Form for a DTO without Doctine installed, you get the exception message:
`Somehow the doctrine service is missing. Is DoctrineBundle installed?`

But Doctine is not supposed to be mandatory. This PR add a note to inform that doctine is missing, without falling hard if the FQCN is valid