### PR TITLE
Add help doc for reset-password

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -52,6 +52,7 @@ class MakeResetPassword extends AbstractMaker
     {
         $command
             ->setDescription('Create controller, entity, and repositories for use with symfonycasts/reset-password-bundle.')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeResetPassword.txt'))
         ;
     }
 

--- a/src/Resources/help/MakeResetPassword.txt
+++ b/src/Resources/help/MakeResetPassword.txt
@@ -1,7 +1,7 @@
 The <info>%command.name%</info> command generates all the files needed to implement
  a fully-functional & secure password reset system.
 
-The Symfony Casts Reset Password Bundle is required and can be added using composer:
+The SymfonycastsResetPasswordBundle is required and can be added using composer:
 <info>composer require symfonycasts/reset-password-bundle</info>
 
 For more information on the <info>reset-password-bundle</info> check out:

--- a/src/Resources/help/MakeResetPassword.txt
+++ b/src/Resources/help/MakeResetPassword.txt
@@ -1,0 +1,18 @@
+The <info>%command.name%</info> command generates all the files needed to implement
+ a fully-functional & secure password reset system.
+
+The Symfony Casts Reset Password Bundle is required and can be added using composer:
+<info>composer require symfonycasts/reset-password-bundle</info>
+
+For more information on the <info>reset-password-bundle</info> check out:
+<href=https://github.com/symfonycasts/reset-password-bundle>https://github.com/symfonycasts/reset-password-bundle</>
+
+<info>%command.name%</info> requires a user entity with an email property,
+email getter method, and a password setter method. Maker will ask for these
+interactively if they cannot be guessed.
+
+Maker will also update your <info>reset-password.yaml</info> configuration file
+if one exists. If you have customized the configuration file, maker will attempt
+to modify it accordingly but preserve your customizations.
+
+<info>php %command.full_name%</info>


### PR DESCRIPTION
Provides helpful information when calling `make:reset-password --help`