### PR TITLE
Fixing usage of legacy manager registry

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -52,11 +52,13 @@ class MakeResetPassword extends AbstractMaker
 {
     private $fileManager;
     private $doctrineHelper;
+    private $entityClassGenerator;
 
-    public function __construct(FileManager $fileManager, DoctrineHelper $doctrineHelper)
+    public function __construct(FileManager $fileManager, DoctrineHelper $doctrineHelper, EntityClassGenerator $entityClassGenerator)
     {
         $this->fileManager = $fileManager;
         $this->doctrineHelper = $doctrineHelper;
+        $this->entityClassGenerator = $entityClassGenerator;
     }
 
     public static function getCommandName(): string
@@ -323,9 +325,7 @@ class MakeResetPassword extends AbstractMaker
 
     private function generateRequestEntity(Generator $generator, ClassNameDetails $requestClassNameDetails, ClassNameDetails $repositoryClassNameDetails, string $userClass): void
     {
-        $entityClassGenerator = new EntityClassGenerator($generator, $this->doctrineHelper);
-
-        $requestEntityPath = $entityClassGenerator->generateEntityClass($requestClassNameDetails, false, false, false);
+        $requestEntityPath = $this->entityClassGenerator->generateEntityClass($requestClassNameDetails, false, false, false);
 
         $generator->writeChanges();
 
@@ -359,7 +359,7 @@ CODE
 
         $this->fileManager->dumpFile($requestEntityPath, $manipulator->getSourceCode());
 
-        $entityClassGenerator->generateRepositoryClass(
+        $this->entityClassGenerator->generateRepositoryClass(
             $repositoryClassNameDetails->getFullName(),
             $requestClassNameDetails->getFullName(),
             false,

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -77,6 +77,7 @@
             <service id="maker.maker.make_reset_password" class="Symfony\Bundle\MakerBundle\Maker\MakeResetPassword">
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.doctrine_helper" />
+                <argument type="service" id="maker.entity_class_generator" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -11,7 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry as LegacyManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -155,8 +156,15 @@ final class Validator
         return $name;
     }
 
-    public static function validateDoctrineFieldName(string $name, ManagerRegistry $registry)
+    /**
+     * @param ManagerRegistry|LegacyManagerRegistry $registry
+     */
+    public static function validateDoctrineFieldName(string $name, $registry)
     {
+        if (!$registry instanceof ManagerRegistry && !$registry instanceof LegacyManagerRegistry) {
+            throw new \InvalidArgumentException(sprintf('Argument 2 to %s::validateDoctrineFieldName must be an instance of %s, %s passed.', __CLASS__, ManagerRegistry::class, \is_object($registry) ? \get_class($registry) : \gettype($registry)));
+        }
+
         // check reserved words
         if ($registry->getConnection()->getDatabasePlatform()->getReservedKeywordsList()->isKeyword($name)) {
             throw new \InvalidArgumentException(sprintf('Name "%s" is a reserved word.', $name));


### PR DESCRIPTION
The user's app might use either the new or old class. This is already handled correctly on DoctrineHelper.

Fixes #665 