### PR TITLE
"Variables" param in file and template generators should be optional

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -65,7 +65,7 @@ class Generator
     /**
      * Generate a normal file from a template.
      */
-    public function generateFile(string $targetPath, string $templateName, array $variables)
+    public function generateFile(string $targetPath, string $templateName, array $variables = [])
     {
         $variables = array_merge($variables, [
             'helper' => $this->twigHelper,
@@ -219,7 +219,7 @@ class Generator
     /**
      * Generate a template file.
      */
-    public function generateTemplate(string $targetPath, string $templateName, array $variables)
+    public function generateTemplate(string $targetPath, string $templateName, array $variables = [])
     {
         $this->generateFile(
             $this->fileManager->getPathForTemplate($targetPath),


### PR DESCRIPTION
- file & template generator $variables param is now optional

Not all file and templates require variables to be passed for creation. 