### PR TITLE
Fixing wrapping of doctrine:migrations:diff command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/http-kernel": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
+        "composer/semver": "^3.0@dev",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.8",

--- a/src/Console/MigrationDiffFilteredOutput.php
+++ b/src/Console/MigrationDiffFilteredOutput.php
@@ -25,21 +25,21 @@ class MigrationDiffFilteredOutput implements OutputInterface
         $this->output = $output;
     }
 
-    public function write($messages, bool $newline = false, int $options = 0)
+    public function write($messages, $newline = false, $options = 0)
     {
         $messages = $this->filterMessages($messages, $newline);
 
         $this->output->write($messages, $newline, $options);
     }
 
-    public function writeln($messages, int $options = 0)
+    public function writeln($messages, $options = 0)
     {
         $messages = $this->filterMessages($messages, true);
 
         $this->output->writeln($messages, $options);
     }
 
-    public function setVerbosity(int $level)
+    public function setVerbosity($level)
     {
         $this->output->setVerbosity($level);
     }
@@ -69,7 +69,7 @@ class MigrationDiffFilteredOutput implements OutputInterface
         return $this->output->isDebug();
     }
 
-    public function setDecorated(bool $decorated)
+    public function setDecorated($decorated)
     {
         $this->output->setDecorated($decorated);
     }

--- a/src/Console/MigrationDiffFilteredOutput.php
+++ b/src/Console/MigrationDiffFilteredOutput.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Console;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrationDiffFilteredOutput implements OutputInterface
+{
+    private $output;
+    private $buffer = '';
+    private $previousLineWasRemoved = false;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function write($messages, bool $newline = false, int $options = 0)
+    {
+        $messages = $this->filterMessages($messages, $newline);
+
+        $this->output->write($messages, $newline, $options);
+    }
+
+    public function writeln($messages, int $options = 0)
+    {
+        $messages = $this->filterMessages($messages, true);
+
+        $this->output->writeln($messages, $options);
+    }
+
+    public function setVerbosity(int $level)
+    {
+        $this->output->setVerbosity($level);
+    }
+
+    public function getVerbosity()
+    {
+        return $this->output->getVerbosity();
+    }
+
+    public function isQuiet()
+    {
+        return $this->output->isQuiet();
+    }
+
+    public function isVerbose()
+    {
+        return $this->output->isVerbose();
+    }
+
+    public function isVeryVerbose()
+    {
+        return $this->output->isVeryVerbose();
+    }
+
+    public function isDebug()
+    {
+        return $this->output->isDebug();
+    }
+
+    public function setDecorated(bool $decorated)
+    {
+        $this->output->setDecorated($decorated);
+    }
+
+    public function isDecorated()
+    {
+        return $this->output->isDecorated();
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter)
+    {
+        $this->output->setFormatter($formatter);
+    }
+
+    public function getFormatter()
+    {
+        return $this->output->getFormatter();
+    }
+
+    public function fetch(): string
+    {
+        return $this->buffer;
+    }
+
+    private function filterMessages($messages, bool $newLine)
+    {
+        if (!is_iterable($messages)) {
+            $messages = [$messages];
+        }
+
+        $hiddenPhrases = [
+            'Generated new migration class',
+            'To run just this migration',
+            'To revert the migration you',
+        ];
+
+        foreach ($messages as $key => $message) {
+            $this->buffer .= $message;
+
+            if ($newLine) {
+                $this->buffer .= PHP_EOL;
+            }
+
+            if ($this->previousLineWasRemoved && !trim($message)) {
+                // hide a blank line after a filtered line
+                unset($messages[$key]);
+                $this->previousLineWasRemoved = false;
+
+                continue;
+            }
+
+            $this->previousLineWasRemoved = false;
+            foreach ($hiddenPhrases as $hiddenPhrase) {
+                if (false !== strpos($message, $hiddenPhrase)) {
+                    $this->previousLineWasRemoved = true;
+                    unset($messages[$key]);
+
+                    break;
+                }
+            }
+        }
+
+        return array_values($messages);
+    }
+}

--- a/src/ConsoleStyle.php
+++ b/src/ConsoleStyle.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -19,6 +21,15 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class ConsoleStyle extends SymfonyStyle
 {
+    private $output;
+
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        $this->output = $output;
+
+        parent::__construct($input, $output);
+    }
+
     public function success($message)
     {
         $this->writeln('<fg=green;options=bold,underscore>OK</> '.$message);
@@ -27,5 +38,10 @@ final class ConsoleStyle extends SymfonyStyle
     public function comment($message)
     {
         $this->text($message);
+    }
+
+    public function getOutput(): OutputInterface
+    {
+        return $this->output;
     }
 }

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -44,6 +44,8 @@ final class MakerTestDetails
 
     private $requiredPhpVersion;
 
+    private $requiredPackageVersions = [];
+
     private $guardAuthenticators = [];
 
     /**
@@ -216,6 +218,13 @@ final class MakerTestDetails
         return $this;
     }
 
+    public function addRequiredPackageVersion(string $packageName, string $versionConstraint): self
+    {
+        $this->requiredPackageVersions[] = ['name' => $packageName, 'version_constraint' => $versionConstraint];
+
+        return $this;
+    }
+
     public function setGuardAuthenticator(string $firewallName, string $id): self
     {
         $this->guardAuthenticators[$firewallName] = $id;
@@ -315,5 +324,10 @@ final class MakerTestDetails
     public function getGuardAuthenticators(): array
     {
         return $this->guardAuthenticators;
+    }
+
+    public function getRequiredPackageVersions(): array
+    {
+        return $this->requiredPackageVersions;
     }
 }

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -69,6 +69,15 @@ final class MakerTestEnvironment
         return $this->path;
     }
 
+    public function readFile(string $path): string
+    {
+        if (!file_exists($this->path.'/'.$path)) {
+            throw new \InvalidArgumentException(sprintf('Cannot find file "%s"', $path));
+        }
+
+        return file_get_contents($this->path.'/'.$path);
+    }
+
     private function changeRootNamespaceIfNeeded()
     {
         if ('App' === ($rootNamespace = $this->testDetails->getRootNamespace())) {

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -69,6 +69,7 @@ class MakeMigrationTest extends MakerTestCase
             ])
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMigration')
             ->configureDatabase(false)
+            ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
             ->addExtraDependencies('doctrine/orm:@stable')
             // generate a migration first
             ->addPreMakeCommand('php bin/console make:migration')
@@ -76,7 +77,6 @@ class MakeMigrationTest extends MakerTestCase
                 $this->assertStringContainsString('You have 1 available migrations to execute', $output);
                 $this->assertStringContainsString('Success', $output);
                 $this->assertCount(14, explode("\n", $output), 'Asserting that very specific output is shown - some should be hidden');
-                var_dump($output);
             }),
         ];
 
@@ -88,6 +88,7 @@ class MakeMigrationTest extends MakerTestCase
             ])
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeMigration')
             ->configureDatabase(false)
+            ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
             ->addExtraDependencies('doctrine/orm:@stable')
             // generate a migration first
             ->addPreMakeCommand('php bin/console make:migration')


### PR DESCRIPTION
This more selectively overrides output so that some output - including
asking a confirmation question - can be shown to the user.

Fixes #643 and fixes #642 