### PR TITLE
Update return typehint

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -530,7 +530,7 @@ final class ClassSourceManipulator
             $collectionTypeHint,
             false,
             // add @return that advertises this as a collection of specific objects
-            [sprintf('@return %s|%s[]', $collectionTypeHint, $typeHint)]
+            [sprintf('@return %s&%s[]', $collectionTypeHint, $typeHint)]
         );
 
         $argName = Str::pluralCamelCaseToSingular($relation->getPropertyName());


### PR DESCRIPTION
I want to do this change
```diff

    /**
-    * @return Collection|Team[]
+    * @return Collection&Team[]
     */
    public function getTeams(): Collection
    {
        return $this->teams;
    }
```

The return type will not be an array of Teams or a Collection. It will be both =)

Reference: https://psalm.dev/docs/annotating_code/type_syntax/intersection_types/