### PR TITLE
Forcing Composer v1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
     - IF %PHP%==0 echo extension=php_curl.dll >> php.ini
     - IF %PHP%==0 echo extension=php_pdo_mysql.dll >> php.ini
     - IF %PHP%==0 echo @php %%~dp0composer.phar %%* > composer.bat
-    - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+    - appveyor-retry appveyor DownloadFile https://getcomposer.org/download/1.10.5/composer.phar
     - cd C:\projects\maker-bundle
     - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
     - IF %dependencies%==highest appveyor-retry composer update --no-progress --no-suggest --ansi


### PR DESCRIPTION
A cheap fix to keep AppVeyor on Composer v1