### PR TITLE
[ResetPassword & VerifyEmail] fix templated email "lifetime" being mutated by timezones

### DIFF
--- a/src/Resources/skeleton/registration/twig_email.tpl.php
+++ b/src/Resources/skeleton/registration/twig_email.tpl.php
@@ -3,7 +3,7 @@
 <p>
     Please confirm your email address by clicking the following link: <br><br>
     <a href="{{ signedUrl|raw }}">Confirm my Email</a>.
-    This link will expire in {{ expiresAt|date('g') }} hour(s).
+    This link will expire in {{ expiresAt|date('g', 'UTC') }} hour(s).
 </p>
 
 <p>

--- a/src/Resources/skeleton/resetPassword/twig_email.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_email.tpl.php
@@ -3,7 +3,7 @@
 <p>
     To reset your password, please visit
     <a href="{{ url('app_reset_password', {token: resetToken.token}) }}">here</a>
-    This link will expire in {{ tokenLifetime|date('g') }} hour(s)..
+    This link will expire in {{ tokenLifetime|date('g', 'UTC') }} hour(s)..
 </p>
 
 <p>


### PR DESCRIPTION
Currently in the twig email templates, the `This link will expire in 1 hour(s).` is malformed if a timezone is set either in twig or in PHP.

In the controllers of both ResetPassword & VerifyEmail(RegistrationController) the token lifetime is expressed as `int X`. The lifetime is then passed to the twig templated email where it is ultimately passed to the `date` filter.  This PR enforces that the lifetime value should always be formatted in the UTC timezone.

This is only a temporary solution. Ideally, either the `ResetPasswordBundle` & `VerifyEmailBundle` or `MakerBundle` should use a math based method to transform the lifetime value to a human readable format. e.g
```
$lifetime = 3600;   // seconds

public function convertToHours(int $lifetime): string

$result = ::convertToHours($lifetime);
// 1 hour
```

Refs https://github.com/SymfonyCasts/reset-password-bundle/issues/119