### PR TITLE
keeping aliens at bay with maker + new security 5.2 features

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -168,6 +168,7 @@ class Generator
 
         $variables['relative_path'] = $this->fileManager->relativizePath($targetPath);
         $variables['use_attributes'] = $this->phpCompatUtil->canUseAttributes();
+        $variables['use_typed_properties'] = $this->phpCompatUtil->canUseTypedProperties();
 
         $templatePath = $templateName;
         if (!file_exists($templatePath)) {

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -36,10 +36,12 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * @author Ryan Weaver <ryan@knpuniversity.com>
+ * @author Ryan Weaver   <ryan@symfonycasts.com>
+ * @author Jesse Rushlow <jr@rushlow.dev>
  *
  * @internal
  */
@@ -55,6 +57,8 @@ final class MakeAuthenticator extends AbstractMaker
     private $generator;
 
     private $doctrineHelper;
+
+    private $useSecurity52 = false;
 
     public function __construct(FileManager $fileManager, SecurityConfigUpdater $configUpdater, Generator $generator, DoctrineHelper $doctrineHelper)
     {
@@ -83,6 +87,15 @@ final class MakeAuthenticator extends AbstractMaker
         }
         $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));
         $securityData = $manipulator->getData();
+
+        // Determine if we should use new security features introduced in Symfony 5.2
+        if ($securityData['security']['enable_authenticator_manager'] ?? false) {
+            $this->useSecurity52 = true;
+        }
+
+        if ($this->useSecurity52 && !class_exists(UserBadge::class)) {
+            throw new RuntimeCommandException('MakerBundle does not support generating authenticators using the new authenticator system before symfony/security-bundle 5.2. Please upgrade to 5.2 and try again.');
+        }
 
         // authenticator type
         $authenticatorTypeValues = [
@@ -138,10 +151,13 @@ final class MakeAuthenticator extends AbstractMaker
         $input->setOption('firewall-name', $firewallName = $interactiveSecurityHelper->guessFirewallName($io, $securityData));
 
         $command->addOption('entry-point', null, InputOption::VALUE_OPTIONAL);
-        $input->setOption(
-            'entry-point',
-            $interactiveSecurityHelper->guessEntryPoint($io, $securityData, $input->getArgument('authenticator-class'), $firewallName)
-        );
+
+        if (!$this->useSecurity52) {
+            $input->setOption(
+                'entry-point',
+                $interactiveSecurityHelper->guessEntryPoint($io, $securityData, $input->getArgument('authenticator-class'), $firewallName)
+            );
+        }
 
         if (self::AUTH_TYPE_FORM_LOGIN === $input->getArgument('authenticator-type')) {
             $command->addArgument('controller-class', InputArgument::REQUIRED);
@@ -192,13 +208,21 @@ final class MakeAuthenticator extends AbstractMaker
 
         // update security.yaml with guard config
         $securityYamlUpdated = false;
+
+        $entryPoint = $input->getOption('entry-point');
+
+        if ($this->useSecurity52 && self::AUTH_TYPE_FORM_LOGIN !== $input->getArgument('authenticator-type')) {
+            $entryPoint = false;
+        }
+
         try {
             $newYaml = $this->configUpdater->updateForAuthenticator(
                 $this->fileManager->getFileContents($path = 'config/packages/security.yaml'),
                 $input->getOption('firewall-name'),
-                $input->getOption('entry-point'),
+                $entryPoint,
                 $input->getArgument('authenticator-class'),
-                $input->hasArgument('logout-setup') ? $input->getArgument('logout-setup') : false
+                $input->hasArgument('logout-setup') ? $input->getArgument('logout-setup') : false,
+                $this->useSecurity52
             );
             $generator->dumpFile($path, $newYaml);
             $securityYamlUpdated = true;
@@ -235,10 +259,8 @@ final class MakeAuthenticator extends AbstractMaker
         if (self::AUTH_TYPE_EMPTY_AUTHENTICATOR === $authenticatorType) {
             $this->generator->generateClass(
                 $authenticatorClass,
-                'authenticator/EmptyAuthenticator.tpl.php',
-                [
-                    'provider_key_type_hint' => $this->providerKeyTypeHint(),
-                ]
+                sprintf('authenticator/%sEmptyAuthenticator.tpl.php', $this->useSecurity52 ? 'Security52' : ''),
+                ['provider_key_type_hint' => $this->providerKeyTypeHint()]
             );
 
             return;
@@ -251,12 +273,13 @@ final class MakeAuthenticator extends AbstractMaker
 
         $this->generator->generateClass(
             $authenticatorClass,
-            'authenticator/LoginFormAuthenticator.tpl.php',
+            sprintf('authenticator/%sLoginFormAuthenticator.tpl.php', $this->useSecurity52 ? 'Security52' : ''),
             [
                 'user_fully_qualified_class_name' => trim($userClassNameDetails->getFullName(), '\\'),
                 'user_class_name' => $userClassNameDetails->getShortName(),
                 'username_field' => $userNameField,
                 'username_field_label' => Str::asHumanWords($userNameField),
+                'username_field_var' => Str::asCamelCase($userNameField),
                 'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
                 'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
                 'provider_key_type_hint' => $this->providerKeyTypeHint(),
@@ -322,7 +345,8 @@ final class MakeAuthenticator extends AbstractMaker
                 'main',
                 null,
                 $authenticatorClass,
-                $logoutSetup
+                $logoutSetup,
+                $this->useSecurity52
             );
             $nextTexts[] = '- Your <info>security.yaml</info> could not be updated automatically. You\'ll need to add the following config manually:\n\n'.$yamlExample;
         }

--- a/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
@@ -1,0 +1,44 @@
+<?php echo "<?php\n" ?>
+
+namespace <?php echo $namespace ?>;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+
+class <?php echo $class_name ?> extends AbstractAuthenticator
+{
+    public function supports(Request $request): ?bool
+    {
+        // TODO: Implement supports() method.
+    }
+
+    public function authenticate(Request $request): PassportInterface
+    {
+        // TODO: Implement authenticate() method.
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        // TODO: Implement onAuthenticationSuccess() method.
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        // TODO: Implement onAuthenticationFailure() method.
+    }
+
+//    public function start(Request $request, AuthenticationException $authException = null): Response
+//    {
+//        /*
+//         * If you would like this class to control what happens when an anonymous user accesses a
+//         * protected page (e.g. redirect to /login), uncomment this method and make this class
+//         * implement Symfony\Component\Security\Http\EntryPoint\AuthenticationEntrypointInterface.
+//         *
+//         * For more details, see https://symfony.com/doc/current/security/experimental_authenticators.html#configuring-the-authentication-entry-point
+//         */
+//    }
+}

--- a/src/Resources/skeleton/authenticator/Security52LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/Security52LoginFormAuthenticator.tpl.php
@@ -1,0 +1,62 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+class <?= $class_name; ?> extends AbstractLoginFormAuthenticator
+{
+    use TargetPathTrait;
+
+    public const LOGIN_ROUTE = 'app_login';
+
+    private <?= $use_typed_properties ? 'UrlGeneratorInterface ' : null ?>$urlGenerator;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function authenticate(Request $request): PassportInterface
+    {
+        $<?= $username_field_var ?> = $request->request->get('<?= $username_field ?>', '');
+
+        $request->getSession()->set(Security::LAST_USERNAME, $<?= $username_field_var ?>);
+
+        return new Passport(
+            new UserBadge($<?= $username_field_var ?>),
+            new PasswordCredentials($request->request->get('password', '')),
+            [
+                new CsrfTokenBadge('authenticate', $request->get('_csrf_token')),
+            ]
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        if ($targetPath = $this->getTargetPath($request->getSession(), $firewallName)) {
+            return new RedirectResponse($targetPath);
+        }
+
+        // For example:
+        //return new RedirectResponse($this->urlGenerator->generate('some_route'));
+        throw new \Exception('TODO: provide a valid redirect inside '.__FILE__);
+    }
+
+    protected function getLoginUrl(Request $request): string
+    {
+        return $this->urlGenerator->generate(self::LOGIN_ROUTE);
+    }
+}

--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -12,9 +12,13 @@
 namespace Symfony\Bundle\MakerBundle\Security;
 
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
+use Symfony\Component\HttpKernel\Log\Logger;
 use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 
 /**
+ * @author Ryan Weaver   <ryan@symfonycasts.com>
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
  * @internal
  */
 final class SecurityConfigUpdater
@@ -22,12 +26,24 @@ final class SecurityConfigUpdater
     /** @var YamlSourceManipulator */
     private $manipulator;
 
+    /** @var Logger|null */
+    private $ysmLogger;
+
+    public function __construct(Logger $ysmLogger = null)
+    {
+        $this->ysmLogger = $ysmLogger;
+    }
+
     /**
      * Updates security.yaml contents based on a new User class.
      */
     public function updateForUserClass(string $yamlSource, UserClassConfiguration $userConfig, string $userClass): string
     {
         $this->manipulator = new YamlSourceManipulator($yamlSource);
+
+        if (null !== $this->ysmLogger) {
+            $this->manipulator->setLogger($this->ysmLogger);
+        }
 
         $this->normalizeSecurityYamlFile();
 
@@ -43,9 +59,13 @@ final class SecurityConfigUpdater
         return $contents;
     }
 
-    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass, bool $logoutSetup): string
+    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass, bool $logoutSetup, bool $useSecurity52): string
     {
         $this->manipulator = new YamlSourceManipulator($yamlSource);
+
+        if (null !== $this->ysmLogger) {
+            $this->manipulator->setLogger($this->ysmLogger);
+        }
 
         $this->normalizeSecurityYamlFile();
 
@@ -56,23 +76,50 @@ final class SecurityConfigUpdater
         }
 
         if (!isset($newData['security']['firewalls'][$firewallName])) {
-            $newData['security']['firewalls'][$firewallName] = ['anonymous' => true];
+            if ($useSecurity52) {
+                $newData['security']['firewalls'][$firewallName] = ['lazy' => true];
+            } else {
+                $newData['security']['firewalls'][$firewallName] = ['anonymous' => 'lazy'];
+            }
         }
 
         $firewall = $newData['security']['firewalls'][$firewallName];
 
-        if (!isset($firewall['guard'])) {
-            $firewall['guard'] = [];
-        }
+        if ($useSecurity52) {
+            if (isset($firewall['custom_authenticator'])) {
+                if (\is_array($firewall['custom_authenticator'])) {
+                    $firewall['custom_authenticator'][] = $authenticatorClass;
+                } else {
+                    $stringValue = $firewall['custom_authenticator'];
+                    $firewall['custom_authenticator'] = [];
+                    $firewall['custom_authenticator'][] = $stringValue;
+                    $firewall['custom_authenticator'][] = $authenticatorClass;
+                }
+            } else {
+                $firewall['custom_authenticator'] = $authenticatorClass;
+            }
 
-        if (!isset($firewall['guard']['authenticators'])) {
-            $firewall['guard']['authenticators'] = [];
-        }
+            if (!isset($firewall['entry_point']) && $chosenEntryPoint) {
+                $firewall['entry_point_empty_line'] = $this->manipulator->createEmptyLine();
+                $firewall['entry_point_comment'] = $this->manipulator->createCommentLine(
+                    ' the entry_point start() method determines what happens when an anonymous user accesses a protected page'
+                );
+                $firewall['entry_point'] = $authenticatorClass;
+            }
+        } else {
+            if (!isset($firewall['guard'])) {
+                $firewall['guard'] = [];
+            }
 
-        $firewall['guard']['authenticators'][] = $authenticatorClass;
+            if (!isset($firewall['guard']['authenticators'])) {
+                $firewall['guard']['authenticators'] = [];
+            }
 
-        if (\count($firewall['guard']['authenticators']) > 1) {
-            $firewall['guard']['entry_point'] = $chosenEntryPoint ?? current($firewall['guard']['authenticators']);
+            $firewall['guard']['authenticators'][] = $authenticatorClass;
+
+            if (\count($firewall['guard']['authenticators']) > 1) {
+                $firewall['guard']['entry_point'] = $chosenEntryPoint ?? current($firewall['guard']['authenticators']);
+            }
         }
 
         if (!isset($firewall['logout']) && $logoutSetup) {
@@ -86,10 +133,10 @@ final class SecurityConfigUpdater
         }
 
         $newData['security']['firewalls'][$firewallName] = $firewall;
-        $this->manipulator->setData($newData);
-        $contents = $this->manipulator->getContents();
 
-        return $contents;
+        $this->manipulator->setData($newData);
+
+        return $this->manipulator->getContents();
     }
 
     private function normalizeSecurityYamlFile()

--- a/src/Util/PhpCompatUtil.php
+++ b/src/Util/PhpCompatUtil.php
@@ -36,6 +36,13 @@ class PhpCompatUtil
         return version_compare($version, '8alpha', '>=') && Kernel::VERSION_ID >= 50200;
     }
 
+    public function canUseTypedProperties(): bool
+    {
+        $version = $this->getPhpVersion();
+
+        return version_compare($version, '7.4', '>=');
+    }
+
     protected function getPhpVersion(): string
     {
         $rootDirectory = $this->fileManager->getRootDirectory();

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -231,6 +231,13 @@ class YamlSourceManipulator
             $this->advanceBeyondMultilineArrayLastItem($currentData, $newData);
         }
 
+        if (0 === $this->indentationForDepths[$this->depth] && $this->depth > 1) {
+            $ident = $this->getPreferredIndentationSize();
+            $previousDepth = $this->depth - 1;
+
+            $this->indentationForDepths[$this->depth] = ($ident + $this->indentationForDepths[$previousDepth]);
+        }
+
         while (\count($currentData) < \count($newData)) {
             $newKey = array_keys($newData)[\count($currentData)];
 
@@ -471,9 +478,8 @@ class YamlSourceManipulator
             // we're converting from a scalar to a (multiline) array
             // this means we need to break onto the next line
 
-            // increase the indentation
-            $this->manuallyIncrementIndentation();
-            $newYamlValue = "\n".$this->indentMultilineYamlArray($newYamlValue);
+            // increase(override) the indentation
+            $newYamlValue = "\n".$this->indentMultilineYamlArray($newYamlValue, ($this->indentationForDepths[$this->depth] + $this->getPreferredIndentationSize()));
         } elseif ($this->isCurrentArrayMultiline() && $this->isCurrentArraySequence()) {
             // we are a multi-line sequence, so drop to next line, indent and add "- " in front
             $newYamlValue = "\n".$this->indentMultilineYamlArray('- '.$newYamlValue);
@@ -948,9 +954,11 @@ class YamlSourceManipulator
         --$this->depth;
     }
 
-    private function getCurrentIndentation(): string
+    private function getCurrentIndentation(int $override = null): string
     {
-        return str_repeat(' ', $this->indentationForDepths[$this->depth]);
+        $indent = $override ?? $this->indentationForDepths[$this->depth];
+
+        return str_repeat(' ', $indent);
     }
 
     private function log(string $message, $includeContent = false)
@@ -1295,19 +1303,21 @@ class YamlSourceManipulator
      * Usually an empty line needs to be prepended to this result before
      * adding to the content.
      */
-    private function indentMultilineYamlArray(string $yaml): string
+    private function indentMultilineYamlArray(string $yaml, int $indentOverride = null): string
     {
+        $indent = $this->getCurrentIndentation($indentOverride);
+
         // But, if the *value* is an array, then ITS children will
         // also need to be indented artificially by the same amount
-        $yaml = str_replace("\n", "\n".$this->getCurrentIndentation(), $yaml);
+        $yaml = str_replace("\n", "\n".$indent, $yaml);
 
         if ($this->isMultilineString($yaml)) {
             // Remove extra indentation in case of blank line in multiline string
-            $yaml = str_replace("\n".$this->getCurrentIndentation()."\n", "\n\n", $yaml);
+            $yaml = str_replace("\n".$indent."\n", "\n\n", $yaml);
         }
 
         // now indent this level
-        return $this->getCurrentIndentation().$yaml;
+        return $indent.$yaml;
     }
 
     private function findPositionOfMultilineCharInLine(int $position): ?int

--- a/tests/Maker/MakeAuthenticatorTest.php
+++ b/tests/Maker/MakeAuthenticatorTest.php
@@ -305,5 +305,71 @@ class MakeAuthenticatorTest extends MakerTestCase
                     }
                 ),
         ];
