### PR TITLE
Allow released versions of the deprecation contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-        "symfony/deprecation-contracts": "^2.3",
+        "symfony/deprecation-contracts": "^2.2",
         "symfony/filesystem": "^3.4|^4.0|^5.0",
         "symfony/finder": "^3.4|^4.0|^5.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
This ensures that the package can be installed with `stable` as minimum stability.