### PR TITLE
 [WIP] Feat: Type properties with PHP >= 7.4

### DIFF
--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -56,7 +56,7 @@ final class MakerCommand extends Command
 
     protected function configure()
     {
-        $this->addOption('typed', null, null, 'Type the generated properties', $this->params->get('isTyped'));
+        $this->addOption('typed', null, InputOption::VALUE_OPTIONAL, 'Type the generated properties', $this->params->get('isTyped'));
         $this->maker->configureCommand($this, $this->inputConfig);
     }
 
@@ -88,8 +88,12 @@ final class MakerCommand extends Command
             ]);
         }
 
-        if (70400 < \PHP_VERSION_ID && $input->getOption('typed')) {
-            $response = $this->io->ask('Be careful, you seem to be using a version of PHP that is too old to support property typing. Are you sure you know what you\'re doing');
+        if (null === $input->getOption('typed')) {
+            $input->setOption('typed', true);
+        }
+
+        if (\PHP_VERSION_ID < 70400 && $input->getOption('typed')) {
+            $response = $this->io->confirm('Be careful, you seem to be using a version of PHP that is too old to support property typing. Are you sure you know what you\'re doing', false);
             $input->setOption('typed', $response);
         }
 

--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -56,7 +56,7 @@ final class MakerCommand extends Command
 
     protected function configure()
     {
-        $this->addOption('typed', null, InputOption::VALUE_OPTIONAL, 'Type the generated properties', $this->params->get('isTyped'));
+        $this->addOption('typed', null, InputOption::VALUE_OPTIONAL, 'Type the generated properties', $this->params->get('is_typed'));
         $this->maker->configureCommand($this, $this->inputConfig);
     }
 

--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -56,7 +56,7 @@ final class MakerCommand extends Command
 
     protected function configure()
     {
-        $this->addOption('typed', null, InputOption::VALUE_NONE, 'Type the generated properties', $this->params->get('isTyped'));
+        $this->addOption('typed', null, null, 'Type the generated properties', $this->params->get('isTyped'));
         $this->maker->configureCommand($this, $this->inputConfig);
     }
 

--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -77,6 +77,15 @@ final class MakerCommand extends Command
                 throw new RuntimeCommandException($missingPackagesMessage);
             }
         }
+
+        if (null === $input->getOption('typed')) {
+            $input->setOption('typed', true);
+        }
+
+        if (\PHP_VERSION_ID < 70400 && $input->getOption('typed')) {
+            $response = $this->io->confirm('Be careful, you seem to be using a version of PHP that is too old to support property typing. Are you sure you know what you\'re doing', false);
+            $input->setOption('typed', $response);
+        }
     }
 
     protected function interact(InputInterface $input, OutputInterface $output)
@@ -86,15 +95,6 @@ final class MakerCommand extends Command
                 sprintf('It looks like your app may be using a namespace other than "%s".', $this->generator->getRootNamespace()),
                 'To configure this and make your life easier, see: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html#configuration',
             ]);
-        }
-
-        if (null === $input->getOption('typed')) {
-            $input->setOption('typed', true);
-        }
-
-        if (\PHP_VERSION_ID < 70400 && $input->getOption('typed')) {
-            $response = $this->io->confirm('Be careful, you seem to be using a version of PHP that is too old to support property typing. Are you sure you know what you\'re doing', false);
-            $input->setOption('typed', $response);
         }
 
         foreach ($this->getDefinition()->getArguments() as $argument) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('root_namespace')->defaultValue('App')->end()
+                ->booleanNode('is_typed')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -37,7 +37,7 @@ class MakerExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('isTyped', $config['is_typed']);
+        $container->setParameter('is_typed', $config['is_typed']);
 
         $rootNamespace = trim($config['root_namespace'], '\\');
 

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -37,6 +37,8 @@ class MakerExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        $container->setParameter('isTyped', $config['is_typed']);
+
         $rootNamespace = trim($config['root_namespace'], '\\');
 
         $autoloaderFinderDefinition = $container->getDefinition('maker.autoloader_finder');

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -50,7 +50,7 @@ final class EntityClassGenerator
                 'api_resource' => $apiResource,
                 'should_escape_table_name' => $this->doctrineHelper->isKeyword($tableName),
                 'table_name' => $tableName,
