### PR TITLE
Remove "internal" from FileManager

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -21,7 +21,7 @@ use Symfony\Component\Finder\Finder;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  *
- * @internal
+ * @final
  */
 class FileManager
 {


### PR DESCRIPTION
I'm rewriting the makers of my eloquent bundle to the maker bundle. It works great, except for one thing: For the best consistent experience, I use Laravel's stub files and generator. This means I cannot use the `Generator` argument of `generate()`. However, I would like to use MakerBundle's `FileManager` (for nice output and FQCN to path transformations).

This requires `FileManager` to no longer be internal (at least, I don't want to depend on internal classes in a low-maintenance bundle). Would it be possible to make `FileManager` final only?