### PR TITLE
Reverting - exclude() needs to be relative to in().

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -5,8 +5,8 @@ if (!file_exists(__DIR__.'/src')) {
 }
 
 $finder = PhpCsFixer\Finder::create()
-    ->in('src')
-    ->in('tests')
+    ->in(__DIR__)
+    ->exclude('vendor')
     ->exclude('tests/tmp')
     ->exclude('fixtures')
     // the PHP template files are a bit special
@@ -14,7 +14,7 @@ $finder = PhpCsFixer\Finder::create()
 ;
 
 return PhpCsFixer\Config::create()
-    ->setRules([
+    ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
         '@PHPUnit75Migration:risky' => true,
@@ -31,7 +31,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 EOF
         ]
-    ])
+    ))
     ->setRiskyAllowed(true)
     ->setFinder($finder)
 ;


### PR DESCRIPTION
This meant that the tests/tmp was no longer being excluded.

Revert "Enhancement: Update PHP-CS-Fixer config"

This reverts commit 64a4f568b73253a0ea064660aa2a30c1e6678c45.