+
+        yield 'security_52_empty_authenticator' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeAuthenticator::class),
+                [
+                    // authenticator type => empty-auth
+                    0,
+                    // authenticator class name
+                    'AppCustomAuthenticator',
+                ]
+            )
+                ->setRequiredPhpVersion(70200)
+                ->addRequiredPackageVersion('symfony/security-bundle', '>=5.2')
+                ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorSecurity52Empty')
+                ->assert(
+                    function (string $output, string $directory) {
+                        $this->assertStringContainsString('Success', $output);
+
+                        $fs = new Filesystem();
+                        $this->assertTrue($fs->exists(sprintf('%s/src/Security/AppCustomAuthenticator.php', $directory)));
+
+                        $securityConfig = Yaml::parse(file_get_contents(sprintf('%s/config/packages/security.yaml', $directory)));
+
+                        $this->assertEquals(
+                            'App\\Security\\AppCustomAuthenticator',
+                            $securityConfig['security']['firewalls']['main']['custom_authenticator']
+                        );
+                    }
+                ),
+        ];
+
+        yield 'security_52_login_form_authenticator' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeAuthenticator::class),
+                [
+                    // authenticator type => login-form
+                    1,
+                    // class name
+                    'AppTestSecurity52LoginFormAuthenticator',
+                    // controller name
+                    'SecurityController',
+                    // User selector field
+                    'userEmail',
+                    // Logout Url
+                    'no',
+                ]
+            )
+                ->setRequiredPhpVersion(70200)
+                ->addRequiredPackageVersion('symfony/security-bundle', '>=5.2')
+                ->addExtraDependencies('doctrine')
+                ->addExtraDependencies('twig')
+                ->addExtraDependencies('symfony/form')
+                ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeAuthenticatorSecurity52LoginForm')
+                ->configureDatabase()
+                ->updateSchemaAfterCommand()
+                ->assert(
+                    function (string $output, string $directory) {
+                        $this->assertStringContainsString('Success', $output);
+
+                        $fs = new Filesystem();
+                        $this->assertTrue($fs->exists(sprintf('%s/src/Controller/SecurityController.php', $directory)));
+                        $this->assertTrue($fs->exists(sprintf('%s/templates/security/login.html.twig', $directory)));
+                        $this->assertTrue($fs->exists(sprintf('%s/src/Security/AppTestSecurity52LoginFormAuthenticator.php', $directory)));
+                    }
+                ),
+        ];
     }
 }

