### PR TITLE
feat: adding typing PHP 7.4

### DIFF
--- a/src/Doctrine/EntityRegenerator.php
+++ b/src/Doctrine/EntityRegenerator.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 
 /**
  * @internal
@@ -30,6 +31,7 @@ final class EntityRegenerator
     private $generator;
     private $entityClassGenerator;
     private $overwrite;
+    private $phpCompatUtil;
 
     public function __construct(DoctrineHelper $doctrineHelper, FileManager $fileManager, Generator $generator, EntityClassGenerator $entityClassGenerator, bool $overwrite)
     {
@@ -38,6 +40,7 @@ final class EntityRegenerator
         $this->generator = $generator;
         $this->entityClassGenerator = $entityClassGenerator;
         $this->overwrite = $overwrite;
+        $this->phpCompatUtil = new PhpCompatUtil($fileManager);
     }
 
     public function regenerateEntities(string $classOrNamespace)
@@ -201,6 +204,7 @@ final class EntityRegenerator
     {
         return new ClassSourceManipulator(
             $this->fileManager->getFileContents($classPath),
+            $this->phpCompatUtil,
             $this->overwrite,
             // use annotations
             // if properties need to be generated then, by definition,

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
 use Symfony\Bundle\MakerBundle\Security\SecurityControllerBuilder;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
@@ -60,12 +61,15 @@ final class MakeAuthenticator extends AbstractMaker
 
     private $useSecurity52 = false;
 
+    private $phpCompatUtil;
+
     public function __construct(FileManager $fileManager, SecurityConfigUpdater $configUpdater, Generator $generator, DoctrineHelper $doctrineHelper)
     {
         $this->fileManager = $fileManager;
         $this->configUpdater = $configUpdater;
         $this->generator = $generator;
         $this->doctrineHelper = $doctrineHelper;
+        $this->phpCompatUtil = new PhpCompatUtil($fileManager);
     }
 
     public static function getCommandName(): string
@@ -315,7 +319,7 @@ final class MakeAuthenticator extends AbstractMaker
             throw new RuntimeCommandException(sprintf('Method "login" already exists on class %s', $controllerClassNameDetails->getFullName()));
         }
 
-        $manipulator = new ClassSourceManipulator($controllerSourceCode, true);
+        $manipulator = new ClassSourceManipulator($controllerSourceCode, $this->phpCompatUtil, true);
 
         $securityControllerBuilder = new SecurityControllerBuilder();
         $securityControllerBuilder->addLoginMethod($manipulator);

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -29,6 +29,7 @@ use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -46,6 +47,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 {
     private $fileManager;
     private $doctrineHelper;
+    private $phpCompatUtil;
     private $generator;
     private $entityClassGenerator;
 
@@ -53,6 +55,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
     {
         $this->fileManager = $fileManager;
         $this->doctrineHelper = $doctrineHelper;
+        $this->phpCompatUtil = new PhpCompatUtil($fileManager);
         // $projectDirectory is unused, argument kept for BC
 
         if (null === $generator) {
@@ -757,7 +760,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
     private function createClassManipulator(string $path, ConsoleStyle $io, bool $overwrite): ClassSourceManipulator
     {
-        $manipulator = new ClassSourceManipulator($this->fileManager->getFileContents($path), $overwrite);
+        $manipulator = new ClassSourceManipulator($this->fileManager->getFileContents($path), $this->phpCompatUtil, $overwrite);
         $manipulator->setIo($io);
 
         return $manipulator;

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -27,6 +27,7 @@ use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
@@ -58,12 +59,15 @@ final class MakeRegistrationForm extends AbstractMaker
 
     private $doctrineHelper;
 
+    private $phpCompatUtil;
+
     public function __construct(FileManager $fileManager, FormTypeRenderer $formTypeRenderer, RouterInterface $router, DoctrineHelper $doctrineHelper)
     {
         $this->fileManager = $fileManager;
         $this->formTypeRenderer = $formTypeRenderer;
         $this->router = $router;
         $this->doctrineHelper = $doctrineHelper;
+        $this->phpCompatUtil = new PhpCompatUtil($fileManager);
     }
 
     public static function getCommandName(): string
@@ -339,7 +343,8 @@ final class MakeRegistrationForm extends AbstractMaker
         if ($input->getOption('add-unique-entity-constraint')) {
             $classDetails = new ClassDetails($userClass);
             $userManipulator = new ClassSourceManipulator(
-                file_get_contents($classDetails->getPath())
+                file_get_contents($classDetails->getPath()),
+                $this->phpCompatUtil
             );
             $userManipulator->setIo($io);
 
@@ -356,7 +361,8 @@ final class MakeRegistrationForm extends AbstractMaker
         if ($input->getArgument('will-verify-email')) {
             $classDetails = new ClassDetails($userClass);
             $userManipulator = new ClassSourceManipulator(
-                file_get_contents($classDetails->getPath())
+                file_get_contents($classDetails->getPath()),
+                $this->phpCompatUtil
             );
             $userManipulator->setIo($io);
 

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -26,6 +26,7 @@ use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
@@ -54,6 +55,7 @@ class MakeResetPassword extends AbstractMaker
     private $fileManager;
     private $doctrineHelper;
     private $entityClassGenerator;
+    private $phpCompatUtil;
 
     private $fromEmailAddress;
     private $fromEmailName;
@@ -68,6 +70,7 @@ class MakeResetPassword extends AbstractMaker
         $this->fileManager = $fileManager;
         $this->doctrineHelper = $doctrineHelper;
         $this->entityClassGenerator = $entityClassGenerator;
+        $this->phpCompatUtil = new PhpCompatUtil($fileManager);
     }
 
     public static function getCommandName(): string
@@ -326,7 +329,8 @@ class MakeResetPassword extends AbstractMaker
         $generator->writeChanges();
 
         $manipulator = new ClassSourceManipulator(
-            $this->fileManager->getFileContents($requestEntityPath)
+            $this->fileManager->getFileContents($requestEntityPath),
+            $this->phpCompatUtil
         );
 
         $manipulator->addInterface(ResetPasswordRequestInterface::class);
@@ -369,7 +373,8 @@ CODE
         );
 
         $manipulator = new ClassSourceManipulator(
-            $this->fileManager->getFileContents($pathRequestRepository)
+            $this->fileManager->getFileContents($pathRequestRepository),
+            $this->phpCompatUtil
         );
 
         $manipulator->addInterface(ResetPasswordRequestRepositoryInterface::class);

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -24,6 +24,7 @@ use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
 use Symfony\Bundle\MakerBundle\Security\UserClassBuilder;
 use Symfony\Bundle\MakerBundle\Security\UserClassConfiguration;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
@@ -51,12 +52,15 @@ final class MakeUser extends AbstractMaker
 
     private $entityClassGenerator;
 
+    private $phpCompatUtil;
+
     public function __construct(FileManager $fileManager, UserClassBuilder $userClassBuilder, SecurityConfigUpdater $configUpdater, EntityClassGenerator $entityClassGenerator)
     {
         $this->fileManager = $fileManager;
         $this->userClassBuilder = $userClassBuilder;
         $this->configUpdater = $configUpdater;
         $this->entityClassGenerator = $entityClassGenerator;
+        $this->phpCompatUtil = new PhpCompatUtil($fileManager);
     }
 
     public static function getCommandName(): string
@@ -156,6 +160,7 @@ final class MakeUser extends AbstractMaker
         // B) Implement UserInterface
         $manipulator = new ClassSourceManipulator(
             $this->fileManager->getFileContents($classPath),
+            $this->phpCompatUtil,
             true
         );
         $manipulator->setIo($io);

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -26,9 +26,9 @@ class <?= $class_name; ?> extends AbstractFormLoginAuthenticator<?= $password_au
 
     public const LOGIN_ROUTE = 'app_login';
 
-<?= $user_is_entity ? "    private \$entityManager;\n" : null ?>
-    private $urlGenerator;
-    private $csrfTokenManager;
+<?= $user_is_entity ? "    private " . ($use_typed_properties ? "EntityManagerInterface " : null) ."\$entityManager;\n" : null ?>
+    private <?= $use_typed_properties ? "UrlGeneratorInterface " : null ?>$urlGenerator;
+    private <?= $use_typed_properties ? "CsrfTokenManagerInterface " : null ?>$csrfTokenManager;
 <?= $user_needs_encoder ? "    private \$passwordEncoder;\n" : null ?>
 
     public function __construct(<?= $user_is_entity ? 'EntityManagerInterface $entityManager, ' : null ?>UrlGeneratorInterface $urlGenerator, CsrfTokenManagerInterface $csrfTokenManager<?= $user_needs_encoder ? ', UserPasswordEncoderInterface $passwordEncoder' : null ?>)

--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -11,8 +11,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class <?= $class_name; ?> extends Command
 {
-    protected static $defaultName = '<?= $command_name; ?>';
-    protected static $defaultDescription = 'Add a short description for your command';
+    protected static <?= $use_typed_properties ? "string " : null ?>$defaultName = '<?= $command_name; ?>';
+    protected static <?= $use_typed_properties ? "string " : null ?>$defaultDescription = 'Add a short description for your command';
 
     protected function configure()
     {

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -21,7 +21,7 @@ class <?= $class_name."\n" ?>
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
      */
