### PR TITLE
lower symfony/contracts dependency version a tad bit more

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-        "symfony/deprecation-contracts": "^2.2",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/filesystem": "^3.4|^4.0|^5.0",
         "symfony/finder": "^3.4|^4.0|^5.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
PR #728 introduced `symfony/deprecations-contracts` at version `^2.3` which prevented some users from using maker bundle.

PR #746 fixed the reported issue by lowering the version constraint to `^2.2`. But in reality we can lower it even further to `2.1` as
this is when `symfony/deprecation-contracts` was introduced.