### PR TITLE
DoctrineCommand is gone in DoctrineMigrationsBundle 3.0

### DIFF
--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
-use Doctrine\Bundle\MigrationsBundle\Command\DoctrineCommand;
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Symfony\Bundle\MakerBundle\ApplicationAwareMakerInterface;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
@@ -120,7 +120,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(
-            DoctrineCommand::class,
+            DoctrineBundle::class,
             'migrations'
         );
     }


### PR DESCRIPTION
The command otherwise seems to work just fine on 3.0 alpha.

This should be BC for older versions as the bundle class has always existed.