### PR TITLE
swapping jellybean for popsicle

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -178,7 +178,7 @@ final class Str
         $nouns = [
             'elephant',
             'pizza',
-            'jellybean',
+            'popsicle',
             'chef',
             'puppy',
             'gnome',


### PR DESCRIPTION
the capitalization in the wizard was confusing because Jelly Bean is two words and 'bean' was showing up lowercase.