### PR TITLE
Use Command:SUCCESS constant for command exit code when possible

### DIFF
--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -37,6 +37,6 @@ class <?= $class_name; ?> extends Command
 
         $io->success('You have a new command! Now make it your own! Pass --help to see your options.');
 
-        return 0;
+        return <?= defined('Symfony\Component\Console\Command\Command::SUCCESS') ? 'Command::SUCCESS' : '0' ?>;
     }
 }


### PR DESCRIPTION
This is follow-up for https://github.com/symfony/symfony/issues/35431

It would also align generated code with an example in the documentation.
https://symfony.com/doc/current/console.html#creating-a-command