### PR TITLE
Allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.1.3",
+        "php": ">=7.1.3",
         "doctrine/inflector": "^1.2",
         "nikic/php-parser": "^4.0",
         "symfony/config": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
That will help test Symfony with PHP 8. That opens up support for PHP 8 annotations in the generated code as well.

I've not updated the Travix matrix as @OskarStark is doing some work there.
