### PR TITLE
#395 - guess entity name in normalizer template

### DIFF
--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -15,7 +15,7 @@ class <?= $class_name ?> implements NormalizerInterface<?= $cacheable_interface 
         $this->normalizer = $normalizer;
     }
 
-    public function normalize($object, $format = null, array $context = array()): array
+    public function normalize($object, $format = null, array $context = []): array
     {
         $data = $this->normalizer->normalize($object, $format, $context);
 
@@ -26,7 +26,7 @@ class <?= $class_name ?> implements NormalizerInterface<?= $cacheable_interface 
 
     public function supportsNormalization($data, $format = null): bool
     {
-        return $data instanceof \App\Entity\BlogPost;
+        return $data instanceof \App\Entity\<?= str_replace('Normalizer', null, $class_name) ?>;
     }
 <?php if ($cacheable_interface): ?>
 

--- a/tests/Maker/MakeSerializerNormalizerTest.php
+++ b/tests/Maker/MakeSerializerNormalizerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeSerializerNormalizer;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
+
+class MakeSerializerNormalizerTest extends MakerTestCase
+{
+    public function getTestDetails()
+    {
+        yield 'serializer_normalizer' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeSerializerNormalizer::class),
+            [
+                // normalizer class name
+                'FooBarNormalizer',
+            ]),
+        ];
+    }
+}


### PR DESCRIPTION
Hi,

To fix https://github.com/symfony/maker-bundle/issues/395, I propose to do like in https://github.com/symfony/maker-bundle/pull/658. 
_This is only for Normalizer, because Voter was already fixed in https://github.com/symfony/maker-bundle/pull/658_

This intends to replace : https://github.com/symfony/maker-bundle/pull/416