--- a/tests/Security/yaml_fixtures/expected_authenticator/empty_source.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/empty_source.yaml
@@ -1,6 +1,6 @@
 security:
     firewalls:
         main:
-            anonymous: true
+            anonymous: lazy
             guard:
                 authenticators: [App\Security\AppCustomAuthenticator]

--- a/tests/Security/yaml_fixtures/expected_authenticator/security_52_empty_source.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/security_52_empty_source.yaml
@@ -1,0 +1,6 @@
+security:
+    enable_authenticator_manager: true
+    firewalls:
+        main:
+            lazy: true
+            custom_authenticator: App\Security\AppCustomAuthenticator

--- a/tests/Security/yaml_fixtures/expected_authenticator/security_52_with_firewalls_and_logout.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/security_52_with_firewalls_and_logout.yaml
@@ -1,4 +1,5 @@
 security:
+    enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         in_memory: { memory: ~ }
@@ -8,10 +9,11 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: lazy
-            guard:
-                authenticators:
-                    - App\Security\AppCustomAuthenticator
+            lazy: true
+            custom_authenticator: App\Security\AppCustomAuthenticator
+
+            # the entry_point start() method determines what happens when an anonymous user accesses a protected page
+            entry_point: App\Security\AppCustomAuthenticator
             logout:
                 path: app_logout
                 # where to redirect after logout

