### PR TITLE
Dropping doctrine/inflector v2 support temporarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.18
+====
+
+* Reverted support for `doctrine/inflector` 2.0 - #611 thanks to @weaverryan
+
 1.17
 ====
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.1.3",
-        "doctrine/inflector": "^1.2 || ^2.0",
+        "doctrine/inflector": "^1.2",
         "nikic/php-parser": "^4.0",
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
This was causting doctrine/inflector v2 to be installed. Then,
if a user required another package that only worked with v1 - like
doctrine/orm, that package would fail to install because the user's
app is locked on v2.

Dropping support for v2 isn't really a fix, but will make it more
compatible with the ecosystem at the current time. Later, especially
when doctrine/orm allows 2, we can again.

See also https://github.com/composer/composer/issues/8910

Note: I kept the v2 compatible code in the bundle for now.

Fixes #609 