### PR TITLE
Allow to display links on created files

### DIFF
--- a/src/DependencyInjection/CompilerPass/RemoveMissingParametersPass.php
+++ b/src/DependencyInjection/CompilerPass/RemoveMissingParametersPass.php
@@ -25,7 +25,7 @@ class RemoveMissingParametersPass implements CompilerPassInterface
     {
         if (!$container->hasParameter('twig.default_path')) {
             $container->getDefinition('maker.file_manager')
-                ->replaceArgument(3, null);
+                ->replaceArgument(4, null);
         }
     }
 }

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle;
 
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
+use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -26,17 +27,24 @@ class FileManager
 {
     private $fs;
     private $autoloaderUtil;
+    private $makerFileLinkFormatter;
     private $rootDirectory;
     /** @var SymfonyStyle */
     private $io;
     private $twigDefaultPath;
 
-    public function __construct(Filesystem $fs, AutoloaderUtil $autoloaderUtil, string $rootDirectory, string $twigDefaultPath = null)
-    {
+    public function __construct(
+        Filesystem $fs,
+        AutoloaderUtil $autoloaderUtil,
+        MakerFileLinkFormatter $makerFileLinkFormatter,
+        string $rootDirectory,
+        string $twigDefaultPath = null
+    ) {
         // move FileManagerTest stuff
         // update EntityRegeneratorTest to mock the autoloader
         $this->fs = $fs;
         $this->autoloaderUtil = $autoloaderUtil;
+        $this->makerFileLinkFormatter = $makerFileLinkFormatter;
         $this->rootDirectory = rtrim($this->realPath($this->normalizeSlashes($rootDirectory)), '/');
         $this->twigDefaultPath = $twigDefaultPath ? rtrim($this->relativizePath($twigDefaultPath), '/') : null;
     }
@@ -67,12 +75,13 @@ class FileManager
         }
 
         $this->fs->dumpFile($absolutePath, $content);
+        $relativePath = $this->relativizePath($filename);
 
         if ($this->io) {
             $this->io->comment(sprintf(
                 '%s: %s',
                 $comment,
-                $this->relativizePath($filename)
+                $this->makerFileLinkFormatter->makeLinkedPath($absolutePath, $relativePath)
             ));
         }
     }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,6 +10,7 @@
             <service id="maker.file_manager" class="Symfony\Bundle\MakerBundle\FileManager">
                 <argument type="service" id="filesystem" />
                 <argument type="service" id="maker.autoloader_util" />
+                <argument type="service" id="maker.file_link_formatter" />
                 <argument>%kernel.project_dir%</argument>
                 <argument>%twig.default_path%</argument>
             </service>
@@ -20,6 +21,10 @@
 
             <service id="maker.autoloader_util" class="Symfony\Bundle\MakerBundle\Util\AutoloaderUtil">
                 <argument type="service" id="maker.autoloader_finder" />
+            </service>
+
+            <service id="maker.file_link_formatter" class="Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter" >
+                <argument type="service" id="debug.file_link_formatter" on-invalid="ignore" />
             </service>
 
             <service id="maker.event_registry" class="Symfony\Bundle\MakerBundle\EventRegistry">

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -245,9 +245,9 @@ final class MakerTestEnvironment
 
         $matches = [];
 
-        preg_match_all('#(created|updated): (.*)\n#iu', $output, $matches, PREG_PATTERN_ORDER);
+        preg_match_all('#(created|updated): (]8;;[^]*\\\)?(.*?)(]8;;\\\)?\n#iu', $output, $matches, PREG_PATTERN_ORDER);
 
-        return array_map('trim', $matches[2]);
+        return array_map('trim', $matches[3]);
     }
 
     public function fileExists(string $file)

--- a/src/Util/MakerFileLinkFormatter.php
+++ b/src/Util/MakerFileLinkFormatter.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Util;
+
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
+
+/**
+ * @internal
+ */
+final class MakerFileLinkFormatter
+{
+    private $fileLinkFormatter;
+
+    public function __construct(FileLinkFormatter $fileLinkFormatter = null)
+    {
+        // Since nullable types are not available in 7.0; can be removed when php >= 7.1 required
+        if (0 == \func_num_args()) {
+            throw new \LogicException('$fileLinkFormatter argument is required');
+        }
+
+        $this->fileLinkFormatter = $fileLinkFormatter;
+    }
+
+    public function makeLinkedPath(string $absolutePath, string $relativePath): string
+    {
+        if (!$this->fileLinkFormatter) {
+            return $relativePath;
+        }
+
+        if (!$formatted = $this->fileLinkFormatter->format($absolutePath, 1)) {
+            return $relativePath;
+        }
+
+        return $this->createLink(
+            $relativePath,
+            $formatted
+        );
+    }
+
+    private function createLink(string $text, string $href): string
+    {
+        return "\033]8;;{$href}\033\\{$text}\033]8;;\033\\";
+    }
+}

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\MakerBundle\Doctrine\EntityRegenerator;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
+use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
@@ -108,7 +109,7 @@ class EntityRegeneratorTest extends TestCase
                 return $tmpDir.'/src/'.str_replace('\\', '/', $shortClassName).'.php';
             });
 