-                'isTyped' => $isTyped,
+                'is_typed' => $isTyped,
             ]
         );
 

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -31,7 +31,7 @@ final class EntityClassGenerator
         $this->doctrineHelper = $doctrineHelper;
     }
 
-    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true): string
+    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true, bool $isTyped = false): string
     {
         $repoClassDetails = $this->generator->createClassNameDetails(
             $entityClassDetails->getRelativeName(),
@@ -50,6 +50,7 @@ final class EntityClassGenerator
                 'api_resource' => $apiResource,
                 'should_escape_table_name' => $this->doctrineHelper->isKeyword($tableName),
                 'table_name' => $tableName,
+                'isTyped' => $isTyped,
             ]
         );
 

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -188,7 +188,7 @@ final class MakeAuthenticator extends AbstractMaker
             $input->getArgument('authenticator-class'),
             $input->hasArgument('user-class') ? $input->getArgument('user-class') : null,
             $input->hasArgument('username-field') ? $input->getArgument('username-field') : null,
-            $input->getOption('isTyped')
+            $input->getOption('typed')
         );
 
         // update security.yaml with guard config

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -261,7 +261,7 @@ final class MakeAuthenticator extends AbstractMaker
                 'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
                 'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
                 'provider_key_type_hint' => $this->providerKeyTypeHint(),
-                'isTyped' => $isTyped,
+                'is_typed' => $isTyped,
             ]
         );
     }

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -187,7 +187,8 @@ final class MakeAuthenticator extends AbstractMaker
             $input->getArgument('authenticator-type'),
             $input->getArgument('authenticator-class'),
             $input->hasArgument('user-class') ? $input->getArgument('user-class') : null,
-            $input->hasArgument('username-field') ? $input->getArgument('username-field') : null
+            $input->hasArgument('username-field') ? $input->getArgument('username-field') : null,
+            $input->getOption('isTyped')
         );
 
         // update security.yaml with guard config
@@ -229,7 +230,7 @@ final class MakeAuthenticator extends AbstractMaker
         );
     }
 
