### PR TITLE
Re-adding PHP 7.0 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
 matrix:
     fast_finish: true
     include:
+        - php: 7.0.8
         - php: 7.1.33
         - php: 7.3
         - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "doctrine/orm": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.8",
         "friendsoftwig/twigcs": "^3.1.2",
-        "symfony/http-client": "^4.3|^5.0",
         "symfony/phpunit-bridge": "^4.3|^5.0",
         "symfony/process": "^3.4|^4.0|^5.0",
         "symfony/security-core": "^3.4|^4.0|^5.0",

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Test;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\InputStream;
 
@@ -437,25 +436,22 @@ echo json_encode($missingDependencies);
                 return $this->targetFlexVersion;
             }
 
+            if ('dev' === $targetVersion) {
+                $this->targetFlexVersion = 'dev-master';
+
+                return $this->targetFlexVersion;
+            }
+
+            throw new \Exception('Invalid target version');
+            /*
+             * For possible future stable-dev handling
             $httpClient = HttpClient::create();
             $response = $httpClient->request('GET', 'https://symfony.com/versions.json');
             $data = $response->toArray();
-
-            switch ($targetVersion) {
-                case 'stable-dev':
-                    $version = $data['latest'];
-                    $parts = explode('.', $version);
-
-                    $this->targetFlexVersion = sprintf('%s.%s.x-dev', $parts[0], $parts[1]);
-
-                    break;
-                case 'dev':
-                    $this->targetFlexVersion = 'dev-master';
-
-                    break;
-                default:
-                    throw new \Exception('Invalid target version');
-            }
+            $version = $data['latest'];
+            $parts = explode('.', $version);
+            $this->targetFlexVersion = sprintf('%s.%s.x-dev', $parts[0], $parts[1]);
+            */
         }
 
         return $this->targetFlexVersion;

--- a/src/Test/MakerTestKernel.php
+++ b/src/Test/MakerTestKernel.php
@@ -53,11 +53,14 @@ class MakerTestKernel extends Kernel implements CompilerPassInterface
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
     {
+        $routerConfig = [];
+        if (Kernel::VERSION_ID >= 40200) {
+            $routerConfig['utf8'] = true;
+        }
+
         $c->loadFromExtension('framework', [
             'secret' => 123,
-            'router' => [
-                'utf8' => true,
-            ],
+            'router' => $routerConfig,
         ]);
     }
 

--- a/tests/EventRegistryTest.php
+++ b/tests/EventRegistryTest.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\MakerBundle\EventRegistry;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -83,11 +84,19 @@ class EventRegistryTest extends TestCase
                    ->method('getListeners');
 
         $registry = new EventRegistry($dispatcher);
-        $this->assertSame(ExceptionEvent::class, $registry->getEventClassName(KernelEvents::EXCEPTION));
+        $this->assertSame(
+            // compat for older Symfony versions
+            \class_exists(ExceptionEvent::class) ? ExceptionEvent::class : GetResponseForExceptionEvent::class,
+            $registry->getEventClassName(KernelEvents::EXCEPTION)
+        );
     }
 
     public function testGetEventClassNameGivenEventAsClass()
     {
+        if (!class_exists(ControllerEvent::class)) {
+            $this->markTestSkipped();
+        }
+
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $registry = new EventRegistry($dispatcher);

--- a/tests/FileManagerTest.php
+++ b/tests/FileManagerTest.php
@@ -187,7 +187,7 @@ class FileManagerTest extends TestCase
         ];
     }
 
-    public function testWithMakerFileLinkFormatter(): void
+    public function testWithMakerFileLinkFormatter()
     {
         $fileLinkFormatter = $this->createMock(FileLinkFormatter::class);
         $fileLinkFormatter


### PR DESCRIPTION
For the time being, the bundle still supports PHP 7.0. I had (accidentally) removed 7.0 from the test matrix at some point. Let's see if we can add it back.