### PR TITLE
Added alternative suggestion after creating an entity

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -264,6 +264,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         $this->writeSuccessMessage($io);
         $io->text([
             'Next: When you\'re ready, create a migration with <info>php bin/console make:migration</info>',
+            'Don\'t want to use migrations? Run <info>php bin/console doctrine:schema:update --force</info> update match your database with entities',
             '',
         ]);
     }


### PR DESCRIPTION
When I started learning symfony after creating my very first entity I started using migrations, I didn't even knew that I can run `bin/console d:s:u --force`.

I think new users should be suggested this option