--- a/tests/Security/yaml_fixtures/expected_authenticator/security_52_with_multiple_authenticators.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/security_52_with_multiple_authenticators.yaml
@@ -1,0 +1,11 @@
+security:
+    enable_authenticator_manager: true
+    firewalls:
+        main:
+            lazy: true
+            custom_authenticator:
+                - App\Security\SomeOtherAuthenticator
+                - App\Security\AppCustomAuthenticator
+
+            # the entry_point start() method determines what happens when an anonymous user accesses a protected page
+            entry_point: App\Security\AppCustomAuthenticator

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_source.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_source.yaml
@@ -6,7 +6,7 @@ security:
     firewalls:
         dev: ~
         main:
-            anonymous: true
+            anonymous: lazy
             guard:
                 authenticators:
                     - App\Security\AppCustomAuthenticator

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls.yaml
@@ -8,7 +8,7 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: true
+            anonymous: lazy
             guard:
                 authenticators:
                     - App\Security\AppCustomAuthenticator

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_authenticator.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_authenticator.yaml
@@ -8,11 +8,11 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: true
+            anonymous: lazy
             guard:
                 authenticators:
                     - App\Security\Authenticator
                     - App\Security\AppCustomAuthenticator
                 entry_point: App\Security\AppCustomAuthenticator
         foo:
