### PR TITLE
create maker for symfony casts reset password bundle

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -1,0 +1,315 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
+use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Yaml\Yaml;
+use SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle;
+
+/**
+ * @author Romaric Drigon <romaric.drigon@gmail.com>
+ * @author Jesse Rushlow  <jr@rushlow.dev>
+ * @author Ryan Weaver    <ryan@symfonycasts.com>
+ *
+ * @internal
+ * @final
+ */
+class MakeResetPassword extends AbstractMaker
+{
+    private $fileManager;
+
+    public function __construct(FileManager $fileManager)
+    {
+        $this->fileManager = $fileManager;
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:reset-password';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->setDescription('Create controller, entity, and repositories for use with symfonycasts/reset-password-bundle.')
+        ;
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(SymfonyCastsResetPasswordBundle::class, 'symfonycasts/reset-password-bundle');
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    {
+        $io->title('Let\'s make a password reset feature!');
+
+        // initialize arguments & commands that are internal (i.e. meant only to be asked)
+        $command
+            ->addArgument('from-email-address', InputArgument::REQUIRED)
+            ->addArgument('from-email-name', InputArgument::REQUIRED)
+            ->addArgument('controller-reset-success-redirect', InputArgument::REQUIRED)
+            ->addArgument('user-class')
+            ->addArgument('email-property-name')
+            ->addArgument('email-getter')
+            ->addArgument('password-setter')
+        ;
+
+        $interactiveSecurityHelper = new InteractiveSecurityHelper();
+
+        if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
+            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. This command needs that file to accurately build the reset password form.');
+        }
+
+        $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));
+        $securityData = $manipulator->getData();
+        $providersData = $securityData['security']['providers'] ?? [];
+
+        $input->setArgument(
+            'user-class',
+            $userClass = $interactiveSecurityHelper->guessUserClass(
+                $io,
+                $providersData,
+                'What is the User entity that should be used with the "forgotten password" feature? (e.g. <fg=yellow>App\\Entity\\User</>)'
+            )
+        );
+
+        $input->setArgument(
+            'email-property-name',
+            $interactiveSecurityHelper->guessEmailField($io, $userClass)
+        );
+        $input->setArgument(
+            'email-getter',
+            $interactiveSecurityHelper->guessEmailGetter($io, $userClass)
+        );
+        $input->setArgument(
+            'password-setter',
+            $interactiveSecurityHelper->guessPasswordSetter($io, $userClass)
+        );
+
+        $io->text(sprintf('Implementing reset password for <info>%s</info>', $userClass));
+
+        $io->section('- ResetPasswordController -');
+        $io->text('A named route is used for redirecting after a successful reset. Even a route that does not exist yet can be used here.');
+        $input->setArgument('controller-reset-success-redirect', $io->ask(
+            'What route should users be redirected to after their password has been successfully reset?',
+            'app_home',
+            [Validator::class, 'notBlank']
+        )
+        );
+
+        $io->section('- Email Templates -');
+        $emailText[] = 'These are used to generate the email code. Don\'t worry, you can change them in the code later!';
+        $io->text($emailText);
+
+        $input->setArgument('from-email-address', $io->ask(
+            'What email address will be used to send reset confirmations? e.g. admin@your-domain.com',
+            null,
+            [Validator::class, 'validateEmailAddress']
+        ));
+
+        $input->setArgument('from-email-name', $io->ask(
+            'What "name" should be associated with that email address? e.g. "Acme Mail Bot"',
+            null,
+            [Validator::class, 'notBlank']
+        )
+        );
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $userClass = $input->getArgument('user-class');
+        $userClassNameDetails = $generator->createClassNameDetails(
+            '\\'.$userClass,
+            'Entity\\'
+        );
+
+        $controllerClassNameDetails = $generator->createClassNameDetails(
+            'ResetPasswordController',
+            'Controller\\'
+        );
+
+        $requestClassNameDetails = $generator->createClassNameDetails(
+            'ResetPasswordRequest',
+            'Entity\\'
+        );
+
+        $repositoryClassNameDetails = $generator->createClassNameDetails(
+            'ResetPasswordRequestRepository',
+            'Repository\\'
+        );
+
+        $requestFormTypeClassNameDetails = $generator->createClassNameDetails(
+            'ResetPasswordRequestFormType',
+            'Form\\'
+        );
+
+        $changePasswordFormTypeClassNameDetails = $generator->createClassNameDetails(
+            'ChangePasswordFormType',
+            'Form\\'
+        );
+
+        $generator->generateController(
+            $controllerClassNameDetails->getFullName(),
+            'resetPassword/ResetPasswordController.tpl.php',
+            [
+                'user_full_class_name' => $userClassNameDetails->getFullName(),
+                'user_class_name' => $userClassNameDetails->getShortName(),
+                'request_form_type_full_class_name' => $requestFormTypeClassNameDetails->getFullName(),
+                'request_form_type_class_name' => $requestFormTypeClassNameDetails->getShortName(),
+                'reset_form_type_full_class_name' => $changePasswordFormTypeClassNameDetails->getFullName(),
+                'reset_form_type_class_name' => $changePasswordFormTypeClassNameDetails->getShortName(),
+                'password_setter' => $input->getArgument('password-setter'),
+                'success_redirect_route' => $input->getArgument('controller-reset-success-redirect'),
+                'from_email' => $input->getArgument('from-email-address'),
+                'from_email_name' => $input->getArgument('from-email-name'),
+                'email_getter' => $input->getArgument('email-getter'),
+            ]
+        );
+
+        $generator->generateClass(
+            $requestClassNameDetails->getFullName(),
+            'resetPassword/ResetPasswordRequest.tpl.php',
+            [
+                'repository_class_name' => $repositoryClassNameDetails->getFullName(),
+                'user_full_class_name' => $userClassNameDetails->getFullName(),
+            ]
+        );
+
+        $generator->generateClass(
+            $repositoryClassNameDetails->getFullName(),
+            'resetPassword/ResetPasswordRequestRepository.tpl.php',
+            [
+                'request_class_full_name' => $requestClassNameDetails->getFullName(),
+                'request_class_name' => $requestClassNameDetails->getShortName(),
+            ]
+        );
+
+        $this->setBundleConfig($io, $generator, $repositoryClassNameDetails->getFullName());
+
+        $generator->generateClass(
+            $requestFormTypeClassNameDetails->getFullName(),
+            'resetPassword/ResetPasswordRequestFormType.tpl.php',
+            [
+                'email_field' => $input->getArgument('email-property-name'),
+            ]
+        );
+
+        $generator->generateClass(
+            $changePasswordFormTypeClassNameDetails->getFullName(),
+            'resetPassword/ChangePasswordFormType.tpl.php'
+        );
+
+        $generator->generateTemplate(
+            'reset_password/check_email.html.twig',
+            'resetPassword/twig_check_email.tpl.php'
+        );
+
+        $generator->generateTemplate(
+            'reset_password/email.html.twig',
+            'resetPassword/twig_email.tpl.php'
+        );
+
+        $generator->generateTemplate(
+            'reset_password/request.html.twig',
+            'resetPassword/twig_request.tpl.php',
+            [
+                'email_field' => $input->getArgument('email-property-name'),
+            ]
+        );
+
+        $generator->generateTemplate(
+            'reset_password/reset.html.twig',
+            'resetPassword/twig_reset.tpl.php'
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+        $this->successMessage($input, $io, $requestClassNameDetails->getFullName());
+    }
+
+    private function setBundleConfig(ConsoleStyle $io, Generator $generator, string $repositoryClassFullName)
+    {
+        $configFileExists = $this->fileManager->fileExists($path = 'config/packages/reset_password.yaml');
+
+        /*
+         * reset_password.yaml does not exist, we assume flex was present when
+         * the bundle was installed & a customized configuration is in use.
+         * Remind the developer to set the repository class accordingly.
+         */
+        if (!$configFileExists) {
+            $io->text(sprintf('We can\'t find %s. That\'s ok, you probably have a customized configuration.', $path));
+            $io->text('Just remember to set the <fg=yellow>request_password_repository</> in your configuration.');
+            $io->newLine();
+
+            return;
+        }
+
+        $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));
+        $data = $manipulator->getData();
+
+        $symfonyCastsKey = 'symfonycasts_reset_password';
+
+        /*
+         * reset_password.yaml exists, and was probably created by flex;
+         * Let's replace it with a "clean" file.
+         */
+        if (1 >= \count($data[$symfonyCastsKey])) {
+            $yaml = [
+                $symfonyCastsKey => [
+                    'request_password_repository' => $repositoryClassFullName,
+                ],
+            ];
+
+            $generator->dumpFile($path, Yaml::dump($yaml));
+
+            return;
+        }
+
+        /*
+         * reset_password.yaml exists and appears to have been customized
+         * before running make:reset-password. Let's just change the repository
+         * value and preserve everything else.
+         */
+        $data[$symfonyCastsKey]['request_password_repository'] = $repositoryClassFullName;
+
+        $manipulator->setData($data);
+
+        $generator->dumpFile($path, $manipulator->getContents());
+    }
+
+    private function successMessage(InputInterface $input, ConsoleStyle $io, string $requestClassName)
+    {
+        $closing[] = 'Next:';
+        $closing[] = sprintf('  1) Run <fg=yellow>"php bin/console make:migration"</> to generate a migration for the new <fg=yellow>"%s"</> entity.', $requestClassName);
+        $closing[] = '  2) Review forms in <fg=yellow>"src/Form"</> to customize validation and labels.';
+        $closing[] = '  3) Review and customize the templates in <fg=yellow>`templates/reset_password`</>.';
+        $closing[] = '  4) Make sure your <fg=yellow>MAILER_DSN</> env var has the correct settings.';
+
+        $io->text($closing);
+        $io->newLine();
+        $io->text('Then open your browser, go to "/reset-password" and enjoy!');
+        $io->newLine();
+    }
+}

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -68,6 +68,11 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_reset_password" class="Symfony\Bundle\MakerBundle\Maker\MakeResetPassword">
+                <argument type="service" id="maker.file_manager" />
+                <tag name="maker.command" />
+            </service>
+
             <service id="maker.maker.make_serializer_encoder" class="Symfony\Bundle\MakerBundle\Maker\MakeSerializerEncoder">
                 <tag name="maker.command" />
             </service>