-    private function generateAuthenticatorClass(array $securityData, string $authenticatorType, string $authenticatorClass, $userClass, $userNameField)
+    private function generateAuthenticatorClass(array $securityData, string $authenticatorType, string $authenticatorClass, $userClass, $userNameField, bool $isTyped)
     {
         // generate authenticator class
         if (self::AUTH_TYPE_EMPTY_AUTHENTICATOR === $authenticatorType) {
@@ -260,6 +261,7 @@ final class MakeAuthenticator extends AbstractMaker
                 'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
                 'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
                 'provider_key_type_hint' => $this->providerKeyTypeHint(),
+                'isTyped' => $isTyped,
             ]
         );
     }

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -57,6 +57,7 @@ final class MakeCommand extends AbstractMaker
             'command/Command.tpl.php',
             [
                 'command_name' => $commandName,
+                'is_typed' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -147,7 +147,10 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (!$classExists) {
             $entityPath = $this->entityClassGenerator->generateEntityClass(
                 $entityClassDetails,
-                $input->getOption('api-resource')
+                $input->getOption('api-resource'),
+                false,
+                true,
+                $input->getOption('typed')
             );
 
             $generator->writeChanges();
@@ -188,7 +191,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             if (\is_array($newField)) {
                 $annotationOptions = $newField;
                 unset($annotationOptions['fieldName']);
-                $manipulator->addEntityField($newField['fieldName'], $annotationOptions);
+                $manipulator->addEntityField($newField['fieldName'], $annotationOptions, [], $input->getOption('typed'));
 
                 $currentFields[] = $newField['fieldName'];
             } elseif ($newField instanceof EntityRelation) {

--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -94,7 +94,10 @@ final class MakeMessage extends AbstractMaker
 
         $generator->generateClass(
             $messageClassNameDetails->getFullName(),
-            'message/Message.tpl.php'
+            'message/Message.tpl.php',
+            [
+                'isTyped' => $input->getOption('typed'),
+            ]
         );
 
         $generator->generateClass(

--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -96,7 +96,7 @@ final class MakeMessage extends AbstractMaker
             $messageClassNameDetails->getFullName(),
             'message/Message.tpl.php',
             [
-                'isTyped' => $input->getOption('typed'),
+                'is_typed' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -230,6 +230,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 [
                     'id_getter' => $input->getArgument('id-getter'),
                     'email_getter' => $input->getArgument('email-getter'),
+                    'isTyped' => $input->getOption('typed'),
                 ]
             );
 
@@ -274,6 +275,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 'authenticator_full_class_name' => $authenticatorClassName,
                 'firewall_name' => $input->getOption('firewall-name'),
                 'redirect_route_name' => $input->getOption('redirect-route-name'),
+                'isTyped' => $input->getOption('typed'),
             ]
         );
 
@@ -311,7 +313,7 @@ final class MakeRegistrationForm extends AbstractMaker
             );
             $userManipulator->setIo($io);
 
-            $userManipulator->addProperty('isVerified', ['@ORM\Column(type="boolean")'], false);
+            $userManipulator->addProperty('isVerified', ['@ORM\Column(type="boolean")'], false, !$input->getOption('typed') ?: 'bool');
             $userManipulator->addAccessorMethod('isVerified', 'isVerified', 'bool', false);
             $userManipulator->addSetter('isVerified', 'bool', false);
 

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -230,7 +230,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 [
                     'id_getter' => $input->getArgument('id-getter'),
                     'email_getter' => $input->getArgument('email-getter'),
-                    'isTyped' => $input->getOption('typed'),
+                    'is_typed' => $input->getOption('typed'),
                 ]
             );
 
@@ -275,7 +275,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 'authenticator_full_class_name' => $authenticatorClassName,
                 'firewall_name' => $input->getOption('firewall-name'),
                 'redirect_route_name' => $input->getOption('redirect-route-name'),
-                'isTyped' => $input->getOption('typed'),
+                'is_typed' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -209,7 +209,7 @@ class MakeResetPassword extends AbstractMaker
                 'from_email_name' => $input->getArgument('from-email-name'),
                 'email_getter' => $input->getArgument('email-getter'),
                 'email_field' => $input->getArgument('email-property-name'),
-                'isTyped' => $input->getOption('typed'),
+                'is_typed' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -209,10 +209,11 @@ class MakeResetPassword extends AbstractMaker
                 'from_email_name' => $input->getArgument('from-email-name'),
                 'email_getter' => $input->getArgument('email-getter'),
                 'email_field' => $input->getArgument('email-property-name'),
+                'isTyped' => $input->getOption('typed'),
             ]
         );
 
-        $this->generateRequestEntity($generator, $requestClassNameDetails, $repositoryClassNameDetails, $userClass);
+        $this->generateRequestEntity($generator, $requestClassNameDetails, $repositoryClassNameDetails, $userClass, $input->getOption('typed'));
 
         $this->setBundleConfig($io, $generator, $repositoryClassNameDetails->getFullName());
 
@@ -323,9 +324,9 @@ class MakeResetPassword extends AbstractMaker
         $io->newLine();
     }
 
