### PR TITLE
Debugging CI Failure related to doctrine/persistence

### DIFF
--- a/src/Doctrine/EntityRegenerator.php
+++ b/src/Doctrine/EntityRegenerator.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Bundle\MakerBundle\Doctrine;
 
-use Doctrine\Common\Persistence\Mapping\MappingException as CommonMappingException;
+use Doctrine\Common\Persistence\Mapping\MappingException as LegacyCommonMappingException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\Persistence\Mapping\MappingException as PersistenceMappingException;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -43,7 +44,7 @@ final class EntityRegenerator
     {
         try {
             $metadata = $this->doctrineHelper->getMetadata($classOrNamespace);
-        } catch (MappingException | CommonMappingException $mappingException) {
+        } catch (MappingException | LegacyCommonMappingException | PersistenceMappingException $mappingException) {
             $metadata = $this->doctrineHelper->getMetadata($classOrNamespace, true);
         }
 


### PR DESCRIPTION
The tests are now mostly fixed, after a few vendor libraries implemented fixes.

However, there is still one test that's failing, and I'm unable to repeat it locally:

https://travis-ci.org/github/symfony/maker-bundle/jobs/721078624#L366

This started erroring between builds 2377 and 2380. No relevant changes were made to Maker, but there *were* some significant Doctrine vendor updates:

```
from: doctrine/persistence (1.4.x-dev 7faf8b7):
to:   doctrine/persistence (2.0.x-dev ebb6c32):

from: doctrine/doctrine-bundle (dev-master b74e72c):
to:   doctrine/doctrine-bundle (dev-master 78b13d5):
Summary: basically just the allowing of doctrine/persistence v2

from: doctrine/common (2.13.x-dev f3812c0):
to: doctrine/common (dev-master c799163):
```

The tl;dr is that something in doctrine/persistence 2 or doctrine/common 3 is causing a failure that I can't repeat locally. 