### PR TITLE
reinstate doctrine/inflector v2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.1.3",
-        "doctrine/inflector": "^1.2",
+        "doctrine/inflector": "^1.2|^2.0",
         "nikic/php-parser": "^4.0",
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/console": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
due to incompatibilities with `doctrine/orm`, `doctrine/inflector` `v2` was dropped in #611. `orm` now supports inflector v2 as of https://github.com/doctrine/orm/pull/8147 which has been released.

closes #756 