### PR TITLE
re-adding invalid answer to test case

### DIFF
--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -85,6 +85,8 @@ class MakeEntityTest extends MakerTestCase
             [
                 // entity class name
                 'User',
+                // this field already exists
+                'firstName',
                 // add additional fields
                 'lastName',
                 'string',


### PR DESCRIPTION
A bug in Symfony was previously causing problems. Should be fixed by symfony/symfony#37286