### PR TITLE
Make reset password - custom user entity

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -107,7 +107,7 @@ class MakeResetPassword extends AbstractMaker
         );
         $input->setArgument(
             'email-getter',
-            $interactiveSecurityHelper->guessEmailGetter($io, $userClass)
+            $interactiveSecurityHelper->guessEmailGetter($io, $userClass, $input->getArgument('email-property-name'))
         );
         $input->setArgument(
             'password-setter',
@@ -191,6 +191,7 @@ class MakeResetPassword extends AbstractMaker
                 'from_email' => $input->getArgument('from-email-address'),
                 'from_email_name' => $input->getArgument('from-email-name'),
                 'email_getter' => $input->getArgument('email-getter'),
+                'email_field' => $input->getArgument('email-property-name'),
             ]
         );
 

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -44,7 +44,7 @@ class <?= $class_name ?> extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             return $this->processSendingPasswordResetEmail(
-                $form->get('email')->getData(),
+                $form->get('<?= $email_field ?>')->getData(),
                 $mailer
             );
         }
@@ -133,7 +133,7 @@ class <?= $class_name ?> extends AbstractController
     private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer): RedirectResponse
     {
         $user = $this->getDoctrine()->getRepository(<?= $user_class_name ?>::class)->findOneBy([
-            'email' => $emailFormData,
+            '<?= $email_field ?>' => $emailFormData,
         ]);
 
         // Marks that you are allowed to see the app_check_email page.

--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Security;
 
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -222,12 +223,14 @@ authenticators will be ignored, and can be blank.',
         );
     }
 
-    public function guessEmailGetter(SymfonyStyle $io, string $userClass): string
+    public function guessEmailGetter(SymfonyStyle $io, string $userClass, string $emailPropertyName): string
     {
         $reflectionClass = new \ReflectionClass($userClass);
 
-        if ($reflectionClass->hasMethod('getEmail')) {
-            return 'getEmail';
+        $supposedEmailMethodName = 'get'.Str::asCamelCase($emailPropertyName);
+
+        if ($reflectionClass->hasMethod($supposedEmailMethodName)) {
+            return $supposedEmailMethodName;
         }
 
         $classMethods = [];

--- a/tests/Security/InteractiveSecurityHelperTest.php
+++ b/tests/Security/InteractiveSecurityHelperTest.php
@@ -298,7 +298,7 @@ class InteractiveSecurityHelperTest extends TestCase
     /**
      * @dataProvider guessEmailGetterTest
      */
-    public function testGuessEmailGetter(string $expectedEmailGetter, bool $automaticallyGuessed, string $class = '', array $choices = [])
+    public function testGuessEmailGetter(string $expectedEmailGetter, string $emailAttribute, bool $automaticallyGuessed, string $class = '', array $choices = [])
     {
         /** @var SymfonyStyle|\PHPUnit_Framework_MockObject_MockObject $io */
         $io = $this->createMock(SymfonyStyle::class);
@@ -310,7 +310,7 @@ class InteractiveSecurityHelperTest extends TestCase
         $interactiveSecurityHelper = new InteractiveSecurityHelper();
         $this->assertEquals(
             $expectedEmailGetter,
-            $interactiveSecurityHelper->guessEmailGetter($io, $class)
+            $interactiveSecurityHelper->guessEmailGetter($io, $class, $emailAttribute)
         );
     }
 
@@ -318,12 +318,22 @@ class InteractiveSecurityHelperTest extends TestCase
     {
         yield 'guess_fixture_class' => [
             'expectedPasswordSetter' => 'getEmail',
+            'email',
             true,
             FixtureClass7::class,
         ];
 
+        yield 'guess_fixture_class_different_property' => [
+            'expectedPasswordSetter' => 'getEmail',
+            'myEmail',
+            false,
+            FixtureClass7::class,
+            ['getEmail'],
+        ];
+
         yield 'guess_fixture_class_2' => [
             'expectedPasswordSetter' => 'getMyEmail',
+            '',
             false,
             FixtureClass8::class,
             ['getMyEmail'],

--- a/tests/fixtures/MakeResetPasswordCustomUserAttribute/config/packages/security.yml
+++ b/tests/fixtures/MakeResetPasswordCustomUserAttribute/config/packages/security.yml
@@ -1,0 +1,3 @@
+security:
+    encoders:
+        App\Entity\User: bcrypt

--- a/tests/fixtures/MakeResetPasswordCustomUserAttribute/src/Entity/UserCustom.php
+++ b/tests/fixtures/MakeResetPasswordCustomUserAttribute/src/Entity/UserCustom.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Entity;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserCustom implements UserInterface
+{
+    private $emailAddress;
+
+    public function getEmailAddress()
+    {
+    }
+
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function setMyPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}


### PR DESCRIPTION
Should fix #605 
And `guessEmailGetter` is smarter with the use of the custom email property