-            anonymous: true
+            anonymous: lazy

--- a/tests/Security/yaml_fixtures/expected_user_class/simple_security_with_single_memory_provider_configured.yaml
+++ b/tests/Security/yaml_fixtures/expected_user_class/simple_security_with_single_memory_provider_configured.yaml
@@ -14,5 +14,5 @@ security:
     firewalls:
         dev: ~
         main:
-            anonymous: true
+            anonymous: lazy
             provider: app_user_provider

--- a/tests/Security/yaml_fixtures/source/security_52_empty_security.yaml
+++ b/tests/Security/yaml_fixtures/source/security_52_empty_security.yaml
@@ -1,0 +1,2 @@
+security:
+    enable_authenticator_manager: true

--- a/tests/Security/yaml_fixtures/source/security_52_with_firewalls_and_logout.yaml
+++ b/tests/Security/yaml_fixtures/source/security_52_with_firewalls_and_logout.yaml
@@ -1,4 +1,5 @@
 security:
+    enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         in_memory: { memory: ~ }
@@ -8,9 +9,4 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: lazy
-            guard:
-                authenticators:
-                    - App\Security\Authenticator
-        foo:
-            anonymous: lazy
+            lazy: true

--- a/tests/Security/yaml_fixtures/source/security_52_with_multiple_authenticators.yaml
+++ b/tests/Security/yaml_fixtures/source/security_52_with_multiple_authenticators.yaml
@@ -1,0 +1,6 @@
+security:
+    enable_authenticator_manager: true
+    firewalls:
+        main:
+            lazy: true
+            custom_authenticator: App\Security\SomeOtherAuthenticator

