### PR TITLE
Added UUID and GUID default type to entity maker

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -322,6 +322,10 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             $defaultType = 'boolean';
         } elseif (0 === strpos($snakeCasedField, 'has_')) {
             $defaultType = 'boolean';
+        } elseif ('uuid' === $snakeCasedField) {
+            $defaultType = 'uuid';
+        } elseif ('guid' === $snakeCasedField) {
+            $defaultType = 'guid';
         }
 
         $type = null;


### PR DESCRIPTION
Hello,

When you want to create a field, for an entity, representing an uuid, if you name it `uuid` the maker will set the default type to `uuid`. Same for `guid`.
![image](https://user-images.githubusercontent.com/27960254/79916400-f314b400-8428-11ea-9810-5f02d66e324b.png)
![image](https://user-images.githubusercontent.com/27960254/79917430-c3ff4200-842a-11ea-9591-0e7307c21daf.png)
