### PR TITLE
Remove empty parenthesis

### DIFF
--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -17,8 +17,8 @@ use Doctrine\ORM\Mapping as ORM;
 class <?= $class_name."\n" ?>
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/Util/fixtures/source/ProductWithTabs.php
+++ b/tests/Util/fixtures/source/ProductWithTabs.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
 class Product
 {
 	/**
-	 * @ORM\Id()
-	 * @ORM\GeneratedValue()
+	 * @ORM\Id
+	 * @ORM\GeneratedValue
 	 * @ORM\Column(type="integer")
 	 */
 	private $id;

--- a/tests/Util/fixtures/with_tabs/ProductWithTabs.php
+++ b/tests/Util/fixtures/with_tabs/ProductWithTabs.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
 class Product
 {
 	/**
-	 * @ORM\Id()
-	 * @ORM\GeneratedValue()
+	 * @ORM\Id
+	 * @ORM\GeneratedValue
 	 * @ORM\Column(type="integer")
 	 */
 	private $id;

--- a/tests/fixtures/MakeAuthenticatorLoginFormExistingController/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormExistingController/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntity/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntity/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntityLogout/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntityLogout/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntityNoEncoder/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntityNoEncoder/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/fixtures/MakeRegistrationFormEntity/src/Entity/User.php
+++ b/tests/fixtures/MakeRegistrationFormEntity/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/fixtures/MakeRegistrationFormNoGuessing/src/Entity/User.php
+++ b/tests/fixtures/MakeRegistrationFormNoGuessing/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/fixtures/MakeRegistrationFormVerifyEmail/src/Entity/User.php
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmail/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailFunctionalTest/src/Entity/User.php
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailFunctionalTest/src/Entity/User.php
@@ -11,8 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class User implements UserInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
+     * @ORM\Id
+     * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
     private $id;


### PR DESCRIPTION
The [Doctrine](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/annotations-reference.html#id) and [Symfony](https://symfony.com/doc/current/doctrine.html#creating-an-entity-class) documentation (even after it explains how to use maker to create the entity) leaves them off.

I thought it would be nice if they matched.