### PR TITLE
Remove trailing "." for consistency with #36798

### DIFF
--- a/src/Maker/MakeDockerDatabase.php
+++ b/src/Maker/MakeDockerDatabase.php
@@ -67,7 +67,7 @@ final class MakeDockerDatabase extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
-            ->setDescription('Adds a database container to your docker-compose.yaml file.')
+            ->setDescription('Adds a database container to your docker-compose.yaml file')
         ;
     }
 

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -67,7 +67,7 @@ class MakeResetPassword extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig)
     {
         $command
-            ->setDescription('Create controller, entity, and repositories for use with symfonycasts/reset-password-bundle.')
+            ->setDescription('Create controller, entity, and repositories for use with symfonycasts/reset-password-bundle')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeResetPassword.txt'))
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 (to be switched while merging)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Following https://github.com/symfony/symfony/pull/36798. When running `bin/console` almost all the command descriptions do not end with a ".". So in order to be consistent, we should remove it from the Make Bundle Commands.

![image](https://user-images.githubusercontent.com/351553/89835336-e3021b00-db64-11ea-87c9-6d2ac50f6db2.png)

Thanks in again for your great work!