### PR TITLE
Add text email for password reset request

### DIFF
--- a/src/Resources/skeleton/resetPassword/twig_email.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_email.tpl.php
@@ -1,11 +1,9 @@
 <h1>Hi!</h1>
 
-<p>
-    To reset your password, please visit
-    <a href="{{ url('app_reset_password', {token: resetToken.token}) }}">here</a>
-    This link will expire in {{ tokenLifetime|date('g') }} hour(s)..
-</p>
+<p>To reset your password, please visit the following link</p>
 
-<p>
-    Cheers!
-</p>
+<a href="{{ url('app_reset_password', {token: resetToken.token}) }}">{{ url('app_reset_password', {token: resetToken.token}) }}</a>
+
+<p>This link will expire in {{ tokenLifetime|date('g') }} hour(s).</p>
+
+<p>Cheers!</p>


### PR DESCRIPTION
When no text template is specified, Symfony mailer converts the HTML template to text by stripping out the tags. This causes the text template to be malformed and includes references to links that don't exist. This PR adds a text template when requesting a password reset.

**Before:**

![Screenshot 2020-06-24 at 22 32 17](https://user-images.githubusercontent.com/144858/85624853-d2f0b380-b66a-11ea-916c-06a33fb03965.png)

**After:**

![Screenshot 2020-06-24 at 22 35 31](https://user-images.githubusercontent.com/144858/85624990-0a5f6000-b66b-11ea-8e5c-d4b7852b675a.png)
