### PR TITLE
Enhancement: Do not install mysql-client, use the already installed one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
 
             - name: "Verify MySQL connection from host"
               run: |
-                  sudo apt-get install -y mysql-client
                   mysql --host 127.0.0.1 --port 3306 -uroot -proot -e "SHOW DATABASES;"
 
             - name: "Setup Database"


### PR DESCRIPTION
THis PR

* [x] fixes the builds where `mysql-client` (sometimes) could not be installed via `apt-get`. It looks like we don't need to install it, as there is a `mysql-client` already available.