### PR TITLE
change from-email-address default value to empty string

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -167,7 +167,7 @@ final class Validator
         return $name;
     }
 
-    public static function validateEmailAddress(string $email): string
+    public static function validateEmailAddress(?string $email): string
     {
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             throw new RuntimeCommandException(sprintf('"%s" is not a valid email address.', $email));

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -68,10 +68,17 @@ class ValidatorTest extends TestCase
     public function testValidateEmailAddress()
     {
         $this->assertSame('jr@rushlow.dev', Validator::validateEmailAddress('jr@rushlow.dev'));
+    }
 
+    public function testInvalidateEmailAddress()
+    {
         $this->expectException(RuntimeCommandException::class);
         $this->expectExceptionMessage('"badEmail" is not a valid email address.');
         Validator::validateEmailAddress('badEmail');
+
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('"" is not a valid email address.');
+        Validator::validateEmailAddress('');
     }
 
     public function testInvalidClassName()


### PR DESCRIPTION
when create a reset-password at question `What email address will be used to send reset confirmations? e.g. mailer@your-domain.com` and we just enter without filling the answer it will thrown an exception 
```
Argument 1 passed to Symfony\Bundle\MakerBundle\Validator::validateEmailAddress() must be of the type string, null given, called in /path/vendor/symfony/console/Helper/QuestionHelper.php on line 468
```

there are 2 possible solution. 1. change the default value to empty string (this PR), or 2. make the `validateEmailAddress` argument nullable and check the value inside the method.