### PR TITLE
Better guess entity name in Voter template

### DIFF
--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -13,7 +13,7 @@ class <?= $class_name ?> extends Voter
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
         return in_array($attribute, ['POST_EDIT', 'POST_VIEW'])
-            && $subject instanceof \App\Entity\BlogPost;
+            && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;
     }
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)


### PR DESCRIPTION
`$subject instanceof \App\Entity\BlogPost;` part replaced with `$subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;` to better guess entity name based on Voter naming convention.