### PR TITLE
ignoring external deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="TEST_DATABASE_DSN" value="mysql://root:@127.0.0.1:3306/test_maker" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
For example, there is nothing we can do about doctrine/orm using doctrine/common persistence classes. Reference: https://symfony.com/doc/current/components/phpunit_bridge.html#internal-deprecations