### PR TITLE
php8 attributes support for generated controllers

### DIFF
--- a/src/Maker/AbstractMaker.php
+++ b/src/Maker/AbstractMaker.php
@@ -48,4 +48,9 @@ abstract class AbstractMaker implements MakerInterface
             $message
         );
     }
+
+    final protected function useAttributes(): bool
+    {
+        return \PHP_VERSION_ID >= 80000;
+    }
 }

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -58,6 +58,7 @@ final class MakeController extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'controller/Controller.tpl.php',
             [
+                'use_attributes' => $this->useAttributes(),
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'with_template' => $this->isTwigInstalled() && !$noTemplate,

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -143,6 +143,7 @@ final class MakeCrud extends AbstractMaker
             $controllerClassDetails->getFullName(),
             'crud/controller/Controller.tpl.php',
             array_merge([
+                    'use_attributes' => $this->useAttributes(),
                     'entity_full_class_name' => $entityClassDetails->getFullName(),
                     'entity_class_name' => $entityClassDetails->getShortName(),
                     'form_full_class_name' => $formClassDetails->getFullName(),

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -258,6 +258,7 @@ final class MakeRegistrationForm extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'registration/RegistrationController.tpl.php',
             [
+                'use_attributes' => $this->useAttributes(),
                 'route_path' => '/register',
                 'route_name' => 'app_register',
                 'form_class_name' => $formClassDetails->getShortName(),

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -197,6 +197,7 @@ class MakeResetPassword extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'resetPassword/ResetPasswordController.tpl.php',
             [
+                'use_attributes' => $this->useAttributes(),
                 'user_full_class_name' => $userClassNameDetails->getFullName(),
                 'user_class_name' => $userClassNameDetails->getShortName(),
                 'request_form_type_full_class_name' => $requestFormTypeClassNameDetails->getFullName(),

--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -8,9 +8,13 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
+<?php if ($use_attributes) { ?>
+    #[Route('<?= $route_path ?>', name: '<?= $route_name ?>')]
+<?php } else { ?>
     /**
      * @Route("<?= $route_path ?>", name="<?= $route_name ?>")
      */
+<?php } ?>
     public function index(): Response
     {
 <?php if ($with_template) { ?>

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -12,14 +12,22 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+<?php if ($use_attributes) { ?>
+#[Route('<?= $route_path ?>')]
+<?php } else { ?>
 /**
  * @Route("<?= $route_path ?>")
  */
+<?php } ?>
 class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
+<?php if ($use_attributes) { ?>
+    #[Route('/', name: '<?= $route_name ?>_index', methods: ['GET'])]
+<?php } else { ?>
     /**
      * @Route("/", name="<?= $route_name ?>_index", methods={"GET"})
      */
+<?php } ?>
 <?php if (isset($repository_full_class_name)): ?>
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>): Response
     {
@@ -40,9 +48,13 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 <?php endif ?>
 
+<?php if ($use_attributes) { ?>
+    #[Route('/new', name: '<?= $route_name ?>_new', methods: ['GET', 'POST'])]
+<?php } else { ?>
     /**
      * @Route("/new", name="<?= $route_name ?>_new", methods={"GET","POST"})
      */
+<?php } ?>
     public function new(Request $request): Response
     {
         $<?= $entity_var_singular ?> = new <?= $entity_class_name ?>();
@@ -63,9 +75,13 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         ]);
     }
 
+<?php if ($use_attributes) { ?>
+    #[Route('/{<?= $entity_identifier ?>}', name: '<?= $route_name ?>_show', methods: ['GET'])]
+<?php } else { ?>
     /**
      * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_show", methods={"GET"})
      */
+<?php } ?>
     public function show(<?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
         return $this->render('<?= $templates_path ?>/show.html.twig', [
@@ -73,9 +89,13 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         ]);
     }
 
+<?php if ($use_attributes) { ?>
+    #[Route('/{<?= $entity_identifier ?>}/edit', name: '<?= $route_name ?>_edit', methods: ['GET', 'POST'])]
+<?php } else { ?>
     /**
      * @Route("/{<?= $entity_identifier ?>}/edit", name="<?= $route_name ?>_edit", methods={"GET","POST"})
      */
+<?php } ?>
     public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
         $form = $this->createForm(<?= $form_class_name ?>::class, $<?= $entity_var_singular ?>);
@@ -93,9 +113,13 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         ]);
     }
 
+<?php if ($use_attributes) { ?>
+    #[Route('/{<?= $entity_identifier ?>}', name: '<?= $route_name ?>_delete', methods: ['DELETE'])]
+<?php } else { ?>
     /**
      * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_delete", methods={"DELETE"})
      */
+<?php } ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
         if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->request->get('_token'))) {

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -39,9 +39,13 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 
 <?php endif; ?>
+<?php if ($use_attributes) { ?>
+    #[Route('<?= $route_path ?>', name: '<?= $route_name ?>')]
+<?php } else { ?>
     /**
      * @Route("<?= $route_path ?>", name="<?= $route_name ?>")
      */
+<?php } ?>
     public function register(Request $request, UserPasswordEncoderInterface $passwordEncoder<?= $authenticator_full_class_name ? sprintf(', GuardAuthenticatorHandler $guardHandler, %s $authenticator', $authenticator_class_name) : '' ?>): Response
     {
         $user = new <?= $user_class_name ?>();
@@ -91,9 +95,13 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 <?php if ($will_verify_email): ?>
 
+<?php if ($use_attributes) { ?>
+    #[Route('/verify/email', name: 'app_verify_email')]
+<?php } else { ?>
     /**
      * @Route("/verify/email", name="app_verify_email")
      */
+<?php } ?>
     public function verifyUserEmail(Request $request): Response
     {
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -18,9 +18,13 @@ use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
+<?php if ($use_attributes) { ?>
+#[Route('/reset-password')]
+<?php } else { ?>
 /**
  * @Route("/reset-password")
  */
+<?php } ?>
 class <?= $class_name ?> extends AbstractController
 {
     use ResetPasswordControllerTrait;
@@ -35,8 +39,13 @@ class <?= $class_name ?> extends AbstractController
     /**
      * Display & process form to request a password reset.
      *
+<?php if ($use_attributes) { ?>
+     */
+    #[Route('', name: 'app_forgot_password_request')]
+<?php } else { ?>
      * @Route("", name="app_forgot_password_request")
      */
+<?php } ?>
     public function request(Request $request, MailerInterface $mailer): Response
     {
         $form = $this->createForm(<?= $request_form_type_class_name ?>::class);
@@ -57,8 +66,13 @@ class <?= $class_name ?> extends AbstractController
     /**
      * Confirmation page after a user has requested a password reset.
      *
+<?php if ($use_attributes) { ?>
+     */
+    #[Route('/check-email', name: 'app_check_email')]
+<?php } else { ?>
      * @Route("/check-email", name="app_check_email")
      */
+<?php } ?>
     public function checkEmail(): Response
     {
         // We prevent users from directly accessing this page
@@ -74,8 +88,13 @@ class <?= $class_name ?> extends AbstractController
     /**
      * Validates and process the reset URL that the user clicked in their email.
      *
+<?php if ($use_attributes) { ?>
+     */
+    #[Route('/reset/{token}', name: 'app_reset_password')]
+<?php } else { ?>
      * @Route("/reset/{token}", name="app_reset_password")
      */
+<?php } ?>
     public function reset(Request $request, UserPasswordEncoderInterface $passwordEncoder, string $token = null): Response
     {
         if ($token) {


### PR DESCRIPTION
When using PHP8, Maker Bundle uses route attributes in the generated controllers instead of annotations.

- make:controller
- make:crud
- make:registration-form
- make:reset-password

As Doctrine/ORM does not currently have PHP8 support, we are unable to test the route functionality for `crud`, `registration-form`, & `reset-password`. No additional tests should be needed when Doctrine is PHP8 compatible.