--- a/tests/Security/yaml_fixtures/source/simple_security_with_firewalls.yaml
+++ b/tests/Security/yaml_fixtures/source/simple_security_with_firewalls.yaml
@@ -8,4 +8,4 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: true
+            anonymous: lazy

--- a/tests/Security/yaml_fixtures/source/simple_security_with_firewalls_and_logout.yaml
+++ b/tests/Security/yaml_fixtures/source/simple_security_with_firewalls_and_logout.yaml
@@ -8,4 +8,4 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            anonymous: true
+            anonymous: lazy

--- a/tests/Security/yaml_fixtures/source/simple_security_with_single_memory_provider_configured.yaml
+++ b/tests/Security/yaml_fixtures/source/simple_security_with_single_memory_provider_configured.yaml
@@ -6,5 +6,5 @@ security:
     firewalls:
         dev: ~
         main:
-            anonymous: true
+            anonymous: lazy
             provider: in_memory

--- a/tests/Util/YamlSourceManipulatorTest.php
+++ b/tests/Util/YamlSourceManipulatorTest.php
@@ -59,7 +59,7 @@ class YamlSourceManipulatorTest extends TestCase
             list($source, $changeCode, $expected) = explode('===', $file->getContents());
 
             // Multiline string ends with an \n
-            $source = rtrim($source, "\n");
+            $source = substr_replace($source, '', (\strlen($source) - 1));
             $expected = ltrim($expected, "\n");
 
             $data = Yaml::parse($source);

