### PR TITLE
Add make:makefile

### DIFF
--- a/src/Maker/MakeMakefile.php
+++ b/src/Maker/MakeMakefile.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Steven Dubois <contact@duboiss.fr>
+ * @author Aymeric Gueracague <aymeric.gueracague@gmail.com>
+ */
+final class MakeMakefile extends AbstractMaker
+{
+    private $fileManager;
+    private $fileSystem;
+    private $makefilePath;
+    private $hasDoctrine = false;
+    private $hasDoctrineFixturesBundle = false;
+    private $useSqlite = false;
+    private $hasTwig = false;
+    private $hasEncore = false;
+    private $nodePackagesManager = null;
+
+    public function __construct(FileManager $fileManager)
+    {
+        $this->fileSystem = new FileSystem();
+        $this->fileManager = $fileManager;
+        $this->makefilePath = sprintf('%s/Makefile', $this->fileManager->getRootDirectory());
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:makefile';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->setDescription('Adds a Makefile to your project')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeMakefile.txt'))
+        ;
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        $io->section('- Makefile Setup -');
+
+        if ($this->fileManager->fileExists($this->makefilePath)) {
+            $io->warning('You already have a Makefile, we rename it!');
+
+            $confirmation = new ConfirmationQuestion('This will rename your existing Makefile to Makefile.old - Are you sure?', false);
+
+            if (!$io->askQuestion($confirmation)) {
+                exit;
+            }
+
+            $this->fileSystem->rename($this->makefilePath, $this->makefilePath.'.old', true);
+        }
+
+        if ($this->twigIsInstalled()) {
+            $this->hasTwig = true;
+            $this->info('Twig detected.', $io);
+        }
+
+        if ($this->doctrineIsIntalled()) {
+            $this->hasDoctrine = true;
+            $this->info('Doctrine detected.', $io);
+            if ($this->useSqliteDatabase()) {
+                $this->useSqlite = true;
+            }
+            if ($this->doctrineFixturesBundleIsInstalled()) {
+                $this->hasDoctrineFixturesBundle = true;
+                $this->info('Doctrine fixtures bundle detected.', $io);
+            }
+        }
+
+        $encorePath = sprintf('%s/webpack.config.js', $this->fileManager->getRootDirectory());
+
+        if ($this->fileManager->fileExists($encorePath)) {
+            $this->hasEncore = true;
+            $this->info('Webpack Encore detected.', $io);
+
+            $this->detectNodePackagesManager($io);
+        }
+
+        $this->writeSuccessMessage($io);
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $generator->generateFile(
+            $this->makefilePath,
+            'makefile/Makefile.tpl.php',
+            [
+                'hasTwig' => $this->hasTwig,
+                'hasDoctrine' => $this->hasDoctrine,
+                'useSqlite' => $this->useSqlite,
+                'hasDoctrineFixturesBundle' => $this->hasDoctrineFixturesBundle,
+                'hasEncore' => $this->hasEncore,
+                'useYarn' => 'yarn' === $this->nodePackagesManager,
+            ]
+        );
+        $generator->writeChanges();
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+    }
+
+    private function twigIsInstalled(): bool
+    {
+        return class_exists('Twig\Environment');
+    }
+
+    private function doctrineIsIntalled(): bool
+    {
+        return \array_key_exists('DATABASE_URL', $_SERVER);
+    }
+
+    private function doctrineFixturesBundleIsInstalled(): bool
+    {
+        return class_exists('Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle');
+    }
+
+    private function useSqliteDatabase(): bool
+    {
+        return 0 === strpos($_SERVER['DATABASE_URL'], 'sqlite');
+    }
+
+    private function detectNodePackagesManager(ConsoleStyle $io): void
+    {
+        $npmLockPath = sprintf('%s/package-lock.json', $this->fileManager->getRootDirectory());
+        $yarnLockPath = sprintf('%s/yarn.lock', $this->fileManager->getRootDirectory());
+
+        if (!$this->fileManager->fileExists($npmLockPath)) {
+            if (!$this->fileManager->fileExists($yarnLockPath)) {
+                $io->warning('package-lock.json or yarn.lock not found.');
+                $this->nodePackagesManager = $this->askNodePackagesManager($io);
+            } else {
+                $this->nodePackagesManager = 'yarn';
+            }
+        } else {
+            $this->nodePackagesManager = 'npm';
+        }
+
+        if ($this->fileManager->fileExists($npmLockPath) && $this->fileManager->fileExists($yarnLockPath)) {
+            $this->nodePackagesManager = $this->askNodePackagesManager($io);
+        }
+    }
+
+    private function askNodePackagesManager(ConsoleStyle $io): string
+    {
+        $choice = null;
+        while (null === $choice) {
+            $packagesManagers = ['yarn', 'npm'];
+            $question = new Question('Which Node packages manager do you want to use (npm or yarn)', 'yarn');
+            $question->setAutocompleterValues($packagesManagers);
+            $choice = $io->askQuestion($question);
+
+            if (!\in_array($choice, $packagesManagers, true)) {
+                $io->error(sprintf('Invalid package manager "%s". Please choose between npm or yarn', $choice));
+                $io->writeln('');
+
+                $choice = null;
+            }
+        }
+
+        return $choice;
+    }
+
+    private function info(string $message, ConsoleStyle $io): void
+    {
+        $io->block($message, 'INFO', 'fg=green', ' ', false);
+    }
+}

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -58,6 +58,11 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_makefile" class="Symfony\Bundle\MakerBundle\Maker\MakeMakefile">
+                <argument type="service" id="maker.file_manager" />
+                <tag name="maker.command" />
+            </service>
+
             <service id="maker.maker.make_message" class="Symfony\Bundle\MakerBundle\Maker\MakeMessage">
                 <argument type="service" id="maker.file_manager" />
                 <tag name="maker.command" />

