### PR TITLE
Added type-hints to onAuthenticationSuccess

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -35,6 +35,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -234,7 +235,9 @@ final class MakeAuthenticator extends AbstractMaker
             $this->generator->generateClass(
                 $authenticatorClass,
                 'authenticator/EmptyAuthenticator.tpl.php',
-                []
+                [
+                    'provider_key_type_hint' => $this->providerKeyTypeHint(),
+                ]
             );
 
             return;
@@ -255,6 +258,7 @@ final class MakeAuthenticator extends AbstractMaker
                 'username_field_label' => Str::asHumanWords($userNameField),
                 'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
                 'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
+                'provider_key_type_hint' => $this->providerKeyTypeHint(),
             ]
         );
     }
@@ -364,5 +368,16 @@ final class MakeAuthenticator extends AbstractMaker
             Yaml::class,
             'yaml'
         );
+    }
+
+    private function providerKeyTypeHint(): string
+    {
+        $reflectionMethod = new \ReflectionMethod(AbstractFormLoginAuthenticator::class, 'onAuthenticationSuccess');
+        $typeHint = (string)$reflectionMethod->getParameters()[2]->getType();
+        if ($typeHint) {
+            $typeHint .= ' ';
+        }
+
+        return $typeHint;
     }
 }

--- a/src/Resources/skeleton/authenticator/EmptyAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/EmptyAuthenticator.tpl.php
@@ -36,7 +36,7 @@ class <?= $class_name ?> extends AbstractGuardAuthenticator
         // todo
     }
 
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, <?= $provider_key_type_hint ?>$providerKey)
     {
         // todo
     }

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -98,7 +98,7 @@ class <?= $class_name; ?> extends AbstractFormLoginAuthenticator<?= $password_au
     }
 
 <?php endif ?>
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, <?= $provider_key_type_hint ?>$providerKey)
     {
         if ($targetPath = $this->getTargetPath($request->getSession(), $providerKey)) {
             return new RedirectResponse($targetPath);


### PR DESCRIPTION
Added type-hints to `onAuthenticationSuccess` to support [changes](https://github.com/symfony/security-guard/commit/3105836b14bd984e9839a697ca9e65c2e6c7db8e) introduced in `symfony/security-guard 5.0`