### PR TITLE
make:subscriber: fix list active event

### DIFF
--- a/src/EventRegistry.php
+++ b/src/EventRegistry.php
@@ -107,6 +107,10 @@ class EventRegistry
             if (isset(self::$newEventsMap[$listenerKey])) {
                 unset($listeners[$listenerKey]);
             }
+
+            if (!isset(self::$eventsMap[$listenerKey])) {
+                self::$eventsMap[$listenerKey] = $this->getEventClassName($listenerKey);
+            }
         }
 
         $activeEvents = array_unique(array_merge($activeEvents, array_keys($listeners)));


### PR DESCRIPTION
With an addtionnal bundle or a component like "security-bundle", we have an exception
```
Notice: Undefined index: debug.security.authorization.vote
```

Now the mapping is good : 
![Capture d’écran 2020-03-03 à 15 23 00](https://user-images.githubusercontent.com/12966574/75784721-ee098180-5d62-11ea-9ab5-0e64b6efd254.png)
