### PR TITLE
Fixing bug where passing the full class name as the event didn't return same string

### DIFF
--- a/src/EventRegistry.php
+++ b/src/EventRegistry.php
@@ -125,6 +125,11 @@ class EventRegistry
      */
     public function getEventClassName(string $event)
     {
+        // if the event is already a class name, use it
+        if (class_exists($event)) {
+            return $event;
+        }
+
         if (isset(self::$eventsMap[$event])) {
             return self::$eventsMap[$event];
         }

--- a/tests/EventRegistryTest.php
+++ b/tests/EventRegistryTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\EventRegistry;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -83,6 +84,14 @@ class EventRegistryTest extends TestCase
 
         $registry = new EventRegistry($dispatcher);
         $this->assertSame(ExceptionEvent::class, $registry->getEventClassName(KernelEvents::EXCEPTION));
+    }
+
+    public function testGetEventClassNameGivenEventAsClass()
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $registry = new EventRegistry($dispatcher);
+        $this->assertSame(ControllerEvent::class, $registry->getEventClassName(ControllerEvent::class));
     }
 }
 


### PR DESCRIPTION
This caused an undefined index when running `make:subscriber` and choosing a fully-qualified event class as your event string. In this case, `EventRegistry::getEventClassName()` really has no work to do.