### PR TITLE
Avoid duplicate "use" statement for FormType

### DIFF
--- a/src/Renderer/FormTypeRenderer.php
+++ b/src/Renderer/FormTypeRenderer.php
@@ -42,7 +42,7 @@ final class FormTypeRenderer
             $fields[$name] = $fieldTypeOptions;
         }
 
-        $mergedTypeUseStatements = array_merge($fieldTypeUseStatements, $extraUseClasses);
+        $mergedTypeUseStatements = array_unique(array_merge($fieldTypeUseStatements, $extraUseClasses));
         sort($mergedTypeUseStatements);
 
         $this->generator->generateClass(


### PR DESCRIPTION
A small change to make use statement unique.

I created a custom maker that add extra informations in EntityFormType, and I find that it's generate a FormType with multiple use statements. (based on MakerCrud).

Before:
```php
<?php
namespace App\Form;

use App\Entity\MyEntity;
use Symfony\Component\Form\AbstractType;
use App\Form\MyFormType;
use App\Form\MyFormType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;

class MyEntityType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('field1')
            ->add('field2', MyFormType::class)
            ->add('field3', MyFormType::class)
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => MyEntity::class,
        ]);
    }
}
```

After:
```php
<?php
namespace App\Form;

use App\Entity\MyEntity;
use Symfony\Component\Form\AbstractType;
use App\Form\MyFormType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;

class MyEntityType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('field1')
            ->add('field2', MyFormType::class)
            ->add('field3', MyFormType::class)
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => MyEntity::class,
        ]);
    }
}
```