### PR TITLE
[CI] disable fail fast functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
             - 'master'
 
 env:
-    fail-fast: true
     PHPUNIT_FLAGS: "-v"
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
     SYMFONY_REQUIRE: ">=3.4"
@@ -19,6 +18,7 @@ jobs:
         runs-on: "ubuntu-latest"
 
         strategy:
+            fail-fast: false
             matrix:
                 php-version:
                     - '7.4'
@@ -81,6 +81,7 @@ jobs:
             SYMFONY_SKELETON_STABILITY: ${{ matrix.symfony-skeleton-stability }}
 
         strategy:
+            fail-fast: false
             matrix:
                 php-version:
                     - '7.1.3'


### PR DESCRIPTION
allows tests to run across all of the matrix's even if one matrix fails.