-        $fileManager = new FileManager($fs, $autoloaderUtil, $tmpDir);
+        $fileManager = new FileManager($fs, $autoloaderUtil, new MakerFileLinkFormatter(null), $tmpDir);
         $doctrineHelper = new DoctrineHelper('App\\Entity', $container->get('doctrine'));
         $regenerator = new EntityRegenerator(
             $doctrineHelper,

--- a/tests/FileManagerTest.php
+++ b/tests/FileManagerTest.php
@@ -14,7 +14,10 @@ namespace Symfony\Bundle\MakerBundle\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
+use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 
 class FileManagerTest extends TestCase
 {
@@ -23,7 +26,12 @@ class FileManagerTest extends TestCase
      */
     public function testRelativizePath(string $rootDir, string $absolutePath, string $expectedPath)
     {
-        $fileManager = new FileManager(new Filesystem(), $this->createMock(AutoloaderUtil::class), $rootDir);
+        $fileManager = new FileManager(
+            new Filesystem(),
+            $this->createMock(AutoloaderUtil::class),
+            new MakerFileLinkFormatter(null),
+            $rootDir
+        );
 
         $this->assertSame($expectedPath, $fileManager->relativizePath($absolutePath));
     }
@@ -72,7 +80,12 @@ class FileManagerTest extends TestCase
      */
     public function testAbsolutizePath(string $rootDir, string $path, string $expectedPath)
     {
-        $fileManager = new FileManager(new Filesystem(), $this->createMock(AutoloaderUtil::class), $rootDir);
+        $fileManager = new FileManager(
+            new Filesystem(),
+            $this->createMock(AutoloaderUtil::class),
+            new MakerFileLinkFormatter(null),
+            $rootDir
+        );
         $this->assertSame($expectedPath, $fileManager->absolutizePath($path));
     }
 
@@ -108,7 +121,12 @@ class FileManagerTest extends TestCase
      */
     public function testIsPathInVendor(string $rootDir, string $path, bool $expectedIsInVendor)
     {
-        $fileManager = new FileManager(new Filesystem(), $this->createMock(AutoloaderUtil::class), $rootDir);
+        $fileManager = new FileManager(
+            new Filesystem(),
+            $this->createMock(AutoloaderUtil::class),
+            new MakerFileLinkFormatter(null),
+            $rootDir
+        );
         $this->assertSame($expectedIsInVendor, $fileManager->isPathInVendor($path));
     }
 
@@ -150,7 +168,13 @@ class FileManagerTest extends TestCase
      */
     public function testPathForTemplate(string $rootDir, string $twigDefaultPath, string $expectedTemplatesFolder)
     {
-        $fileManager = new FileManager(new Filesystem(), $this->createMock(AutoloaderUtil::class), $rootDir, $twigDefaultPath);
+        $fileManager = new FileManager(
+            new Filesystem(),
+            $this->createMock(AutoloaderUtil::class),
+            new MakerFileLinkFormatter(null),
+            $rootDir,
+            $twigDefaultPath
+        );
         $this->assertSame($expectedTemplatesFolder, $fileManager->getPathForTemplate('template.html.twig'));
     }
 
@@ -161,5 +185,32 @@ class FileManagerTest extends TestCase
             '/home/project/templates',
             'templates/template.html.twig',
         ];
+    }
+
+    public function testWithMakerFileLinkFormatter(): void
+    {
+        $fileLinkFormatter = $this->createMock(FileLinkFormatter::class);
+        $fileLinkFormatter
+            ->method('format')
+            ->willReturnCallback(function ($path, $line) {
+                return sprintf('subl://open?url=file://%s&line=%d', $path, $line);
+            });
+
+        $fileManager = new FileManager(
+            $this->createMock(Filesystem::class),
+            $this->createMock(AutoloaderUtil::class),
+            new MakerFileLinkFormatter($fileLinkFormatter),
+            '/app'
+        );
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io
+            ->expects($this->once())
+            ->method('comment')
+            ->with("<fg=green>no change</>: \033]8;;subl://open?url=file:///app/myfile&line=1\033\\myfile\033]8;;\033\\");
+
+        $fileManager->setIO($io);
+
+        $fileManager->dumpFile('myfile', '');
     }
 }

--- a/tests/Util/MakerFileLinkFormatterTest.php
+++ b/tests/Util/MakerFileLinkFormatterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
+
+final class MakerFileLinkFormatterTest extends TestCase
+{
+    public function provideMakeLinkedPath(): \Generator
+    {
+        yield 'no_formatter' => [false, false, './my/relative/path'];
+        yield 'with_formatter' => [
+            true,
+            true,
+            "\033]8;;subl://open?url=file:///my/absolute/path&line=1\033\\./my/relative/path\033]8;;\033\\",
+        ];
+        yield 'formatter_returns_false' => [true, false, './my/relative/path'];
+    }
+
+    /**
+     * @dataProvider provideMakeLinkedPath
+     */
+    public function testMakeLinkedPath(bool $withFileLinkFormatter, bool $linkFormatterReturnsLink, string $expectedOutput): void
+    {
+        $fileLinkFormatter = null;
+        if ($withFileLinkFormatter) {
+            $fileLinkFormatter = $this->createMock(FileLinkFormatter::class);
+            $return = $linkFormatterReturnsLink ? $this->returnCallback(function ($path, $line) {
+                return sprintf('subl://open?url=file://%s&line=%d', $path, $line);
+            }) : $this->returnValue(false);
+            $fileLinkFormatter
+               ->method('format')
+               ->will($return);
+        }
+
+        $sut = new MakerFileLinkFormatter($fileLinkFormatter);
+        $this->assertEquals(
+           $expectedOutput,
+           $sut->makeLinkedPath('/my/absolute/path', './my/relative/path')
+       );
+    }
+}

--- a/tests/fixtures/MakeController/config/packages/framework.yaml
+++ b/tests/fixtures/MakeController/config/packages/framework.yaml
@@ -1,0 +1,2 @@
+framework:
+  ide: 'phpstorm://open?file=%%f&line=%%l'


### PR DESCRIPTION
This PR aims to display terminal links on the created file paths when the `framework.ide` configuration param (or `debug.file_link_format` container parameter) is set (only displayed if the terminal support it).