### PR TITLE
Update MakerFileLinkFormatter.php

### DIFF
--- a/src/Util/MakerFileLinkFormatter.php
+++ b/src/Util/MakerFileLinkFormatter.php
@@ -47,7 +47,6 @@ final class MakerFileLinkFormatter
         }
 
         $outputFormatterStyle = new OutputFormatterStyle();
-        $outputFormatterStyle->setHref($formatted);
 
         return $outputFormatterStyle->apply($relativePath);
     }

--- a/src/Util/MakerFileLinkFormatter.php
+++ b/src/Util/MakerFileLinkFormatter.php
@@ -47,6 +47,10 @@ final class MakerFileLinkFormatter
         }
 
         $outputFormatterStyle = new OutputFormatterStyle();
+        
+        if (method_exists(OutputFormatterStyle::class, 'setHref')) {
+            $outputFormatterStyle->setHref($formatted);
+        }
 
         return $outputFormatterStyle->apply($relativePath);
     }


### PR DESCRIPTION
I checked https://github.com/symfony/console/tree/3.4 
The Method does not exist in any Version of "symfony/console". Why is it calling here?
$outputFormatterStyle->setHref($formatted);

Maybe not nesseary?