### PR TITLE
improve php8 attribute support in makers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+        "symfony/deprecation-contracts": "^2.3",
         "symfony/filesystem": "^3.4|^4.0|^5.0",
         "symfony/finder": "^3.4|^4.0|^5.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",

--- a/src/Maker/AbstractMaker.php
+++ b/src/Maker/AbstractMaker.php
@@ -48,9 +48,4 @@ abstract class AbstractMaker implements MakerInterface
             $message
         );
     }
-
-    final protected function useAttributes(): bool
-    {
-        return \PHP_VERSION_ID >= 80000;
-    }
 }

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -58,7 +58,6 @@ final class MakeController extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'controller/Controller.tpl.php',
             [
-                'use_attributes' => $this->useAttributes(),
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'with_template' => $this->isTwigInstalled() && !$noTemplate,

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -143,7 +143,6 @@ final class MakeCrud extends AbstractMaker
             $controllerClassDetails->getFullName(),
             'crud/controller/Controller.tpl.php',
             array_merge([
-                    'use_attributes' => $this->useAttributes(),
                     'entity_full_class_name' => $entityClassDetails->getFullName(),
                     'entity_class_name' => $entityClassDetails->getShortName(),
                     'form_full_class_name' => $formClassDetails->getFullName(),

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -258,7 +258,6 @@ final class MakeRegistrationForm extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'registration/RegistrationController.tpl.php',
             [
-                'use_attributes' => $this->useAttributes(),
                 'route_path' => '/register',
                 'route_name' => 'app_register',
                 'form_class_name' => $formClassDetails->getShortName(),

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -197,7 +197,6 @@ class MakeResetPassword extends AbstractMaker
             $controllerClassNameDetails->getFullName(),
             'resetPassword/ResetPasswordController.tpl.php',
             [
-                'use_attributes' => $this->useAttributes(),
                 'user_full_class_name' => $userClassNameDetails->getFullName(),
                 'user_class_name' => $userClassNameDetails->getShortName(),
                 'request_form_type_full_class_name' => $requestFormTypeClassNameDetails->getFullName(),

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -49,6 +49,7 @@
             <service id="maker.generator" class="Symfony\Bundle\MakerBundle\Generator">
                 <argument type="service" id="maker.file_manager" />
                 <argument /> <!-- root namespace -->
+                <argument type="service" id="maker.php_compat_util" />
             </service>
 
             <service id="maker.entity_class_generator" class="Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator">
@@ -62,6 +63,10 @@
 
             <service id="maker.renderer.form_type_renderer" class="Symfony\Bundle\MakerBundle\Renderer\FormTypeRenderer">
                 <argument type="service" id="maker.generator" />
+            </service>
+
+            <service id="maker.php_compat_util" class="Symfony\Bundle\MakerBundle\Util\PhpCompatUtil">
+                <argument type="service" id="maker.file_manager" />
             </service>
         </services>
 </container>

--- a/src/Util/PhpCompatUtil.php
+++ b/src/Util/PhpCompatUtil.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Util;
+
+use Symfony\Bundle\MakerBundle\FileManager;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+class PhpCompatUtil
+{
+    /** @var FileManager */
+    private $fileManager;
+
+    public function __construct(FileManager $fileManager)
+    {
+        $this->fileManager = $fileManager;
+    }
+
+    public function canUseAttributes(): bool
+    {
+        $version = $this->getPhpVersion();
+
+        return version_compare($version, '8alpha', '>=');
+    }
+
+    protected function getPhpVersion(): string
+    {
+        $rootDirectory = $this->fileManager->getRootDirectory();
+
+        $composerLockPath = sprintf('%s/composer.lock', $rootDirectory);
+
+        if (!$this->fileManager->fileExists($composerLockPath)) {
+            return PHP_VERSION;
+        }
+
+        $lockFileContents = json_decode($this->fileManager->getFileContents($composerLockPath), true);
+
+        if (empty($lockFileContents['platform-overrides']) || empty($lockFileContents['platform-overrides']['php'])) {
+            return PHP_VERSION;
+        }
+
+        return $lockFileContents['platform-overrides']['php'];
+    }
+}

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\MakerInterface;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class MakerCommandTest extends TestCase
@@ -35,7 +36,9 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'));
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App', $mockPhpCompatUtil));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);
@@ -48,7 +51,9 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'));
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown', $mockPhpCompatUtil));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
@@ -113,7 +114,8 @@ class EntityRegeneratorTest extends TestCase
 
         $fileManager = new FileManager($fs, $autoloaderUtil, new MakerFileLinkFormatter(null), $tmpDir);
         $doctrineHelper = new DoctrineHelper('App\\Entity', $container->get('doctrine'));
-        $generator = new Generator($fileManager, 'App\\');
+        $phpCompatUtil = new PhpCompatUtil($fileManager);
+        $generator = new Generator($fileManager, 'App\\', $phpCompatUtil);
         $entityClassGenerator = new EntityClassGenerator($generator, $doctrineHelper);
         $entityClassGenerator->setMangerRegistryClassName(ManagerRegistry::class);
         $regenerator = new EntityRegenerator(

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 
 class GeneratorTest extends TestCase
 {
@@ -26,7 +27,11 @@ class GeneratorTest extends TestCase
         $fileManager->expects($this->any())
             ->method('getNamespacePrefixForClass')
             ->willReturn('Foo');
-        $generator = new Generator($fileManager, 'App\\');
+
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+
+        $generator = new Generator($fileManager, 'App\\', $mockPhpCompatUtil);
+
         $classNameDetails = $generator->createClassNameDetails($name, $prefix, $suffix);
 
         $this->assertSame($expectedFullClassName, $classNameDetails->getFullName());

--- a/tests/Util/PhpVersionTest.php
+++ b/tests/Util/PhpVersionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ */
+class PhpVersionTest extends TestCase
+{
+    /**
+     * @dataProvider phpVersionDataProvider
+     */
+    public function testUsesPhpPlatformFromComposerJsonFile(string $version, bool $expectedResult): void
+    {
+        $json = sprintf('{"platform-overrides": {"php": "%s"}}', $version);
+
+        $mockFileManager = $this->createMock(FileManager::class);
+        $mockFileManager
+            ->expects(self::once())
+            ->method('getRootDirectory')
+            ->willReturn('/test')
+        ;
+
+        $mockFileManager
+            ->expects(self::once())
+            ->method('fileExists')
+            ->with('/test/composer.lock')
+            ->willReturn(true)
+        ;
+
+        $mockFileManager
+            ->expects(self::once())
+            ->method('getFileContents')
+            ->with('/test/composer.lock')
+            ->willReturn($json)
+        ;
+
+        $version = new PhpCompatUtil($mockFileManager);
+
+        $result = $version->canUseAttributes();
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function phpVersionDataProvider(): \Generator
+    {
+        yield ['8', true];
+        yield ['8.0', true];
+        yield ['8.0.1', true];
+        yield ['8RC1', true];
+        yield ['8.1alpha1', true];
+        yield ['8.0.0beta2', true];
+        yield ['8beta', true];
+        yield ['7', false];
+        yield ['7.0', false];
+        yield ['7.1.1', false];
+        yield ['7.0.0RC3', false];
+    }
+
+    public function testFallBackToPhpVersionWithoutLockFile(): void
+    {
+        $mockFileManager = $this->createMock(FileManager::class);
+        $mockFileManager
+            ->expects(self::once())
+            ->method('getRootDirectory')
+            ->willReturn('/test')
+        ;
+
+        $mockFileManager
+            ->expects(self::once())
+            ->method('fileExists')
+            ->with('/test/composer.lock')
+            ->willReturn(false)
+        ;
+
+        $mockFileManager
+            ->expects(self::never())
+            ->method('getFileContents')
+        ;
+
+        $util = new PhpCompatUtilTestFixture($mockFileManager);
+
+        $result = $util->getVersionForTest();
+
+        self::assertSame(PHP_VERSION, $result);
+    }
+
+    public function testWithoutPlatformVersionSet(): void
+    {
+        $json = '{"platform-overrides": {}}';
+
+        $mockFileManager = $this->createMock(FileManager::class);
+        $mockFileManager
+            ->expects(self::once())
+            ->method('getRootDirectory')
+            ->willReturn('/test')
+        ;
+
+        $mockFileManager
+            ->expects(self::once())
+            ->method('fileExists')
+            ->with('/test/composer.lock')
+            ->willReturn(true)
+        ;
+
+        $mockFileManager
+            ->expects(self::once())
+            ->method('getFileContents')
+            ->with('/test/composer.lock')
+            ->willReturn($json)
+        ;
+
+        $util = new PhpCompatUtilTestFixture($mockFileManager);
+
+        $result = $util->getVersionForTest();
+
+        self::assertSame(PHP_VERSION, $result);
+    }
+}
+
+class PhpCompatUtilTestFixture extends PhpCompatUtil
+{
+    public function getVersionForTest(): string
+    {
+        return $this->getPhpVersion();
+    }
+}


### PR DESCRIPTION
Before we just checked the value of `\PHP_VERSION_ID` and passed a `bool` to templates that could use attributes. Now we've expended attribute support by checking if `composer.lock` has a platform override set. If not then we fall back to `\PHP_VERSION`

We've also introduced a new `PhpCompatUtil::class` & `use_attributes` is globally available to all templates.