### PR TITLE
using stable-dev in tests to get latest fixes from Symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ matrix:
     fast_finish: true
     include:
         - php: 7.1.33
+          env: MAKER_TEST_VERSION=stable
         - php: 7.3
+          env: MAKER_TEST_VERSION=stable-dev
         - php: 7.3
           env: MAKER_TEST_VERSION=dev
     allow_failures:

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -319,13 +319,19 @@ final class MakerTestEnvironment
             $this->cachePath
         )->run();
 
-        $rootPath = str_replace('\\', '\\\\', realpath(__DIR__.'/../..'));
-
-        // dev deps already will allow dev deps, but we should prefer stable
         if (false !== strpos($targetVersion, 'dev')) {
-            MakerTestProcess::create('composer config prefer-stable true', $this->flexPath)
+            // make sure that dev versions allow dev deps
+            // for the current stable minor of Symfony, by default,
+            // minimum-stability is NOT dev, even when getting the -dev version
+            // of symfony/skeleton
+            MakerTestProcess::create('composer config minimum-stability dev', $this->flexPath)
+                ->run();
+
+            MakerTestProcess::create(['composer', 'update'], $this->flexPath)
                 ->run();
         }
+
+        $rootPath = str_replace('\\', '\\\\', realpath(__DIR__.'/../..'));
 
         // processes any changes needed to the Flex project
         $replacements = [

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -429,7 +429,7 @@ echo json_encode($missingDependencies);
     private function getTargetFlexVersion(): string
     {
         if (null === $this->targetFlexVersion) {
-            $targetVersion = $_SERVER['MAKER_TEST_VERSION'] ?? 'stable';
+            $targetVersion = $_SERVER['MAKER_TEST_VERSION'] ?? 'stable-dev';
 
             if ('stable' === $targetVersion) {
                 $this->targetFlexVersion = '';

--- a/src/Test/MakerTestProcess.php
+++ b/src/Test/MakerTestProcess.php
@@ -24,7 +24,7 @@ final class MakerTestProcess
 
     private function __construct($commandLine, $cwd, array $envVars, $timeout)
     {
-        $this->process = is_string($commandLine)
+        $this->process = \is_string($commandLine)
             ? Process::fromShellCommandline($commandLine, $cwd, null, null, $timeout)
             : new Process($commandLine, $cwd, null, null, $timeout);
 

--- a/src/Test/MakerTestProcess.php
+++ b/src/Test/MakerTestProcess.php
@@ -24,7 +24,7 @@ final class MakerTestProcess
 
     private function __construct($commandLine, $cwd, array $envVars, $timeout)
     {
-        $this->process = method_exists(Process::class, 'fromShellCommandline')
+        $this->process = is_string($commandLine)
             ? Process::fromShellCommandline($commandLine, $cwd, null, null, $timeout)
             : new Process($commandLine, $cwd, null, null, $timeout);
 

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -43,7 +43,7 @@ class MakeMigrationTest extends MakerTestCase
                 // see that the exact filename is in the output
                 $iterator = $finder->getIterator();
                 $iterator->rewind();
-                $this->assertStringContainsString(sprintf('"migrations/%s"', $iterator->current()->getFilename()), $output);
+                $this->assertStringContainsString(sprintf('"%s/%s"', $migrationsDirectoryPath, $iterator->current()->getFilename()), $output);
             }),
         ];
 

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -32,8 +32,11 @@ class MakeMigrationTest extends MakerTestCase
             ->assert(function (string $output, string $directory) {
                 $this->assertStringContainsString('Success', $output);
 
+                // support for Migrations 3 (/migrations) and earlier
+                $migrationsDirectoryPath = file_exists($directory.'/migrations') ? 'migrations' : 'src/Migrations';
+
                 $finder = new Finder();
-                $finder->in($directory.'/migrations')
+                $finder->in($directory.'/'.$migrationsDirectoryPath)
                     ->name('*.php');
                 $this->assertCount(1, $finder);
 

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -33,14 +33,14 @@ class MakeMigrationTest extends MakerTestCase
                 $this->assertStringContainsString('Success', $output);
 
                 $finder = new Finder();
-                $finder->in($directory.'/src/Migrations')
+                $finder->in($directory.'/migrations')
                     ->name('*.php');
                 $this->assertCount(1, $finder);
 
                 // see that the exact filename is in the output
                 $iterator = $finder->getIterator();
                 $iterator->rewind();
-                $this->assertStringContainsString(sprintf('"src/Migrations/%s"', $iterator->current()->getFilename()), $output);
+                $this->assertStringContainsString(sprintf('"migrations/%s"', $iterator->current()->getFilename()), $output);
             }),
         ];
 

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -28,7 +28,7 @@ class MakeMigrationTest extends MakerTestCase
             // doctrine-migrations-bundle only requires doctrine-bundle, which
             // only requires doctrine/dbal. But we're testing with the ORM,
             // so let's install it
-            ->addExtraDependencies('doctrine/orm')
+            ->addExtraDependencies('doctrine/orm:@stable')
             ->assert(function (string $output, string $directory) {
                 $this->assertStringContainsString('Success', $output);
 
@@ -53,7 +53,7 @@ class MakeMigrationTest extends MakerTestCase
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMigration')
             ->configureDatabase()
             // sync the database, so no changes are needed
-            ->addExtraDependencies('doctrine/orm')
+            ->addExtraDependencies('doctrine/orm:@stable')
             ->assert(function (string $output, string $directory) {
                 $this->assertNotContains('Success', $output);
 


### PR DESCRIPTION
This avoids a behavior change in https://github.com/symfony/console/compare/6f533d9...d2c9f77 from symfony/symfony#37286

I'll create a PR to revert this after merge, which we will merge once the issue is resolved.