### PR TITLE
avoiding stable-dev dependencies on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,12 @@ matrix:
         - php: 7.1.33
           env: MAKER_TEST_VERSION=stable
         - php: 7.3
-          env: MAKER_TEST_VERSION=stable-dev
+          env: MAKER_TEST_VERSION=stable
+          # too unstable - sometimes we need other dev deps
+          # for things to pass, sometimes dev deps of other libraries
+          # are unstable and cause things to fail.
+#        - php: 7.3
+#          env: MAKER_TEST_VERSION=stable-dev
         - php: 7.3
           env: MAKER_TEST_VERSION=dev
     allow_failures:

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -444,7 +444,7 @@ echo json_encode($missingDependencies);
     private function getTargetFlexVersion(): string
     {
         if (null === $this->targetFlexVersion) {
-            $targetVersion = $_SERVER['MAKER_TEST_VERSION'] ?? 'stable-dev';
+            $targetVersion = $_SERVER['MAKER_TEST_VERSION'] ?? 'stable';
 
             if ('stable' === $targetVersion) {
                 $this->targetFlexVersion = '';


### PR DESCRIPTION
They are too likely to break. Sometimes, in order for the
"dev" version of Symfony's stable branch to pass, we need
dev versions of other dependencies. Sometimes, we need the
exact opposite: dev versions of other libs cause failures.