### PR TITLE
Docs: improve make:form helper

### DIFF
--- a/src/Resources/help/MakeForm.txt
+++ b/src/Resources/help/MakeForm.txt
@@ -3,3 +3,14 @@ The <info>%command.name%</info> command generates a new form class.
 <info>php %command.full_name% UserType</info>
 
 If the argument is missing, the command will ask for the form class interactively.
+
+You can optionally specify the bound class in a second argument.
+This can be the name of an entity like <info>User</info>
+
+<info>php %command.full_name% UserType User</info>
+
+You can also specify a fully qualified name to another class like <info>\App\Dto\UserData</info>.
+Slashes must be escaped in the argument.
+
+<info>php %command.full_name% UserType \\App\\Dto\\UserData</info>
+


### PR DESCRIPTION
Add information about the second argument (bound-class).
Give hints on using the bound-class with classes other than entities.

Improves on #301 and fixes #477 