### PR TITLE
fix indentation when adding new key after multiline array

### DIFF
--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -1184,7 +1184,7 @@ class YamlSourceManipulator
             return;
         }
 
-        $this->indentationForDepths[$this->depth] = $this->getPreferredIndentationSize() - $guessedIndentationSize;
+        $this->indentationForDepths[$this->depth] = $this->indentationForDepths[$this->depth] - $guessedIndentationSize;
     }
 
     private function isEOF(int $position = null)

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -474,6 +474,7 @@ class YamlSourceManipulator
             // increase the indentation
             $this->manuallyIncrementIndentation();
             $newYamlValue = "\n".$this->indentMultilineYamlArray($newYamlValue);
+            $this->indentationForDepths[$this->depth] -= 4;
         } elseif ($this->isCurrentArrayMultiline() && $this->isCurrentArraySequence()) {
             // we are a multi-line sequence, so drop to next line, indent and add "- " in front
             $newYamlValue = "\n".$this->indentMultilineYamlArray('- '.$newYamlValue);

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -474,7 +474,7 @@ class YamlSourceManipulator
             // increase the indentation
             $this->manuallyIncrementIndentation();
             $newYamlValue = "\n".$this->indentMultilineYamlArray($newYamlValue);
-            $this->indentationForDepths[$this->depth] -= 4;
+            $this->manuallyDecrementIndentation();
         } elseif ($this->isCurrentArrayMultiline() && $this->isCurrentArraySequence()) {
             // we are a multi-line sequence, so drop to next line, indent and add "- " in front
             $newYamlValue = "\n".$this->indentMultilineYamlArray('- '.$newYamlValue);
@@ -1172,6 +1172,19 @@ class YamlSourceManipulator
     private function manuallyIncrementIndentation()
     {
         $this->indentationForDepths[$this->depth] = $this->indentationForDepths[$this->depth] + $this->getPreferredIndentationSize();
+    }
+
+    private function manuallyDecrementIndentation(): void
+    {
+        $guessedIndentationSize = $this->getPreferredIndentationSize();
+
+        if ($this->indentationForDepths[$this->depth] === $guessedIndentationSize) {
+            $this->indentationForDepths[$this->depth] -= 4;
+
+            return;
+        }
+
+        $this->indentationForDepths[$this->depth] = $this->getPreferredIndentationSize() - $guessedIndentationSize;
     }
 
     private function isEOF(int $position = null)

--- a/tests/Util/yaml_fixtures/complex_string_to_array.test
+++ b/tests/Util/yaml_fixtures/complex_string_to_array.test
@@ -1,0 +1,14 @@
+main:
+    custom_authenticator: App\Security\SomeOtherAuthenticator
+===
+$string = $data['main']['custom_authenticator'];
+$data['main']['custom_authenticator'] = [];
+$data['main']['custom_authenticator'][] = $string;
+$data['main']['custom_authenticator'][] = 'App\Security\AppCustomAuthenticator';
+$data['main']['entry_point'] = 'Entry';
+===
+main:
+    custom_authenticator:
+        - App\Security\SomeOtherAuthenticator
+        - App\Security\AppCustomAuthenticator
+    entry_point: Entry

--- a/tests/Util/yaml_fixtures/string_to_array.test
+++ b/tests/Util/yaml_fixtures/string_to_array.test
@@ -1,0 +1,18 @@
+security:
+    firewalls:
+        main:
+            lazy: true
+            custom_authenticator: App\Security\SomeOtherAuthenticator
+===
+$string = $data['security']['firewalls']['main']['custom_authenticator'];
+$data['security']['firewalls']['main']['custom_authenticator'] = [];
+$data['security']['firewalls']['main']['custom_authenticator'][] = $string;
+$data['security']['firewalls']['main']['custom_authenticator'][] = 'App\Security\AppCustomAuthenticator';
+===
+security:
+    firewalls:
+        main:
+            lazy: true
+            custom_authenticator:
+                - App\Security\SomeOtherAuthenticator
+                - App\Security\AppCustomAuthenticator


### PR DESCRIPTION
YSM does not decrease the indentation after adding a multi line array. This PR fixes that by removing the manual indentation that is added for the additional lines in the multi line array - after the multi line array values are created.