### PR TITLE
Create 'main' database in Docker by default

### DIFF
--- a/src/Docker/DockerDatabaseServices.php
+++ b/src/Docker/DockerDatabaseServices.php
@@ -31,6 +31,7 @@ final class DockerDatabaseServices
                     'image' => sprintf('mariadb:%s', $version),
                     'environment' => [
                         'MYSQL_ROOT_PASSWORD' => 'password',
+                        'MYSQL_DATABASE' => 'main',
                     ],
                 ];
             case 'mysql':
@@ -38,6 +39,7 @@ final class DockerDatabaseServices
                     'image' => sprintf('mysql:%s', $version),
                     'environment' => [
                         'MYSQL_ROOT_PASSWORD' => 'password',
+                        'MYSQL_DATABASE' => 'main',
                     ],
                 ];
             case 'postgres':

--- a/tests/Maker/MakeDockerDatabaseTest.php
+++ b/tests/Maker/MakeDockerDatabaseTest.php
@@ -68,6 +68,7 @@ final class MakeDockerDatabaseTest extends MakerTestCase
 
                     self::assertSame('mysql:latest', $mysql['image']);
                     self::assertSame('password', $mysql['environment']['MYSQL_ROOT_PASSWORD']);
+                    self::assertSame('main', $mysql['environment']['MYSQL_DATABASE']);
                     self::assertSame(['3306'], $mysql['ports']);
                 }
             ),
@@ -94,6 +95,7 @@ final class MakeDockerDatabaseTest extends MakerTestCase
 
                     self::assertSame('mariadb:latest', $mariadb['image']);
                     self::assertSame('password', $mariadb['environment']['MYSQL_ROOT_PASSWORD']);
+                    self::assertSame('main', $mariadb['environment']['MYSQL_DATABASE']);
                     self::assertSame(['3306'], $mariadb['ports']);
                 }
             ),


### PR DESCRIPTION
This adds the MYSQL_DATABASE environment variable to docker-compose.yaml, which enables Docker to create a default database called 'main'. This matches the symfony binary's default expected database.