-    private function generateRequestEntity(Generator $generator, ClassNameDetails $requestClassNameDetails, ClassNameDetails $repositoryClassNameDetails, string $userClass): void
+    private function generateRequestEntity(Generator $generator, ClassNameDetails $requestClassNameDetails, ClassNameDetails $repositoryClassNameDetails, string $userClass, bool $isTyped = false): void
     {
-        $requestEntityPath = $this->entityClassGenerator->generateEntityClass($requestClassNameDetails, false, false, false);
+        $requestEntityPath = $this->entityClassGenerator->generateEntityClass($requestClassNameDetails, false, false, false, $isTyped);
 
         $generator->writeChanges();
 

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -54,6 +54,7 @@ final class MakeSerializerEncoder extends AbstractMaker
             'serializer/Encoder.tpl.php',
             [
                 'format' => $format,
+                'isTyped' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -54,7 +54,7 @@ final class MakeSerializerEncoder extends AbstractMaker
             'serializer/Encoder.tpl.php',
             [
                 'format' => $format,
-                'isTyped' => $input->getOption('typed'),
+                'is_typed' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeSerializerNormalizer.php
+++ b/src/Maker/MakeSerializerNormalizer.php
@@ -51,7 +51,7 @@ final class MakeSerializerNormalizer extends AbstractMaker
             $normalizerClassNameDetails->getFullName(),
             'serializer/Normalizer.tpl.php',
             [
-                'is_typed' => $input->getOption('is_typed'),
+                'is_typed' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeSerializerNormalizer.php
+++ b/src/Maker/MakeSerializerNormalizer.php
@@ -49,7 +49,10 @@ final class MakeSerializerNormalizer extends AbstractMaker
 
         $generator->generateClass(
             $normalizerClassNameDetails->getFullName(),
-            'serializer/Normalizer.tpl.php'
+            'serializer/Normalizer.tpl.php',
+            [
+                'is_typed' => $input->getOption('is_typed'),
+            ]
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -144,7 +144,8 @@ final class MakeUser extends AbstractMaker
             $classPath = $this->entityClassGenerator->generateEntityClass(
                 $userClassNameDetails,
                 false, // api resource
-                $userClassConfiguration->hasPassword() && interface_exists(PasswordUpgraderInterface::class) // security user
+                $userClassConfiguration->hasPassword() && interface_exists(PasswordUpgraderInterface::class), // security user
+                $input->getOption('typed')
             );
         } else {
             $classPath = $generator->generateClass($userClassNameDetails->getFullName(), 'Class.tpl.php');

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -62,7 +62,9 @@ final class MakeValidator extends AbstractMaker
         $generator->generateClass(
             $constraintFullClassName,
             'validator/Constraint.tpl.php',
-            []
+            [
+                'isTyped' => $input->getOption('isTyped'),
+            ]
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -63,7 +63,7 @@ final class MakeValidator extends AbstractMaker
             $constraintFullClassName,
             'validator/Constraint.tpl.php',
             [
-                'isTyped' => $input->getOption('typed'),
+                'is_typed' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -63,7 +63,7 @@ final class MakeValidator extends AbstractMaker
             $constraintFullClassName,
             'validator/Constraint.tpl.php',
             [
-                'isTyped' => $input->getOption('isTyped'),
+                'isTyped' => $input->getOption('typed'),
             ]
         );
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -44,6 +44,7 @@
                 <argument /> <!-- maker -->
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.generator" />
+                <argument type="service" id="parameter_bag" />
             </service>
 
             <service id="maker.generator" class="Symfony\Bundle\MakerBundle\Generator">

--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -43,11 +43,19 @@ optional arguments and options. Check them out with the ``--help`` option:
 
     $ php bin/console make:controller --help
 
+To adding typing on for your properties of your class you can use the optional
+--typing flag. This feature need PHP >= 7.4
+
+.. code-block:: terminal
+
+    $ php bin/console make:entity --typed
+
 Configuration
 -------------
 
 This bundle doesn't require any configuration. But, you *can* configure
-the root namespace that is used to "guess" what classes you want to generate:
+the root namespace that is used to "guess" what classes you want to generate.
+You can also defined if the properties of your class need to be typed:
 
 .. code-block:: yaml
 
@@ -58,6 +66,8 @@ the root namespace that is used to "guess" what classes you want to generate:
         # Acme namespace, instead of the default App
         # (e.g. Acme\Entity\Article, Acme\Command\MyCommand, etc)
         root_namespace: 'Acme'
+        # tell MakerBundle that properties need to be typed
+        is_typed: true
 
 Creating your Own Makers
 ------------------------

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -24,9 +24,9 @@ class <?= $class_name; ?> extends AbstractFormLoginAuthenticator<?= $password_au
 {
     use TargetPathTrait;
 
-    public const<?= $is_typed ? ' string' : null ?> LOGIN_ROUTE = 'app_login';
+    public const LOGIN_ROUTE = 'app_login';
 
-<?= $user_is_entity ? '    private'.$is_typed ? ' EntityManagerInterface' : null." \$entityManager;\n" : null ?>
+<?= $user_is_entity ? '    private'. ($is_typed ? ' EntityManagerInterface' : null) ." \$entityManager;\n" : null ?>
     private<?= $is_typed ? ' UrlGeneratorInterface' : null  ?> $urlGenerator;
     private<?= $is_typed ? ' CsrfTokenManagerInterface' : null  ?> $csrfTokenManager;
 <?= $user_needs_encoder ? "    private \$passwordEncoder;\n" : null ?>

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -24,7 +24,7 @@ class <?= $class_name; ?> extends AbstractFormLoginAuthenticator<?= $password_au
 {
     use TargetPathTrait;
 
-    public const<?= !$is_typed ?: ' string' ?> LOGIN_ROUTE = 'app_login';
+    public const<?= $is_typed ? ' string' : null ?> LOGIN_ROUTE = 'app_login';
 
 <?= $user_is_entity ? '    private'.$is_typed ? ' EntityManagerInterface' : null." \$entityManager;\n" : null ?>
     private<?= $is_typed ? ' UrlGeneratorInterface' : null  ?> $urlGenerator;

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -24,11 +24,11 @@ class <?= $class_name; ?> extends AbstractFormLoginAuthenticator<?= $password_au
 {
     use TargetPathTrait;
 
-    public const LOGIN_ROUTE = 'app_login';
+    public const<?= !$is_typed ?: ' string' ?> LOGIN_ROUTE = 'app_login';
 
-<?= $user_is_entity ? "    private \$entityManager;\n" : null ?>
-    private $urlGenerator;
-    private $csrfTokenManager;
+<?= $user_is_entity ? '    private'.$is_typed ? ' EntityManagerInterface' : null." \$entityManager;\n" : null ?>
+    private<?= $is_typed ? ' UrlGeneratorInterface' : null  ?> $urlGenerator;
+    private<?= $is_typed ? ' CsrfTokenManagerInterface' : null  ?> $csrfTokenManager;
 <?= $user_needs_encoder ? "    private \$passwordEncoder;\n" : null ?>
 
     public function __construct(<?= $user_is_entity ? 'EntityManagerInterface $entityManager, ' : null ?>UrlGeneratorInterface $urlGenerator, CsrfTokenManagerInterface $csrfTokenManager<?= $user_needs_encoder ? ', UserPasswordEncoderInterface $passwordEncoder' : null ?>)

--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class <?= $class_name; ?> extends Command
 {
-    protected static $defaultName = '<?= $command_name; ?>';
+    protected static<?= $is_typed ? ' string' : null ?> $defaultName = '<?= $command_name; ?>';
 
     protected function configure()
     {

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -21,7 +21,7 @@ class <?= $class_name."\n" ?>
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
-    private<?= $isTyped ? ' ?int' : null ?> $id;
+    private<?= $is_typed ? ' ?int' : null ?> $id;
 
     public function getId(): ?int
     {

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -21,7 +21,7 @@ class <?= $class_name."\n" ?>
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
-    private $id;
+    private<?= $isTyped ? ' ?int' : null ?> $id;
 
     public function getId(): ?int
     {

--- a/src/Resources/skeleton/message/Message.tpl.php
+++ b/src/Resources/skeleton/message/Message.tpl.php
@@ -9,7 +9,7 @@ final class <?= $class_name."\n" ?>
      * data for this message class.
      */
 
-//     private<?= $isTyped ? ' string' : null ?> $name;
+//     private<?= $is_typed ? ' string' : null ?> $name;
 //
 //     public function __construct(string $name)
 //     {

--- a/src/Resources/skeleton/message/Message.tpl.php
+++ b/src/Resources/skeleton/message/Message.tpl.php
@@ -9,7 +9,7 @@ final class <?= $class_name."\n" ?>
      * data for this message class.
      */
 
-//     private $name;
+//     private<?= $isTyped ? ' string' : null ?> $name;
 //
 //     public function __construct(string $name)
 //     {

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -31,7 +31,7 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
 <?php if ($will_verify_email): ?>
-    private<?= $isTyped ? ' EmailVerifier' : null?> $emailVerifier;
+    private<?= $is_typed ? ' EmailVerifier' : null ?> $emailVerifier;
 
     public function __construct(EmailVerifier $emailVerifier)
     {

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -31,7 +31,7 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
 <?php if ($will_verify_email): ?>
-    private $emailVerifier;
+    private<?= $isTyped ? ' EmailVerifier' : null?> $emailVerifier;
 
     public function __construct(EmailVerifier $emailVerifier)
     {

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -25,7 +25,7 @@ class <?= $class_name ?> extends AbstractController
 {
     use ResetPasswordControllerTrait;
 
-    private<?= $isTyped ? ' ResetPasswordHelperInterface' : null?> $resetPasswordHelper;
+    private<?= $is_typed ? ' ResetPasswordHelperInterface' : null ?> $resetPasswordHelper;
 
     public function __construct(ResetPasswordHelperInterface $resetPasswordHelper)
     {

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -25,7 +25,7 @@ class <?= $class_name ?> extends AbstractController
 {
     use ResetPasswordControllerTrait;
 
-    private $resetPasswordHelper;
+    private<?= $isTyped ? ' ResetPasswordHelperInterface' : null?> $resetPasswordHelper;
 
     public function __construct(ResetPasswordHelperInterface $resetPasswordHelper)
     {

--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -8,7 +8,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class <?= $class_name ?> implements NormalizerInterface<?= $cacheable_interface ? ', CacheableSupportsMethodInterface' : '' ?><?= "\n" ?>
 {
-    private $normalizer;
+    private<?= $isTyped ? ' ObjectNormalizer' : null ?> $normalizer;
 
     public function __construct(ObjectNormalizer $normalizer)
     {

--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -8,7 +8,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class <?= $class_name ?> implements NormalizerInterface<?= $cacheable_interface ? ', CacheableSupportsMethodInterface' : '' ?><?= "\n" ?>
 {
-    private<?= $isTyped ? ' ObjectNormalizer' : null ?> $normalizer;
+    private<?= $is_typed ? ' ObjectNormalizer' : null ?> $normalizer;
 
     public function __construct(ObjectNormalizer $normalizer)
     {

--- a/src/Resources/skeleton/validator/Constraint.tpl.php
+++ b/src/Resources/skeleton/validator/Constraint.tpl.php
@@ -13,5 +13,5 @@ class <?= $class_name ?> extends Constraint
      * Any public properties become valid options for the annotation.
      * Then, use these in your validator class.
      */
-    public $message = 'The value "{{ value }}" is not valid.';
+    public<?= $isTyped ? ' string' : null ?> $message = 'The value "{{ value }}" is not valid.';
 }

--- a/src/Resources/skeleton/validator/Constraint.tpl.php
+++ b/src/Resources/skeleton/validator/Constraint.tpl.php
@@ -13,5 +13,5 @@ class <?= $class_name ?> extends Constraint
      * Any public properties become valid options for the annotation.
      * Then, use these in your validator class.
      */
-    public<?= $isTyped ? ' string' : null ?> $message = 'The value "{{ value }}" is not valid.';
+    public<?= $is_typed ? ' string' : null ?> $message = 'The value "{{ value }}" is not valid.';
 }

--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -12,9 +12,9 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
 class <?= $class_name; ?><?= "\n" ?>
 {
-    private<?= $isTyped ? ' VerifyEmailHelperInterface' : null ?> $verifyEmailHelper;
-    private<?= $isTyped ? ' MailerInterface' : null ?> $mailer;
-    private<?= $isTyped ? ' EntityManagerInterface' : null ?> $entityManager;
+    private<?= $is_typed ? ' VerifyEmailHelperInterface' : null ?> $verifyEmailHelper;
+    private<?= $is_typed ? ' MailerInterface' : null ?> $mailer;
+    private<?= $is_typed ? ' EntityManagerInterface' : null ?> $entityManager;
 
     public function __construct(VerifyEmailHelperInterface $helper, MailerInterface $mailer, EntityManagerInterface $manager)
     {

--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -12,9 +12,9 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
 class <?= $class_name; ?><?= "\n" ?>
 {
-    private $verifyEmailHelper;
-    private $mailer;
-    private $entityManager;
+    private<?= $isTyped ? ' VerifyEmailHelperInterface' : null ?> $verifyEmailHelper;
+    private<?= $isTyped ? ' MailerInterface' : null ?> $mailer;
+    private<?= $isTyped ? ' EntityManagerInterface' : null ?> $entityManager;
 
     public function __construct(VerifyEmailHelperInterface $helper, MailerInterface $mailer, EntityManagerInterface $manager)
     {

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class MakerCommandTest extends TestCase
 {
@@ -35,7 +36,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'));
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'), new ParameterBag(['isTyped' => false]));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);
@@ -48,7 +49,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'));
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'), new ParameterBag(['is_typed' => false]));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -36,7 +36,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'), new ParameterBag(['isTyped' => false]));
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'), new ParameterBag(['is_typed' => false]));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);


### PR DESCRIPTION
Edit: now this flag is global and you can defined if you want to use typing in the configuraiton file 🥳 Just one test dosn't pass.
When it's fix, this PR is ready to be merge.

----

Hi 👋 
With PHP 7.4 and the arrival of PHP 8.0 typing is starting to gain importance. So it's why I have adding the ``--typed`` flag. This flag type the properties of your entity.

For exemple, with PHP 7.4 or more, if I create this entity, I obtain the PHP below:
```shell
PS D:\symfony\sf-maker> php .\bin\console make:entity --typed

 Class name of the entity to create or update (e.g. AgreeableKangaroo):
 > TypedPizza
TypedPizza

 created: src/Entity/TypedPizza.php
 created: src/Repository/TypedPizzaRepository.php

 Entity generated! Now let's add some fields!
 You can always add more fields later manually or by re-running this command.

 New property name (press <return> to stop adding fields):
 > isCooked

 Field type (enter ? to see all types) [boolean]:
 >


 Can this field be null in the database (nullable) (yes/no) [no]:
 >

 updated: src/Entity/TypedPizza.php

 Add another property? Enter the property name (or press <return> to stop adding fields):
 >



  Success!


 Next: When you're ready, create a migration with php bin/console make:migration
```

```php
<?php

namespace App\Entity;

use App\Repository\TypedPizzaRepository;
use Doctrine\ORM\Mapping as ORM;

/**
 * @ORM\Entity(repositoryClass=TypedPizzaRepository::class)
 */
class TypedPizza
{
    /**
     * @ORM\Id
     * @ORM\GeneratedValue
     * @ORM\Column(type="integer")
     */
    private $id;

    /**
     * @ORM\Column(type="boolean")
     */
    private ?bool $isCooked;

    public function getId(): ?int
    {
        return $this->id;
    }

    public function getIsCooked(): ?bool
    {
        return $this->isCooked;
    }

    public function setIsCooked(bool $isCooked): self
    {
        $this->isCooked = $isCooked;

        return $this;
    }
}
```

If I execute this command with a lower PHP version I have a confirmation warning to ask if I really want typed properties.
To run the test, this pr need PHP 7.4 inot the CI, see #690