### PR TITLE
making sure comments on sequential lines work

### DIFF
--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -90,11 +90,12 @@ class YamlSourceManipulator
         // update the data now that the special chars have been removed
         $this->currentData = Yaml::parse($this->contents);
 
+        // remove special metadata keys that were replaced
+        $newData = $this->removeMetadataKeys($newData);
+
         // Before comparing, re-index any sequences on the new data.
         // The current data will already use sequential indexes
         $newData = $this->normalizeSequences($newData);
-        // remove special metadata keys that were replaced
-        $newData = $this->removeMetadataKeys($newData);
 
         if ($newData !== $this->currentData) {
             throw new YamlManipulationFailedException(sprintf('Failed updating YAML contents: the process was successful, but something was not updated. Expected new data: %s. Actual new data: %s', var_export($newData, true), var_export($this->currentData, true)));

--- a/tests/Util/yaml_fixtures/add_comment_to_sequence.test
+++ b/tests/Util/yaml_fixtures/add_comment_to_sequence.test
@@ -1,0 +1,23 @@
+version: '3.7'
+services:
+    database:
+        image: 'mysql:8.0'
+        environment:
+            MYSQL_ROOT_PASSWORD: 'root'
+===
+$data['services']['database']['ports'] = [
+    0 => '__COMMENT__ exposes port 3306 to a random port on your host machine',
+    1 => '__COMMENT__ use 3306:3306 to expose to port 3306 on your host machine',
+    2 => '3306',
+];
+===
+version: '3.7'
+services:
+    database:
+        image: 'mysql:8.0'
+        environment:
+            MYSQL_ROOT_PASSWORD: 'root'
+        ports:
+            # exposes port 3306 to a random port on your host machine
+            # use 3306:3306 to expose to port 3306 on your host machine
+            - '3306'


### PR DESCRIPTION
Previously, the reversed logic in the manipulator meant that this transformation *was* done correctly, but the manipulator then reported that the data had somehow gotten corrupt (because indexed keys weren't matching).