### PR TITLE
Prevent open redirect issues when generating LoginFormAuthenticator

### DIFF
--- a/tests/fixtures/MakeAuthenticatorLoginFormCustomUsernameField/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormCustomUsernameField/tests/SecurityControllerTest.php
@@ -11,10 +11,11 @@ class SecurityControllerTest extends WebTestCase
     {
         $authenticatorReflection = new \ReflectionClass(AppCustomAuthenticator::class);
         $constructorParameters = $authenticatorReflection->getConstructor()->getParameters();
-        $this->assertSame('urlGenerator', $constructorParameters[0]->getName());
+        $this->assertSame('httpUtils', $constructorParameters[0]->getName());
+        $this->assertSame('urlGenerator', $constructorParameters[1]->getName());
 
         // assert authenticator is injected
-        $this->assertCount(3, $constructorParameters);
+        $this->assertCount(4, $constructorParameters);
 
         $client = self::createClient();
         $crawler = $client->request('GET', '/login');

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntity/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntity/tests/SecurityControllerTest.php
@@ -16,7 +16,7 @@ class SecurityControllerTest extends WebTestCase
         $this->assertSame('entityManager', $constructorParameters[0]->getName());
 
         // assert authenticator is injected
-        $this->assertCount(4, $constructorParameters);
+        $this->assertCount(5, $constructorParameters);
 
         $client = self::createClient();
         $crawler = $client->request('GET', '/login');

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntityLogout/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntityLogout/tests/SecurityControllerTest.php
@@ -16,7 +16,7 @@ class SecurityControllerTest extends WebTestCase
         $this->assertSame('entityManager', $constructorParameters[0]->getName());
 
         // assert authenticator is injected
-        $this->assertCount(4, $constructorParameters);
+        $this->assertCount(5, $constructorParameters);
 
         $client = self::createClient();
         $crawler = $client->request('GET', '/login');

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntityNoEncoder/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntityNoEncoder/tests/SecurityControllerTest.php
@@ -16,7 +16,7 @@ class SecurityControllerTest extends WebTestCase
         $this->assertSame('entityManager', $constructorParameters[0]->getName());
 
         // assert authenticator is *not* injected
-        $this->assertCount(3, $constructorParameters);
+        $this->assertCount(4, $constructorParameters);
 
         $client = self::createClient();
         $crawler = $client->request('GET', '/login');

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserNotEntity/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserNotEntity/tests/SecurityControllerTest.php
@@ -11,10 +11,11 @@ class SecurityControllerTest extends WebTestCase
     {
         $authenticatorReflection = new \ReflectionClass(AppCustomAuthenticator::class);
         $constructorParameters = $authenticatorReflection->getConstructor()->getParameters();
-        $this->assertSame('urlGenerator', $constructorParameters[0]->getName());
+        $this->assertSame('httpUtils', $constructorParameters[0]->getName());
+        $this->assertSame('urlGenerator', $constructorParameters[1]->getName());
 
         // assert authenticator is injected
-        $this->assertCount(3, $constructorParameters);
+        $this->assertCount(4, $constructorParameters);
 
         $client = self::createClient();
         $crawler = $client->request('GET', '/login');

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserNotEntityNoEncoder/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserNotEntityNoEncoder/tests/SecurityControllerTest.php
@@ -11,10 +11,11 @@ class SecurityControllerTest extends WebTestCase
     {
         $authenticatorReflection = new \ReflectionClass(AppCustomAuthenticator::class);
         $constructorParameters = $authenticatorReflection->getConstructor()->getParameters();
-        $this->assertSame('urlGenerator', $constructorParameters[0]->getName());
+        $this->assertSame('httpUtils', $constructorParameters[0]->getName());
+        $this->assertSame('urlGenerator', $constructorParameters[1]->getName());
 
         // assert authenticator is *not* injected
-        $this->assertCount(2, $constructorParameters);
+        $this->assertCount(3, $constructorParameters);
 
         $client = self::createClient();
         $crawler = $client->request('GET', '/login');


### PR DESCRIPTION
This adds `HttpUtils` to create the redirect `onAuthenticationSuccess` and prevent open redirect issues when creating a LoginFormAuthenticator.

Ref: 
- https://symfony.com/blog/cve-2017-16652-open-redirect-vulnerability-on-security-handlers
- https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php#L56