-    private $id;
+    private <?= $use_typed_properties ? "?int " : null ?>$id;
 
     public function getId(): ?int
     {

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -34,7 +34,7 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
 <?php if ($will_verify_email): ?>
-    private $emailVerifier;
+    private <?= $use_typed_properties ? 'EmailVerifier ' : null ?>$emailVerifier;
 
     public function __construct(EmailVerifier $emailVerifier)
     {

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -29,7 +29,7 @@ class <?= $class_name ?> extends AbstractController
 {
     use ResetPasswordControllerTrait;
 
-    private $resetPasswordHelper;
+    private <?= $use_typed_properties ? "ResetPasswordHelperInterface " : null ?>$resetPasswordHelper;
 
     public function __construct(ResetPasswordHelperInterface $resetPasswordHelper)
     {

--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -8,7 +8,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class <?= $class_name ?> implements NormalizerInterface<?= $cacheable_interface ? ', CacheableSupportsMethodInterface' : '' ?><?= "\n" ?>
 {
-    private $normalizer;
+    private <?= $use_typed_properties ? "ObjectNormalizer " : null ?>$normalizer;
 
     public function __construct(ObjectNormalizer $normalizer)
     {

--- a/src/Resources/skeleton/validator/Constraint.tpl.php
+++ b/src/Resources/skeleton/validator/Constraint.tpl.php
@@ -13,5 +13,5 @@ class <?= $class_name ?> extends Constraint
      * Any public properties become valid options for the annotation.
      * Then, use these in your validator class.
      */
-    public $message = 'The value "{{ value }}" is not valid.';
+    public <?= $use_typed_properties ? "string " : null ?>$message = 'The value "{{ value }}" is not valid.';
 }

--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -12,9 +12,9 @@ use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
 class <?= $class_name; ?><?= "\n" ?>
 {
-    private $verifyEmailHelper;
-    private $mailer;
-    private $entityManager;
+    private <?= $use_typed_properties ? "VerifyEmailHelperInterface " : null ?>$verifyEmailHelper;
+    private <?= $use_typed_properties ? "MailerInterface " : null ?>$mailer;
+    private <?= $use_typed_properties ? "EntityManagerInterface " : null ?>$entityManager;
 
     public function __construct(VerifyEmailHelperInterface $helper, MailerInterface $mailer, EntityManagerInterface $manager)
     {

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -80,11 +80,13 @@ class EntityRegeneratorTest extends TestCase
     public function testXmlRegeneration()
     {
         $kernel = new TestXmlEntityRegeneratorKernel('dev', true);
+        $phpCompatUtil = $this->createMock(PhpCompatUtil::class);
+
         $this->doTestRegeneration(
             __DIR__.'/fixtures/xml_source_project',
             $kernel,
             'Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity',
-            'expected_xml',
+            $phpCompatUtil->canUseTypedProperties() ? 'expected_xml_with_typing' : 'expected_xml',
             false,
             'current_project_xml'
         );

--- a/tests/Doctrine/fixtures/expected_xml_with_typing/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_xml_with_typing/src/Entity/UserAvatar.php
@@ -4,9 +4,9 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity;
 
 class UserAvatar
 {
-    private ?int $id;
+    private $id;
 
-    private ?UserXml $user;
+    private $user;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_xml_with_typing/src/Entity/UserXml.php
+++ b/tests/Doctrine/fixtures/expected_xml_with_typing/src/Entity/UserXml.php
@@ -7,11 +7,11 @@ use Doctrine\Common\Collections\Collection;
 
 class UserXml
 {
-    private ?int $id;
+    private $id;
 
-    private ?string $name;
+    private $name;
 
-    private Collection $avatars;
+    private $avatars;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/expected_xml_with_typing/src/Entity/XOther.php
+++ b/tests/Doctrine/fixtures/expected_xml_with_typing/src/Entity/XOther.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity;
+
+class XOther
+{
+    private ?int $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/fixtures/expected_xml_with_typing/src/Repository/UserRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml_with_typing/src/Repository/UserRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Repository;
+
+use Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity\UserXml;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method UserXml|null find($id, $lockMode = null, $lockVersion = null)
+ * @method UserXml|null findOneBy(array $criteria, array $orderBy = null)
+ * @method UserXml[]    findAll()
+ * @method UserXml[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UserXml::class);
+    }
+
+    // /**
+    //  * @return UserXml[] Returns an array of UserXml objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('u')
+            ->andWhere('u.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('u.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?UserXml
+    {
+        return $this->createQueryBuilder('u')
+            ->andWhere('u.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/tests/Doctrine/fixtures/expected_xml_with_typing/src/Repository/XOtherRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml_with_typing/src/Repository/XOtherRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Repository;
+
+use Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity\XOther;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method XOther|null find($id, $lockMode = null, $lockVersion = null)
+ * @method XOther|null findOneBy(array $criteria, array $orderBy = null)
+ * @method XOther[]    findAll()
+ * @method XOther[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class XOtherRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, XOther::class);
+    }
+
+    // /**
+    //  * @return XOther[] Returns an array of XOther objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('x')
+            ->andWhere('x.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('x.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?XOther
+    {
+        return $this->createQueryBuilder('x')
+            ->andWhere('x.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/tests/Security/SecurityControllerBuilderTest.php
+++ b/tests/Security/SecurityControllerBuilderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Security;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Security\SecurityControllerBuilder;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 
 class SecurityControllerBuilderTest extends TestCase
 {
@@ -22,7 +23,7 @@ class SecurityControllerBuilderTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/SecurityController.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/expected/SecurityController_login.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $securityControllerBuilder = new SecurityControllerBuilder();
         $securityControllerBuilder->addLoginMethod($manipulator);
@@ -35,7 +36,7 @@ class SecurityControllerBuilderTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/SecurityController.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/expected/SecurityController_logout.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $securityControllerBuilder = new SecurityControllerBuilder();
         $securityControllerBuilder->addLogoutMethod($manipulator);
@@ -48,7 +49,7 @@ class SecurityControllerBuilderTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/SecurityController.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/expected/SecurityController_login_logout.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $securityControllerBuilder = new SecurityControllerBuilder();
         $securityControllerBuilder->addLoginMethod($manipulator);

--- a/tests/Security/UserClassBuilderTest.php
+++ b/tests/Security/UserClassBuilderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Security\UserClassBuilder;
 use Symfony\Bundle\MakerBundle\Security\UserClassConfiguration;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 
 class UserClassBuilderTest extends TestCase
 {
@@ -27,6 +28,7 @@ class UserClassBuilderTest extends TestCase
 
         $manipulator = new ClassSourceManipulator(
             file_get_contents($sourceFilename),
+            $this->createMock(PhpCompatUtil::class),
             true
         );
 

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToOne;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToMany;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToOne;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class ClassSourceManipulatorTest extends TestCase
@@ -30,7 +31,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_property/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $method = (new \ReflectionObject($manipulator))->getMethod('addProperty');
         $method->setAccessible(true);
         $method->invoke($manipulator, $propertyName, $commentLines);
@@ -80,7 +81,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_getter/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $method = (new \ReflectionObject($manipulator))->getMethod('addGetter');
         $method->setAccessible(true);
         $method->invoke($manipulator, $propertyName, $type, true, $commentLines);
@@ -126,7 +127,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_setter/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $method = (new \ReflectionObject($manipulator))->getMethod('addSetter');
         $method->setAccessible(true);
         $method->invoke($manipulator, $propertyName, $type, $isNullable, $commentLines);
@@ -172,7 +173,7 @@ class ClassSourceManipulatorTest extends TestCase
      */
     public function testBuildAnnotationLine(string $annotationClass, array $annotationOptions, string $expectedAnnotation)
     {
-        $manipulator = new ClassSourceManipulator('');
+        $manipulator = new ClassSourceManipulator('', $this->createMock(PhpCompatUtil::class));
         $method = (new \ReflectionObject($manipulator))->getMethod('buildAnnotationLine');
         $method->setAccessible(true);
         $actualAnnotation = $method->invoke($manipulator, $annotationClass, $annotationOptions);
@@ -207,7 +208,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_entity_field/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addEntityField($propertyName, $fieldOptions);
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -268,7 +269,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_many_to_one_relation/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addManyToOneRelation($manyToOne);
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -346,7 +347,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_one_to_many_relation/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addOneToManyRelation($oneToMany);
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -397,7 +398,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_many_to_many_relation/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addManyToManyRelation($manyToMany);
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -445,7 +446,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_one_to_one_relation/'.$expectedSourceFilename);
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addOneToOneRelation($oneToOne);
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -550,7 +551,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/ProductWithTabs.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/with_tabs/ProductWithTabs.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $method = (new \ReflectionObject($manipulator))->getMethod('addProperty');
         $method->setAccessible(true);
@@ -568,7 +569,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/User_simple.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/implements_interface/User_simple.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addInterface(UserInterface::class);
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -579,7 +580,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/User_simple_with_interface.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/implements_interface/User_simple_with_interface.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addInterface(UserInterface::class);
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -590,7 +591,7 @@ class ClassSourceManipulatorTest extends TestCase
         $source = file_get_contents(__DIR__.'/fixtures/source/User_empty.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_method/UserEmpty_with_newMethod.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $methodBuilder = $manipulator->createMethodBuilder('testAddNewMethod', 'string', true, ['test comment on public method']);
 
@@ -612,7 +613,7 @@ CODE
         $source = file_get_contents(__DIR__.'/fixtures/source/EmptyController.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_method/Controller_with_action.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $methodBuilder = $manipulator->createMethodBuilder('action', 'JsonResponse', false, ['@Route("/action", name="app_action")']);
         $methodBuilder->addParam(
@@ -636,7 +637,7 @@ CODE
      */
     public function testAddAnnotationToClass(string $source, string $expectedSource)
     {
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
         $manipulator->addAnnotationToClass('Bar\\SomeAnnotation', [
             'message' => 'Foo',
         ]);
@@ -768,7 +769,7 @@ EOF
         $source = file_get_contents(__DIR__.'/fixtures/source/User_empty.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_trait/User_with_only_trait.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addTrait('App\TestTrait');
 
@@ -780,7 +781,7 @@ EOF
         $source = file_get_contents(__DIR__.'/fixtures/source/User_simple.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_trait/User_with_prop_trait.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addTrait('App\TestTrait');
 
@@ -792,7 +793,7 @@ EOF
         $source = file_get_contents(__DIR__.'/fixtures/source/User_with_const.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_trait/User_with_const_trait.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addTrait('App\TestTrait');
 
@@ -804,7 +805,7 @@ EOF
         $source = file_get_contents(__DIR__.'/fixtures/source/User_with_trait.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_trait/User_with_trait_trait.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addTrait('App\TestTrait');
 
@@ -816,7 +817,7 @@ EOF
         $source = file_get_contents(__DIR__.'/fixtures/add_trait/User_with_trait_trait.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_trait/User_with_trait_trait.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addTrait('App\TraitAlreadyHere');
 
@@ -828,7 +829,7 @@ EOF
         $source = file_get_contents(__DIR__.'/fixtures/source/User_empty.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_constructor/UserEmpty_with_constructor.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addConstructor([
                 (new Param('someObjectParam'))->setType('object')->getNode(),
@@ -848,7 +849,7 @@ CODE
         $source = file_get_contents(__DIR__.'/fixtures/source/User_simple.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_constructor/UserSimple_with_constructor.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addConstructor([
             (new Param('someObjectParam'))->setType('object')->getNode(),
@@ -868,7 +869,7 @@ CODE
         $source = file_get_contents(__DIR__.'/fixtures/source/User_with_const.php');
         $expectedSource = file_get_contents(__DIR__.'/fixtures/add_constructor/User_with_constructor_constante.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $manipulator->addConstructor([
             (new Param('someObjectParam'))->setType('object')->getNode(),
@@ -887,7 +888,7 @@ CODE
     {
         $source = file_get_contents(__DIR__.'/fixtures/source/User_with_constructor.php');
 
-        $manipulator = new ClassSourceManipulator($source);
+        $manipulator = new ClassSourceManipulator($source, $this->createMock(PhpCompatUtil::class));
 
         $this->expectException('LogicException');
         $this->expectExceptionMessage('Constructor already exists');


### PR DESCRIPTION
Now the maker-bundle type the properties of class. By default is desactivate, of course I can just check the version of PHP but the person can use PHP 7.4 on his "php path" but work on PHP 7.3 and 7.3 dosen't support typing. It's why you can use the flag "--typed" globaly on all command or use a configuration key to activate it by default on the projet. 

Exemple of entity generated with typing: 
```php
<?php

namespace App\Entity;

use App\Repository\EntityEtGrominetRepository;
use Doctrine\ORM\Mapping as ORM;

/**
 * @ORM\Entity(repositoryClass=EntityEtGrominetRepository::class)
 */
class EntityEtGrominet
{
    /**
     * @ORM\Id
     * @ORM\GeneratedValue
     * @ORM\Column(type="integer")
     */
    private ?int $id;

    /**
     * @ORM\Column(type="string", length=255)
     */
    private ?string $name = null;

    /**
     * @ORM\Column(type="datetime")
     */
    private ?\DateTimeInterface $createdAt = null;

    public function getId(): ?int
    {
        return $this->id;
    }

    public function getName(): ?string
    {
        return $this->name;
    }

    public function setName(string $name): self
    {
        $this->name = $name;

        return $this;
    }

    public function getCreatedAt(): ?\DateTimeInterface
    {
        return $this->createdAt;
    }

    public function setCreatedAt(\DateTimeInterface $createdAt): self
    {
        $this->createdAt = $createdAt;

        return $this;
    }
}

```

In the configuration file, to activate typing by default

```yml
maker:
  is_typed: true
```

~~At the moment, one test (and only one :/) dosn't pass, I don't know why. If someone can looking It's the MakeRegistrationFormTest with the data set "verify_email_functional_test". For more information run the test localy or look at gh action :grin:~~

I've close the #689 PR to make a more clean PR