### PR TITLE
New Messenger Middleware Maker command

### DIFF
--- a/src/Maker/MakeMessengerMiddleware.php
+++ b/src/Maker/MakeMessengerMiddleware.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @author Imad ZAIRIG <imadzairig@gmail.com>
+ *
+ * @internal
+ */
+final class MakeMessengerMiddleware extends AbstractMaker
+{
+    public static function getCommandName(): string
+    {
+        return 'make:messenger-middleware';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->setDescription('Creates a new messenger middleware')
+            ->addArgument('name', InputArgument::OPTIONAL, 'The name of the middleware class (e.g. <fg=yellow>CustomMiddleware</>)')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeMessage.txt'));
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $middlewareClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'Middleware\\',
+            'Middleware'
+        );
+
+        $generator->generateClass(
+            $middlewareClassNameDetails->getFullName(),
+            'middleware/Middleware.tpl.php'
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next:',
+            sprintf('- Open the <info>%s</info> class and add the code you need', $middlewareClassNameDetails->getFullName()),
+            '- Add the middleware to your <info>config/packages/messenger.yaml</info> file',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/messenger.html#middleware</>',
+        ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(
+            MessageBusInterface::class,
+            'messenger'
+        );
+    }
+}

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -57,6 +57,10 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_messenger_middleware" class="Symfony\Bundle\MakerBundle\Maker\MakeMessengerMiddleware">
+                <tag name="maker.command" />
+            </service>
+
             <service id="maker.maker.make_registration_form" class="Symfony\Bundle\MakerBundle\Maker\MakeRegistrationForm">
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.renderer.form_type_renderer" />

--- a/src/Resources/help/MakeMiddleware.txt
+++ b/src/Resources/help/MakeMiddleware.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new Middleware class.
+
+<info>php %command.full_name% CustomMiddleware</info>
+
+If the argument is missing, the command will ask for the message class interactively.

--- a/src/Resources/skeleton/middleware/Middleware.tpl.php
+++ b/src/Resources/skeleton/middleware/Middleware.tpl.php
@@ -1,0 +1,16 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace; ?>;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+final class <?= $class_name; ?> implements MiddlewareInterface
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        // ...
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/tests/Maker/MakeMessengerMiddlewareTest.php
+++ b/tests/Maker/MakeMessengerMiddlewareTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeMessengerMiddleware;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
+
+class MakeMessengerMiddlewareTest extends MakerTestCase
+{
+    public function getTestDetails()
+    {
+        yield 'messenger_middleware' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeMessengerMiddleware::class),
+            [
+                // middleware name
+                'CustomMiddleware',
+            ])->assert(function (string $output, string $directory) {
+                $this->assertFileExists($directory.'/src/Middleware/CustomMiddleware.php');
+            }),
+        ];
+    }
+}


### PR DESCRIPTION
New Command to generate Middleware

<img width="591" alt="capture" src="https://user-images.githubusercontent.com/9056839/77856793-d73b3b00-71f9-11ea-9c7a-a3c72980d7b4.png">

generated code : 

<details>
  <summary>CustomMiddleware</summary>
  
```php
<?php
namespace App\Middleware;

use Symfony\Component\Messenger\Envelope;
use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
use Symfony\Component\Messenger\Middleware\StackInterface;

final class CustomMiddleware implements MiddlewareInterface
{
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         // ...
         return $stack->next()->handle($envelope, $stack);
     }
}

```
</details>