--- a/tests/Util/yaml_fixtures/complex_string_to_array.test
+++ b/tests/Util/yaml_fixtures/complex_string_to_array.test
@@ -1,0 +1,14 @@
+main:
+    custom_authenticator: App\Security\SomeOtherAuthenticator
+===
+$string = $data['main']['custom_authenticator'];
+$data['main']['custom_authenticator'] = [];
+$data['main']['custom_authenticator'][] = $string;
+$data['main']['custom_authenticator'][] = 'App\Security\AppCustomAuthenticator';
+$data['main']['entry_point'] = 'Entry';
+===
+main:
+    custom_authenticator:
+        - App\Security\SomeOtherAuthenticator
+        - App\Security\AppCustomAuthenticator
+    entry_point: Entry

--- a/tests/Util/yaml_fixtures/string_to_array.test
+++ b/tests/Util/yaml_fixtures/string_to_array.test
@@ -1,0 +1,18 @@
+security:
+    firewalls:
+        main:
+            lazy: true
+            custom_authenticator: App\Security\SomeOtherAuthenticator
+===
+$string = $data['security']['firewalls']['main']['custom_authenticator'];
+$data['security']['firewalls']['main']['custom_authenticator'] = [];
+$data['security']['firewalls']['main']['custom_authenticator'][] = $string;
+$data['security']['firewalls']['main']['custom_authenticator'][] = 'App\Security\AppCustomAuthenticator';
+===
+security:
+    firewalls:
+        main:
+            lazy: true
+            custom_authenticator:
+                - App\Security\SomeOtherAuthenticator
+                - App\Security\AppCustomAuthenticator

--- a/tests/Util/yaml_fixtures/string_to_array_with_eof_blank_line.test
+++ b/tests/Util/yaml_fixtures/string_to_array_with_eof_blank_line.test
@@ -1,0 +1,21 @@
+security:
+    firewalls:
+        main:
+            custom_authenticator: App\Security\SomeOtherAuthenticator
+
+
+
+===
+$string = $data['security']['firewalls']['main']['custom_authenticator'];
+$data['security']['firewalls']['main']['custom_authenticator'] = [];
+$data['security']['firewalls']['main']['custom_authenticator'][] = $string;
+$data['security']['firewalls']['main']['custom_authenticator'][] = 'App\Security\AppCustomAuthenticator';
+===
+security:
+    firewalls:
+        main:
+            custom_authenticator:
+                - App\Security\SomeOtherAuthenticator
+                - App\Security\AppCustomAuthenticator
+
+

--- a/tests/fixtures/MakeAuthenticatorSecurity52Empty/config/packages/security.yaml
+++ b/tests/fixtures/MakeAuthenticatorSecurity52Empty/config/packages/security.yaml
@@ -1,0 +1,25 @@
+security:
+    enable_authenticator_manager: true
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            lazy: true
+
+            # activate different ways to authenticate
+
+            # http_basic: true
+            # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate
+
+            # form_login: true
+            # https://symfony.com/doc/current/security/form_login_setup.html
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+    # - { path: ^/admin, roles: ROLE_ADMIN }
+    # - { path: ^/profile, roles: ROLE_USER }

--- a/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/config/packages/security.yaml
+++ b/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/config/packages/security.yaml
@@ -1,0 +1,34 @@
+security:
+    encoders:
+        App\Entity\User: plaintext
+
+    enable_authenticator_manager: true
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        # used to reload user from session & other features (e.g. switch_user)
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: userEmail
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+
+            lazy: true
+            # activate different ways to authenticate
+
+            # http_basic: true
+            # https://symfony.com/doc/current/security.html#a-configuring-how-your-users-will-authenticate
+
+            # form_login: true
+            # https://symfony.com/doc/current/security/form_login_setup.html
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
+    access_control:
+    # - { path: ^/admin, roles: ROLE_ADMIN }
+    # - { path: ^/profile, roles: ROLE_USER }

