### PR TITLE
fix(make:entity): handle new value if nullable in OneToOne association, close #195

### DIFF
--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
@@ -51,13 +51,17 @@ class User
 
     public function setUserProfile(?UserProfile $userProfile): self
     {
-        $this->userProfile = $userProfile;
-
-        // set (or unset) the owning side of the relation if necessary
-        $newUser = null === $userProfile ? null : $this;
-        if ($userProfile->getUser() !== $newUser) {
-            $userProfile->setUser($newUser);
+        // unset the owning side of the relation if necessary
+        if ($userProfile === null && $this->userProfile !== null) {
+            $this->userProfile->setUser(null);
         }
+
+        // set the owning side of the relation if necessary
+        if ($userProfile !== null && $userProfile->getUser() !== $this) {
+            $userProfile->setUser($this);
+        }
+
+        $this->userProfile = $userProfile;
 
         return $this;
     }

--- a/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse.php
@@ -33,13 +33,17 @@ class UserProfile
 
     public function setUser(?User $user): self
     {
-        $this->user = $user;
-
-        // set (or unset) the owning side of the relation if necessary
-        $newUserProfile = null === $user ? null : $this;
-        if ($user->getUserProfile() !== $newUserProfile) {
-            $user->setUserProfile($newUserProfile);
+        // unset the owning side of the relation if necessary
+        if ($user === null && $this->user !== null) {
+            $this->user->setUserProfile(null);
         }
+
+        // set the owning side of the relation if necessary
+        if ($user !== null && $user->getUserProfile() !== $this) {
+            $user->setUserProfile($this);
+        }
+
+        $this->user = $user;
 
         return $this;
     }

--- a/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse_not_nullable.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse_not_nullable.php
@@ -33,12 +33,12 @@ class UserProfile
 
     public function setUser(User $user): self
     {
-        $this->user = $user;
-
         // set the owning side of the relation if necessary
         if ($user->getUserProfile() !== $this) {
             $user->setUserProfile($this);
         }
+
+        $this->user = $user;
 
         return $this;
     }


### PR DESCRIPTION
Hi :wave: 

This PR is a proposal for #195 for handling the new value (if nullable) in a OneToOne association.

The following code was not valid, it fails at `$user->getUserProfile()` if we call `UserProfile#setUser(null)`:
```php
class UserProfile
{
    // ...
    public function setUser(?User $user): self
    {
        $this->user = $user;

        // set (or unset) the owning side of the relation if necessary
        $newUserProfile = null === $user ? null : $this;
        if ($user->getUserProfile() !== $newUserProfile) {
            $user->setUserProfile($newUserProfile);
        }

        return $this;
    }
}
```

The following code takes care of:
- unset the user profile of the previous User (`$this->user`) if we assign a nullable User
- set the profile to the new user, and prevent an infinite loop with `user->getUserProfile() !== $this`
```php
class UserProfile 
{
    public function setUser(?User $user): self
    {
        // unset the owning side of the relation if necessary
        if ($user === null && $this->user !== null) {
            $this->user->setUserProfile(null);
        }

        // set the owning side of the relation if necessary
        if ($user !== null && $user->getUserProfile() !== $this) {
            $user->setUserProfile($this);
        }

        $this->user = $user;

        return $this;
    }
}
```

WDYT? Thanks! 