--- a/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
@@ -1,0 +1,49 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class <?= $class_name ?> extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('plainPassword', RepeatedType::class, [
+                'type' => PasswordType::class,
+                'first_options' => [
+                    'constraints' => [
+                        new NotBlank([
+                            'message' => 'Please enter a password',
+                        ]),
+                        new Length([
+                            'min' => 6,
+                            'minMessage' => 'Your password should be at least {{ limit }} characters',
+                            // max length allowed by Symfony for security reasons
+                            'max' => 4096,
+                        ]),
+                    ],
+                    'label' => 'New password',
+                ],
+                'second_options' => [
+                    'label' => 'Repeat Password',
+                ],
+                'invalid_message' => 'The password fields must match.',
+                // Instead of being set onto the object directly,
+                // this is read and encoded in the controller
+                'mapped' => false,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([]);
+    }
+}

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -1,0 +1,173 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+use <?= $user_full_class_name ?>;
+use <?= $reset_form_type_full_class_name ?>;
+use <?= $request_form_type_full_class_name ?>;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
+use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+/**
+ * @Route("/reset-password")
+ */
+class <?= $class_name ?> extends AbstractController
+{
+    use ResetPasswordControllerTrait;
+
+    private $resetPasswordHelper;
+
+    public function __construct(ResetPasswordHelperInterface $resetPasswordHelper)
+    {
+        $this->resetPasswordHelper = $resetPasswordHelper;
+    }
+
+    /**
+     * Display & process form to request a password reset.
+     *
+     * @Route("", name="app_forgot_password_request")
+     */
+    public function request(Request $request, MailerInterface $mailer): Response
+    {
+        $form = $this->createForm(<?= $request_form_type_class_name ?>::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            return $this->processSendingPasswordResetEmail(
+                $form->get('email')->getData(),
+                $mailer
+            );
+        }
+
+        return $this->render('reset_password/request.html.twig', [
+            'requestForm' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * Confirmation page after a user has requested a password reset.
+     *
+     * @Route("/check-email", name="app_check_email")
+     */
+    public function checkEmail(): Response
+    {
+        // We prevent users from directly accessing this page
+        if (!$this->canCheckEmail()) {
+            return $this->redirectToRoute('app_forgot_password_request');
+        }
+
+        return $this->render('reset_password/check_email.html.twig', [
+            'tokenLifetime' => $this->resetPasswordHelper->getTokenLifetime(),
+        ]);
+    }
+
+    /**
+     * Validates and process the reset URL that the user clicked in their email.
+     *
+     * @Route("/reset/{token}", name="app_reset_password")
+     */
+    public function reset(Request $request, UserPasswordEncoderInterface $passwordEncoder, string $token = null): Response
+    {
+        if ($token) {
+            // We store the token in session and remove it from the URL, to avoid the URL being
+            // loaded in a browser and potentially leaking the token to 3rd party JavaScript.
+            $this->storeTokenInSession($token);
+
+            return $this->redirectToRoute('app_reset_password');
+        }
+
+        $token = $this->getTokenFromSession();
+        if (null === $token) {
+            throw $this->createNotFoundException('No reset password token found in the URL or in the session.');
+        }
+
+        try {
+            $user = $this->resetPasswordHelper->validateTokenAndFetchUser($token);
+        } catch (ResetPasswordExceptionInterface $e) {
+            $this->addFlash('reset_password_error', sprintf(
+                'There was a problem validating your reset request - %s',
+                $e->getReason()
+            ));
+
+            return $this->redirectToRoute('app_forgot_password_request');
+        }
+
+        // The token is valid; allow the user to change their password.
+        $form = $this->createForm(<?= $reset_form_type_class_name ?>::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // A password reset token should be used only once, remove it.
+            $this->resetPasswordHelper->removeResetRequest($token);
+
+            // Encode the plain password, and set it.
+            $encodedPassword = $passwordEncoder->encodePassword(
+                $user,
+                $form->get('plainPassword')->getData()
+            );
+
+            $user-><?= $password_setter ?>($encodedPassword);
+            $this->getDoctrine()->getManager()->flush();
+
+            // The session is cleaned up after the password has been changed.
+            $this->cleanSessionAfterReset();
+
+            return $this->redirectToRoute('<?= $success_redirect_route ?>');
+        }
+
+        return $this->render('reset_password/reset.html.twig', [
+            'resetForm' => $form->createView(),
+        ]);
+    }
+
+    private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer): RedirectResponse
+    {
+        $user = $this->getDoctrine()->getRepository(<?= $user_class_name ?>::class)->findOneBy([
+            'email' => $emailFormData,
+        ]);
+
+        // Marks that you are allowed to see the app_check_email page.
+        $this->setCanCheckEmailInSession();
+
+        // Do not reveal whether a user account was found or not.
+        if (!$user) {
+            return $this->redirectToRoute('app_check_email');
+        }
+
+        try {
+            $resetToken = $this->resetPasswordHelper->generateResetToken($user);
+        } catch (ResetPasswordExceptionInterface $e) {
+            $this->addFlash('reset_password_error', sprintf(
+                'There was a problem handling your password reset request - %s',
+                $e->getReason()
+            ));
+
+            return $this->redirectToRoute('app_forgot_password_request');
+        }
+
+        $email = (new TemplatedEmail())
+            ->from(new Address('<?= $from_email ?>', '<?= $from_email_name ?>'))
+            ->to($user-><?= $email_getter ?>())
+            ->subject('Your password reset request')
+            ->htmlTemplate('reset_password/email.html.twig')
+            ->context([
+                'resetToken' => $resetToken,
+                'tokenLifetime' => $this->resetPasswordHelper->getTokenLifetime(),
+            ])
+        ;
+
+        $mailer->send($email);
+
+        return $this->redirectToRoute('app_check_email');
+    }
+}

--- a/src/Resources/skeleton/resetPassword/ResetPasswordRequest.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordRequest.tpl.php
@@ -1,0 +1,38 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+use Doctrine\ORM\Mapping as ORM;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestTrait;
+
+/**
+ * @ORM\Entity(repositoryClass="<?= $repository_class_name ?>")
+ */
+class <?= $class_name ?> implements ResetPasswordRequestInterface
+{
+    use ResetPasswordRequestTrait;
+
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="<?= $user_full_class_name ?>")
+     */
+    private $user;
+
+    public function __construct(object $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken)
+    {
+        $this->user = $user;
+        $this->initialize($expiresAt, $selector, $hashedToken);
+    }
+
+    public function getUser(): object
+    {
+        return $this->user;
+    }
+}

--- a/src/Resources/skeleton/resetPassword/ResetPasswordRequestFormType.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordRequestFormType.tpl.php
@@ -1,0 +1,30 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class <?= $class_name ?> extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('<?= $email_field ?>', EmailType::class, [
+                'constraints' => [
+                    new NotBlank([
+                        'message' => 'Please enter your email',
+                    ]),
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([]);
+    }
+}

--- a/src/Resources/skeleton/resetPassword/ResetPasswordRequestRepository.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordRequestRepository.tpl.php
@@ -1,0 +1,40 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+use <?= $request_class_full_name ?>;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\Repository\ResetPasswordRequestRepositoryTrait;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
+
+/**
+ * @method <?= $request_class_name ?>|null find($id, $lockMode = null, $lockVersion = null)
+ * @method <?= $request_class_name ?>|null findOneBy(array $criteria, array $orderBy = null)
+ * @method <?= $request_class_name ?>[]    findAll()
+ * @method <?= $request_class_name ?>[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class <?= $class_name ?> extends ServiceEntityRepository implements ResetPasswordRequestRepositoryInterface
+{
+    use ResetPasswordRequestRepositoryTrait;
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, <?= $request_class_name ?>::class);
+    }
+
+    public function createResetPasswordRequest(
+        object $user,
+        \DateTimeInterface $expiresAt,
+        string $selector,
+        string $hashedToken
+    ): ResetPasswordRequestInterface {
+        return new <?= $request_class_name ?>(
+            $user,
+            $expiresAt,
+            $selector,
+            $hashedToken
+        );
+    }
+}

--- a/src/Resources/skeleton/resetPassword/twig_check_email.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_check_email.tpl.php
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Password Reset Email Sent{% endblock %}
+
+{% block body %}
+    <p>An email has been sent that contains a link that you can click to reset your password. This link will expire in {{ tokenLifetime|date('g') }} hour(s).</p>
+    <p>If you don't receive an email please check your spam folder or <a href="{{ path('app_forgot_password_request') }}">try again</a>.</p>
+{% endblock %}

--- a/src/Resources/skeleton/resetPassword/twig_email.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_email.tpl.php
@@ -1,0 +1,11 @@
+<h1>Hi!</h1>
+
+<p>
+    To reset your password, please visit
+    <a href="{{ url('app_reset_password', {token: resetToken.token}) }}">here</a>
+    This link will expire in {{ tokenLifetime|date('g') }} hour(s)..
+</p>
+
+<p>
+    Cheers!
+</p>

--- a/src/Resources/skeleton/resetPassword/twig_request.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_request.tpl.php
@@ -1,0 +1,22 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Reset your password{% endblock %}
+
+{% block body %}
+    {% for flashError in app.flashes('reset_password_error') %}
+        <div class="alert alert-danger" role="alert">{{ flashError }}</div>
+    {% endfor %}
+    <h1>Reset your password</h1>
+
+    {{ form_start(requestForm) }}
+        {{ form_row(requestForm.<?= $email_field ?>) }}
+        <div>
+            <small>
+                Enter your email address and we we will send you a
+                link to reset your password.
+            </small>
+        </div>
+
+        <button class="btn btn-primary">Send password reset email</button>
+    {{ form_end(requestForm) }}
+{% endblock %}

--- a/src/Resources/skeleton/resetPassword/twig_reset.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_reset.tpl.php
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Reset your password{% endblock %}
+
+{% block body %}
+    <h1>Reset your password</h1>
+
+    {{ form_start(resetForm) }}
+        {{ form_row(resetForm.plainPassword) }}
+        <button class="btn btn-primary">Reset password</button>
+    {{ form_end(resetForm) }}
+{% endblock %}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -167,6 +167,15 @@ final class Validator
         return $name;
     }
 
+    public static function validateEmailAddress(string $email): string
+    {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new RuntimeCommandException(sprintf('"%s" is not a valid email address.', $email));
+        }
+
+        return $email;
+    }
+
     public static function existsOrNull(string $className = null, array $entities = [])
     {
         if (null !== $className) {

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeResetPassword;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+class MakeResetPasswordTest extends MakerTestCase
+{
+    public function getTestDetails()
+    {
+        yield 'reset_password_replaces_flex_config' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeResetPassword::class),
+            [
+                'App\Entity\User',
+                'app_home',
+                'jr@rushlow.dev',
+                'SymfonyCasts',
+            ])
+            ->setRequiredPhpVersion(70200)
+            ->addExtraDependencies('security-bundle')
+            ->addExtraDependencies('twig')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPassword')
+            ->assert(
+                function (string $output, string $directory) {
+                    $this->assertStringContainsString('Success', $output);
+
+                    $fs = new Filesystem();
+
+                    $generatedFiles = [
+                        'src/Controller/ResetPasswordController.php',
+                        'src/Entity/ResetPasswordRequest.php',
+                        'src/Form/ChangePasswordFormType.php',
+                        'src/Form/ResetPasswordRequestFormType.php',
+                        'src/Repository/ResetPasswordRequestRepository.php',
+                        'templates/reset_password/check_email.html.twig',
+                        'templates/reset_password/email.html.twig',
+                        'templates/reset_password/request.html.twig',
+                        'templates/reset_password/reset.html.twig',
+                    ];
+
+                    foreach ($generatedFiles as $file) {
+                        $this->assertTrue($fs->exists(sprintf('%s/%s', $directory, $file)));
+                    }
+
+                    $configFileContents = file_get_contents(sprintf('%s/config/packages/reset_password.yaml', $directory));
+
+                    // Flex recipe adds comments in reset_password.yaml, check file was replaced by maker
+                    $this->assertStringNotContainsString('#', $configFileContents);
+
+                    $resetPasswordConfig = Yaml::parse($configFileContents);
+
+                    $this->assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
+                }
+            ),
+        ];
+
+        yield 'reset_password_custom_config' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeResetPassword::class),
+            [
+                'App\Entity\User',
+                'app_home',
+                'jr@rushlow.dev',
+                'SymfonyCasts',
+            ])
+            ->setRequiredPhpVersion(70200)
+            ->addExtraDependencies('security-bundle')
+            ->addExtraDependencies('twig')
+            ->deleteFile('config/packages/reset_password.yaml')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordCustomConfig')
+            ->assert(
+                function (string $output, string $directory) {
+                    $this->assertStringContainsString('Success', $output);
+
+                    $fs = new Filesystem();
+                    $this->assertFalse($fs->exists(sprintf('%s/config/packages/reset_password.yaml', $directory)));
+                    $this->assertStringContainsString(
+                        'Just remember to set the request_password_repository in your configuration.',
+                        $output
+                    );
+                }
+            ),
+        ];
+
+        yield 'reset_password_amends_config' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeResetPassword::class),
+            [
+                'App\Entity\User',
+                'app_home',
+                'jr@rushlow.dev',
+                'SymfonyCasts',
+            ])
+            ->setRequiredPhpVersion(70200)
+            ->addExtraDependencies('security-bundle')
+            ->addExtraDependencies('twig')
+            ->addReplacement(
+                'config/packages/reset_password.yaml',
+                'symfonycasts_reset_password:',
+                Yaml::dump(['symfonycasts_reset_password' => ['lifetime' => 9999]])
+            )
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordModifiedConfig')
+            ->assert(
+                function (string $output, string $directory) {
+                    $this->assertStringContainsString('Success', $output);
+
+                    $configFileContents = file_get_contents(sprintf('%s/config/packages/reset_password.yaml', $directory));
+
+                    $resetPasswordConfig = Yaml::parse($configFileContents);
+
+                    $this->assertStringContainsString('9999', $resetPasswordConfig['symfonycasts_reset_password']['lifetime']);
+                    $this->assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
+                }
+            ),
+        ];
+
+        yield 'reset_password_functional_test' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeResetPassword::class),
+            [
+                'App\Entity\User',
+                'app_home',
+                'jr@rushlow.dev',
+                'SymfonyCasts',
+            ])
+            ->setRequiredPhpVersion(70200)
+            ->addExtraDependencies('doctrine')
+            ->addExtraDependencies('doctrine/annotations')
+            ->addExtraDependencies('mailer')
+            ->addExtraDependencies('security-bundle')
+            ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/validator')
+            ->addExtraDependencies('twig')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordFunctionalTest'),
+        ];
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -65,6 +65,15 @@ class ValidatorTest extends TestCase
         $this->assertSame('Foo', Validator::validateClassName('Foo'));
     }
 
+    public function testValidateEmailAddress()
+    {
+        $this->assertSame('jr@rushlow.dev', Validator::validateEmailAddress('jr@rushlow.dev'));
+
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('"badEmail" is not a valid email address.');
+        Validator::validateEmailAddress('badEmail');
+    }
+
     public function testInvalidClassName()
     {
         $this->expectException(RuntimeCommandException::class);

--- a/tests/fixtures/MakeResetPassword/config/packages/security.yml
+++ b/tests/fixtures/MakeResetPassword/config/packages/security.yml
@@ -1,0 +1,3 @@
+security:
+    encoders:
+        App\Entity\User: bcrypt

--- a/tests/fixtures/MakeResetPassword/src/Entity/User.php
+++ b/tests/fixtures/MakeResetPassword/src/Entity/User.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Entity;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    private $email;
+
+    public function getEmail()
+    {
+    }
+
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function setPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/tests/fixtures/MakeResetPasswordCustomConfig/config/packages/custom_reset_password.yaml
+++ b/tests/fixtures/MakeResetPasswordCustomConfig/config/packages/custom_reset_password.yaml
@@ -1,0 +1,2 @@
+symfonycasts_reset_password:
+    request_password_repository: symfonycasts.reset_password.fake_request_repository

--- a/tests/fixtures/MakeResetPasswordCustomConfig/config/packages/security.yml
+++ b/tests/fixtures/MakeResetPasswordCustomConfig/config/packages/security.yml
@@ -1,0 +1,3 @@
+security:
+    encoders:
+        App\Entity\User: bcrypt

--- a/tests/fixtures/MakeResetPasswordCustomConfig/src/Entity/User.php
+++ b/tests/fixtures/MakeResetPasswordCustomConfig/src/Entity/User.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Entity;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    private $email;
+
+    public function getEmail()
+    {
+    }
+
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function setPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/tests/fixtures/MakeResetPasswordFunctionalTest/config/packages/mailer.yaml
+++ b/tests/fixtures/MakeResetPasswordFunctionalTest/config/packages/mailer.yaml
@@ -1,0 +1,3 @@
+framework:
+  mailer:
+    dsn: 'null://null'

--- a/tests/fixtures/MakeResetPasswordFunctionalTest/config/packages/security.yml
+++ b/tests/fixtures/MakeResetPasswordFunctionalTest/config/packages/security.yml
@@ -1,0 +1,3 @@
+security:
+    encoders:
+        App\Entity\User: bcrypt

--- a/tests/fixtures/MakeResetPasswordFunctionalTest/src/Entity/User.php
+++ b/tests/fixtures/MakeResetPasswordFunctionalTest/src/Entity/User.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Entity;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    private $email;
+
+    public function getEmail()
+    {
+    }
+
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function setPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/tests/fixtures/MakeResetPasswordFunctionalTest/tests/ResetPasswordFunctionalTest.php
+++ b/tests/fixtures/MakeResetPasswordFunctionalTest/tests/ResetPasswordFunctionalTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ResetPasswordFunctionalTest extends WebTestCase
+{
+    public function testResetRequestRoute()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/reset-password');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testResetRequestRouteDeniesInvalidToken()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/reset-password/reset/badToken1234');
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+    }
+
+    public function testCheckEmailRouteRedirectsToRequestRouteIfUserNotAllowedToCheckEmail()
+    {
+        $client = static::createClient();
+        $client->request('GET', '/reset-password/check-email');
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $this->assertResponseRedirects('/reset-password');
+    }
+}

--- a/tests/fixtures/MakeResetPasswordModifiedConfig/config/packages/security.yml
+++ b/tests/fixtures/MakeResetPasswordModifiedConfig/config/packages/security.yml
@@ -1,0 +1,3 @@
+security:
+    encoders:
+        App\Entity\User: bcrypt

--- a/tests/fixtures/MakeResetPasswordModifiedConfig/src/Entity/User.php
+++ b/tests/fixtures/MakeResetPasswordModifiedConfig/src/Entity/User.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Entity;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    private $email;
+
+    public function getEmail()
+    {
+    }
+
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function setPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}


### PR DESCRIPTION
Adds a `make:reset-password` maker to create the classes, entities, and twig templates required by Symfony Casts Reset Password Bundle. This complements the bundle by doing the leg work to provide a true out-of-the-box solution for handling forgotten passwords in traditional Symfony applications.

- [x] test suite depends on PR #565
- [x] depends on flex recipe https://github.com/symfony/recipes/pull/748