### PR TITLE
explicitly set framework.router.utf8 value in test kernel

### DIFF
--- a/src/Test/MakerTestKernel.php
+++ b/src/Test/MakerTestKernel.php
@@ -53,7 +53,12 @@ class MakerTestKernel extends Kernel implements CompilerPassInterface
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
-        $c->setParameter('kernel.secret', 123);
+        $c->loadFromExtension('framework', [
+            'secret' => 123,
+            'router' => [
+                'utf8' => true,
+            ],
+        ]);
     }
 
     public function getProjectDir()

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -151,7 +151,13 @@ class TestEntityRegeneratorKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
-        $c->setParameter('kernel.secret', 123);
+        $c->loadFromExtension('framework', [
+            'secret' => 123,
+            'router' => [
+                'utf8' => true,
+            ],
+        ]);
+
         $c->prependExtensionConfig('doctrine', [
             'dbal' => [
                 'driver' => 'pdo_sqlite',
@@ -200,7 +206,13 @@ class TestXmlEntityRegeneratorKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
-        $c->setParameter('kernel.secret', 123);
+        $c->loadFromExtension('framework', [
+            'secret' => 123,
+            'router' => [
+                'utf8' => true,
+            ],
+        ]);
+
         $c->prependExtensionConfig('doctrine', [
             'dbal' => [
                 'driver' => 'pdo_sqlite',


### PR DESCRIPTION
fixes `Since symfony/framework-bundle 5.1: Not setting the "framework.router.utf8" configuration option is deprecated, it will default to "true" in version 6.0.` deprecation warning in tests / ci

not intended to address any other deprecation's or fix/refactor other logic