--- a/src/Resources/help/MakeMakefile.txt
+++ b/src/Resources/help/MakeMakefile.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a Makefile in your project.
+
+<info>php %command.full_name%</info>
+
+Supports webpack encore and doctrine.

--- a/src/Resources/skeleton/makefile/Makefile.tpl.php
+++ b/src/Resources/skeleton/makefile/Makefile.tpl.php
@@ -1,0 +1,203 @@
+.DEFAULT_GOAL := help
+
+SYMFONY_BIN = symfony
+<?php if ($hasEncore): ?>
+NODE_PACKAGES_MANAGER = <?= $useYarn ? 'yarn' : 'npm' ?>
+
+<?php endif; ?>
+
+COMPOSER = $(SYMFONY_BIN) composer
+PHPUNIT = $(SYMFONY_BIN) php bin/phpunit
+SYMFONY = $(SYMFONY_BIN) console
+
+<?php if ($hasDoctrine): ?>
+##
+## Database
+<?php if ($hasDoctrineFixturesBundle): ?>
+.PHONY: db db-reset db-cache db-validate fixtures
+
+db: vendor db-reset fixtures ## Reset database and load fixtures
+<?php else: ?>
+.PHONY: db db-reset db-cache db-validate
+
+db: vendor db-reset ## Reset database
+<?php endif; ?>
+
+db-cache: vendor ## Clear doctrine database cache
+<?="\t"?>@$(SYMFONY) doctrine:cache:clear-metadata
+<?="\t"?>@$(SYMFONY) doctrine:cache:clear-query
+<?="\t"?>@$(SYMFONY) doctrine:cache:clear-result
+<?="\t"?>@echo "Cleared doctrine cache"
+
+db-reset: vendor ## Reset database
+<?php if ($useSqlite): ?>
+<?="\t"?>@-$(SYMFONY) doctrine:database:drop --force
+<?="\t"?>@-$(SYMFONY) doctrine:database:create
+<?php else: ?>
+<?="\t"?>@-$(SYMFONY) doctrine:database:drop --if-exists --force
+<?="\t"?>@-$(SYMFONY) doctrine:database:create --if-not-exists
+<?php endif; ?>
+<?="\t"?>@$(SYMFONY) doctrine:schema:update --force
+
+db-validate: vendor ## Checks doctrine's mapping configurations are valid
+<?="\t"?>@$(SYMFONY) doctrine:schema:validate --skip-sync -vvv --no-interaction
+
+<?php if ($hasDoctrineFixturesBundle): ?>
+fixtures: vendor ## Load fixtures - requires database with tables
+<?="\t"?>@$(SYMFONY) doctrine:fixtures:load --no-interaction
+
+<?php endif; ?>
+<?php endif; ?>
+
+##
+## Linting
+<?php if ($hasTwig): ?>
+.PHONY: lint lint-container lint-twig lint-yaml
+<?php else: ?>
+.PHONY: lint lint-container lint-yaml
+<?php endif; ?>
+
+lint: vendor ## Run all lint commands
+<?php if ($hasTwig): ?>
+<?="\t"?>@make -j lint-container lint-twig lint-yaml
+<?php else: ?>
+<?="\t"?>@make -j lint-container lint-yaml
+<?php endif; ?>
+
+lint-container: vendor ## Checks the services defined in the container
+<?="\t"?>@$(SYMFONY) lint:container
+
+<?php if ($hasTwig): ?>
+lint-twig: vendor ## Check twig syntax in /templates folder (prod environment)
+<?="\t"?>@$(SYMFONY) lint:twig templates -e prod
+<?php endif; ?>
+
+lint-yaml: vendor ## Check yaml syntax in /config folder
+<?="\t"?>@$(SYMFONY) lint:yaml config
+<?php if ($hasEncore): ?>
+
+
+##
+## Node.js
+.PHONY: assets build watch
+
+<?php if ($useYarn): ?>
+yarn.lock: package.json
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) upgrade
+
+node_modules: yarn.lock ## Install node packages
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) install
+<?php else: ?>
+package-lock.json: package.json
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) update
+
+node_modules: package-lock.json ## Install node packages
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) install
+<?php endif; ?>
+
+assets: node_modules ## Run Webpack Encore to compile development assets
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) run dev
+
+build: node_modules ## Run Webpack Encore to compile production assets
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) run build
+
+watch: node_modules ## Recompile assets automatically when files change
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) run watch
+<?php endif; ?>
+
+
+##
+## PHP
+composer.lock: composer.json
+<?="\t"?>@$(COMPOSER) update
+
+vendor: composer.lock ## Install dependencies in /vendor folder
+<?="\t"?>@$(COMPOSER) install --no-progress
+
+
+##
+## Project
+.PHONY: install update cache-clear cache-warmup ci clean purge reset start
+
+<?php if ($hasDoctrine && $hasEncore): ?>
+install: ## Install project dependencies
+<?="\t"?>@make -j db assets
+
+update: vendor node_modules ## Update project dependencies
+<?="\t"?>@$(COMPOSER) update
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) <?= $useYarn ? 'upgrade' : 'update' ?>
+<?php elseif ($hasDoctrine): ?>
+install: db ## Install project dependencies
+
+update: vendor ## Update project dependencies
+<?="\t"?>@$(COMPOSER) update
+<?php elseif ($hasEncore): ?>
+install: ## Install project dependencies
+<?="\t"?>@make -j vendor assets
+
+update: vendor node_modules ## Update project dependencies
+<?="\t"?>@$(COMPOSER) update
+<?="\t"?>@$(NODE_PACKAGES_MANAGER) <?= $useYarn ? 'upgrade' : 'update' ?>
+<?php else: ?>
+install: vendor ## Install project dependencies
+
+update: vendor ## Update project dependencies
+<?="\t"?>@$(COMPOSER) update
+
+<?php endif; ?>
+
+cache-clear: vendor ## Clear cache for current environment
+<?="\t"?>@$(SYMFONY) cache:clear --no-warmup
+
+cache-warmup: vendor cache-clear ## Clear and warm up cache for current environment
+<?="\t"?>@$(SYMFONY) cache:warmup
+
+<?php if ($hasDoctrine): ?>
+ci: db-validate lint security tests ## Continuous integration
+<?php else: ?>
+ci: lint security tests ## Continuous integration
+<?php endif; ?>
+
+clean: purge ## Delete all dependencies
+<?="\t"?>@echo -n "This will delete var, vendor, node_modules and public/build folders, are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
+<?="\t"?>@rm -rf var vendor node_modules public/build
+<?="\t"?>@echo "Var, vendor, node_modules and public/build folders have been deleted !"
+
+purge: ## Purge cache and logs
+<?="\t"?>@echo -n "This will delete var/cache var/log folders, are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
+<?="\t"?>@rm -rf var/cache/* var/log/*
+<?="\t"?>@echo "Cache and logs have been deleted !"
+
+reset: unserve clean install ## Reset project
+
+start: install serve ## Install project dependencies and launch symfony web server
+
+
+##
+## Symfony binary
+.PHONY: serve unserve security
+
+serve: ## Run symfony web server in the background
+<?="\t"?>@$(SYMFONY_BIN) serve --daemon --no-tls
+
+unserve: ## Stop symfony web server
+<?="\t"?>@$(SYMFONY_BIN) server:stop
+
+security: vendor ## Check packages vulnerabilities (using composer.lock)
+<?="\t"?>@$(SYMFONY_BIN) check:security
+
+
+##
+## Tests
+.PHONY: tests
+
+tests: vendor ## Run tests
+<?="\t"?>@$(PHPUNIT)
+
+
+##
+## Help
+.PHONY: help
+
+help: ## List of all commands
+<?="\t"?>@grep -E '(^[a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'

--- a/tests/Maker/MakeMakefileTest.php
+++ b/tests/Maker/MakeMakefileTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeMakefile;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Steven Dubois <contact@duboiss.fr>
+ * @author Aymeric Gueracague <aymeric.gueracague@gmail.com>
+ */
+class MakeMakefileTest extends MakerTestCase
+{
+    public function getTestDetails(): \Generator
+    {
+        yield 'makefile_basic' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                }),
+        ];
+
+        yield 'makefile_already_exists_in_root' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                [
+                    'yes', // Regenerate it, default is no
+                ]
+            )
+                ->addPreMakeCommand('touch Makefile')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $oldMakefilePath = sprintf('%s/Makefile.old', $directory);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertTrue($fs->exists($oldMakefilePath));
+                }),
+        ];
+
+        yield 'makefile_with_twig' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->addExtraDependencies('twig/twig')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Twig detected', $output);
+                    $this->assertStringContainsString('.PHONY: lint lint-container lint-twig lint-yaml', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_doctrine' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->addExtraDependencies('symfony/orm-pack')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Doctrine detected', $output);
+                    $this->assertStringContainsString('.PHONY: db db-reset db-cache db-validate', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_doctrine_and_fixtures' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->addExtraDependencies('symfony/orm-pack')
+                ->addExtraDependencies('doctrine/doctrine-fixtures-bundle')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Doctrine detected', $output);
+                    $this->assertStringContainsString('Doctrine fixtures bundle detected', $output);
+                    $this->assertStringContainsString('.PHONY: db db-reset db-cache db-validate fixtures', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_doctrine_sqlite' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->addExtraDependencies('symfony/orm-pack')
+                ->addReplacement(
+                    '.env',
+                    'DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"',
+                    'DATABASE_URL="sqlite:///%kernel.project_dir%/var/app.db"'
+                )
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    // --if-exits flag can't be use on sqlite database
+                    $this->assertStringContainsString('@-$(SYMFONY) doctrine:database:drop --force', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_webpack_encore_and_no_pm_initialised' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                [
+                    '', // Default package manager is Yarn
+                ]
+            )
+                ->addPreMakeCommand('touch webpack.config.js')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Webpack Encore detected', $output);
+                    $this->assertStringContainsString('yarn.lock: package.json', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_webpack_encore_and_yarn' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->addPreMakeCommand('touch yarn.lock')
+                ->addPreMakeCommand('touch webpack.config.js')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Webpack Encore detected', $output);
+                    $this->assertStringContainsString('yarn.lock: package.json', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_webpack_encore_and_npm' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->addPreMakeCommand('touch package-lock.json')
+                ->addPreMakeCommand('touch webpack.config.js')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Webpack Encore detected', $output);
+                    $this->assertStringContainsString('package-lock.json: package.json', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_webpack_encore_and_yarn_and_npm' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                [
+                    '', // Yarn by default
+                ]
+            )
+                ->addPreMakeCommand('touch package-lock.json')
+                ->addPreMakeCommand('touch yarn.lock')
+                ->addPreMakeCommand('touch webpack.config.js')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Webpack Encore detected', $output);
+                    $this->assertStringContainsString('yarn.lock: package.json', $makefile);
+                }),
+        ];
+
+        yield 'makefile_with_webpack_encore_with_yarn_and_doctrine' => [
+            MakerTestDetails::createTest(
+                $this->getMakerInstance(MakeMakefile::class),
+                []
+            )
+                ->addExtraDependencies('symfony/orm-pack')
+                ->addPreMakeCommand('touch yarn.lock')
+                ->addPreMakeCommand('touch webpack.config.js')
+                ->assert(function (string $output, string $directory) {
+                    $fs = new Filesystem();
+                    $makefilePath = sprintf('%s/Makefile', $directory);
+                    $makefile = file_get_contents($makefilePath);
+
+                    $this->assertTrue($fs->exists($makefilePath));
+                    $this->assertStringContainsString('Webpack Encore detected', $output);
+                    $this->assertStringContainsString('yarn.lock: package.json', $makefile);
+                    $this->assertStringContainsString('.PHONY: db db-reset db-cache db-validate', $makefile);
+                }),
+        ];
+    }
+}


### PR DESCRIPTION
With @Superkooka

Handle:
- `make help`
- Twig linter command
- Doctrine / Doctrine fixtures bundle
- Webpack encore (yarn/npm)
- Save existing Makefile if user wants to generate new one

Also, most of the commands in the Makefile use parallel jobs.
For the sensitives commands with `rm -rf`, we ask the user for a confirmation.

Example of Makefile with doctrine (sqlite) / fixtures / webpack encore : https://pastebin.com/Scbysu03

![image](https://user-images.githubusercontent.com/29716703/103467189-cd2c0700-4d4c-11eb-86a7-9fbf8ba27d92.png)
![image](https://user-images.githubusercontent.com/29716703/103467190-d1582480-4d4c-11eb-9cfd-bfca972514c0.png)
![image](https://user-images.githubusercontent.com/29716703/103467193-d6b56f00-4d4c-11eb-9b30-0493af941aa6.png)
![image](https://user-images.githubusercontent.com/29716703/103467194-d9b05f80-4d4c-11eb-865a-7c52ed68d005.png)