### PR TITLE
fix invalid expiresAt values for ResetPassword & VerifyEmail templates

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -38,6 +38,7 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validation;
+use SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents;
 use SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle;
 
 /**
@@ -368,7 +369,15 @@ final class MakeRegistrationForm extends AbstractMaker
         $missing = false;
         $composerMessage = 'composer require';
 
-        if (!class_exists(SymfonyCastsVerifyEmailBundle::class)) {
+        // verify-email-bundle 1.1.1 includes support for translations and a fix for the bad expiration time bug.
+        // we need to check that if the bundle is installed, it is version 1.1.1 or greater
+        if (class_exists(SymfonyCastsVerifyEmailBundle::class)) {
+            $reflectedComponents = new \ReflectionClass(VerifyEmailSignatureComponents::class);
+
+            if (!$reflectedComponents->hasMethod('getExpirationMessageKey')) {
+                throw new RuntimeCommandException('Please upgrade symfonycasts/verify-email-bundle to version 1.1.1 or greater.');
+            }
+        } else {
             $missing = true;
             $composerMessage = sprintf('%s symfonycasts/verify-email-bundle', $composerMessage);
         }

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -35,6 +35,7 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Yaml\Yaml;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestTrait;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\Repository\ResetPasswordRequestRepositoryTrait;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 use SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle;
@@ -82,6 +83,16 @@ class MakeResetPassword extends AbstractMaker
         ORMDependencyBuilder::buildDependencies($dependencies);
 
         $dependencies->addClassDependency(Annotation::class, 'annotations');
+
+        // reset-password-bundle 1.2.1 includes support for translations and a fix for the bad expiration time bug.
+        // we need to check that version 1.2.1 is installed
+        if (class_exists(ResetPasswordToken::class)) {
+            $reflectedToken = new \ReflectionClass(ResetPasswordToken::class);
+
+            if (!$reflectedToken->hasMethod('getExpirationMessageKey')) {
+                throw new RuntimeCommandException('Please upgrade symfonycasts/reset-password-bundle to version 1.2.1 or greater.');
+            }
+        }
     }
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command)

--- a/src/Resources/skeleton/registration/twig_email.tpl.php
+++ b/src/Resources/skeleton/registration/twig_email.tpl.php
@@ -3,7 +3,7 @@
 <p>
     Please confirm your email address by clicking the following link: <br><br>
     <a href="{{ signedUrl|raw }}">Confirm my Email</a>.
-    This link will expire in {{ expiresAt|date('g') }} hour(s).
+    This link will expire in {{ expiresAtMessageKey|trans(expiresAtMessageData, 'VerifyEmailBundle') }}.
 </p>
 
 <p>

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -185,7 +185,6 @@ class <?= $class_name ?> extends AbstractController
             ->htmlTemplate('reset_password/email.html.twig')
             ->context([
                 'resetToken' => $resetToken,
-                'tokenLifetime' => $this->resetPasswordHelper->getTokenLifetime(),
             ])
         ;
 

--- a/src/Resources/skeleton/resetPassword/twig_email.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_email.tpl.php
@@ -4,6 +4,6 @@
 
 <a href="{{ url('app_reset_password', {token: resetToken.token}) }}">{{ url('app_reset_password', {token: resetToken.token}) }}</a>
 
-<p>This link will expire in {{ tokenLifetime|date('g') }} hour(s).</p>
+<p>This link will expire in {{ resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle') }}.</p>
 
 <p>Cheers!</p>

--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -33,7 +33,8 @@ class <?= $class_name; ?><?= "\n" ?>
 
         $context = $email->getContext();
         $context['signedUrl'] = $signatureComponents->getSignedUrl();
-        $context['expiresAt'] = $signatureComponents->getExpiresAt();
+        $context['expiresAtMessageKey'] = $signatureComponents->getExpirationMessageKey();
+        $context['expiresAtMessageData'] = $signatureComponents->getExpirationMessageData();
 
         $email->context($context);
 


### PR DESCRIPTION
Depends on:
- [x] https://github.com/SymfonyCasts/verify-email-bundle/pull/43
- [x] https://github.com/SymfonyCasts/reset-password-bundle/pull/135

closes #727 