--- a/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/src/Entity/User.php
+++ b/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/src/Entity/User.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @ORM\Entity()
+ */
+class User implements UserInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=180, unique=true)
+     */
+    private $userEmail;
+
+    /**
+     * @ORM\Column(type="array")
+     */
+    private $roles = [];
+
+    /**
+     * @var string The hashed password
+     * @ORM\Column(type="string")
+     */
+    private $password;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getUserEmail()
+    {
+        return $this->userEmail;
+    }
+
+    public function setUserEmail(string $userEmail): self
+    {
+        $this->userEmail = $userEmail;
+
+        return $this;
+    }
+
+    /**
+     * A visual identifier that represents this user.
+     *
+     * @see UserInterface
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->userEmail;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        // guarantee every user at least has ROLE_USER
+        $roles[] = 'ROLE_USER';
+
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getPassword(): string
+    {
+        return (string) $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getSalt()
+    {
+        // not needed when using the "bcrypt" algorithm in security.yaml
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function eraseCredentials()
+    {
+        // If you store any temporary, sensitive data on the user, clear it here
+        // $this->plainPassword = null;
+    }
+}

--- a/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/src/Repository/UserRepository.php
+++ b/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/src/Repository/UserRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @method User|null find($id, $lockMode = null, $lockVersion = null)
+ * @method User|null findOneBy(array $criteria, array $orderBy = null)
+ * @method User[]    findAll()
+ * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+
+    /**
+     * Used to upgrade (rehash) the user's password automatically over time.
+     */
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    {
+        if (!$user instanceof User) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
+        }
+
+        $user->setPassword($newEncodedPassword);
+        $this->_em->persist($user);
+        $this->_em->flush();
+    }
+}

--- a/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/tests/SecurityControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\User;
+use App\Security\AppTestSecurity52LoginFormAuthenticator;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ */
+class SecurityControllerTest extends WebTestCase
+{
+    public function testGeneratedAuthenticatorHasExpectedConstructorArgs(): void
+    {
+        $authenticatorReflection = new \ReflectionClass(AppTestSecurity52LoginFormAuthenticator::class);
+        $constructorParameters = $authenticatorReflection->getConstructor()->getParameters();
+
+        self::assertSame(UrlGeneratorInterface::class, $constructorParameters[0]->getType()->getName());
+        self::assertSame('urlGenerator', $constructorParameters[0]->getName());
+    }
+
+    public function testLoginFormAuthenticatorUsingSecurity51(): void
+    {
+        $client = self::createClient();
+        $crawler = $client->request('GET', '/login');
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        /** @var EntityManagerInterface $em */
+        $em = self::$kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $user = (new User())->setUserEmail('test@symfony.com')
+            ->setPassword('password');
+        $em->persist($user);
+        $em->flush();
+
+        $form = $crawler->filter('form')->form();
+        $form->setValues(
+            [
+                'userEmail' => 'test@symfony.com',
+                'password' => 'foo',
+            ]
+        );
+        $crawler = $client->submit($form);
+
+        if (500 === $client->getResponse()->getStatusCode()) {
+            self::assertEquals('', $crawler->filter('h1.exception-message')->text());
+        }
+
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
+
+        $client->followRedirect();
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertStringContainsString('Invalid credentials.', $client->getResponse()->getContent());
+
+        $form->setValues(
+            [
+                'userEmail' => 'test@symfony.com',
+                'password' => 'password',
+            ]
+        );
+        $client->submit($form);
+
+        self::assertStringContainsString('TODO: provide a valid redirect', $client->getResponse()->getContent());
+        self::assertNotNull($token = $client->getContainer()->get('security.token_storage')->getToken());
+        self::assertInstanceOf(User::class, $token->getUser());
+    }
+}


### PR DESCRIPTION
Hello Security51! Allows `make:auth` to take advantage of the new security features that were introduced. Starting in Symfony `5.2` when you run `make:auth` MakerBundle will automatically check if you have set:
```
security:
    enable_authenticator_manager: true
```
If so, MakerBundle will generate the required classes to authenticate users leveraging the new Authenticators.

A positive side effect of this PR, all templates can check `$use_typed_properties` to determine if the host is capable of utilizing typed properties that were introduced in PHP 7.4.

e.g. - 

```
private <?= $use_typed_properties ? 'UrlGeneratorInterface ' : null ?>$urlGenerator;
```

Internally, we've added the `PhpCompatUtil::canUseTypedProperties()` method that is called anytime a Maker needs to generate a twig template. We then inject `$use_typed_properties` into all templates so the developer can add typed properties to a generated template without having to worry about a bunch of behind the scenes logic.
