### PR TITLE
[make:registration] allow email verification without authentication

### DIFF
--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -71,6 +71,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.renderer.form_type_renderer" />
                 <argument type="service" id="router" />
+                <argument type="service" id="maker.doctrine_helper" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -11,6 +11,9 @@ use <?= $verify_email_security_service; ?>;
 use <?= $authenticator_full_class_name; ?>;
 <?php endif; ?>
 <?php if ($will_verify_email): ?>
+<?php if ($verify_email_anonymously): ?>
+use <?= $repository_full_class_name; ?>;
+<?php endif; ?>
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 <?php endif; ?>
 use Symfony\Bundle\FrameworkBundle\Controller\<?= $parent_class_name; ?>;
@@ -102,13 +105,33 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
      * @Route("/verify/email", name="app_verify_email")
      */
 <?php } ?>
-    public function verifyUserEmail(Request $request): Response
+    public function verifyUserEmail(Request $request<?= $verify_email_anonymously ? sprintf(', %s %s', $repository_class_name, $repository_var) : null ?>): Response
     {
+<?php if (!$verify_email_anonymously): ?>
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
+<?php else: ?>
+        $id = $request->get('id');
+
+        if (null === $id) {
+            return $this->redirectToRoute('app_register');
+        }
+<?php if ('$manager' === $repository_var): ?>
+
+        $repository = $manager->getRepository(<?= $user_class_name ?>::class);
+        $user = $repository->find($id);
+<?php else: ?>
+
+        <?= $repository_var; ?>->find($id);
+<?php endif; ?>
+
+        if (null === $user) {
+            return $this->redirectToRoute('app_register');
+        }
+<?php endif; ?>
 
         // validate email confirmation link, sets User::isVerified=true and persists
         try {
-            $this->emailVerifier->handleEmailConfirmation($request, $this->getUser());
+            $this->emailVerifier->handleEmailConfirmation($request, <?= $verify_email_anonymously ? '$user' : '$this->getUser()' ?>);
         } catch (VerifyEmailExceptionInterface $exception) {
             $this->addFlash('verify_email_error', $exception->getReason());
 

--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -28,7 +28,12 @@ class <?= $class_name; ?><?= "\n" ?>
         $signatureComponents = $this->verifyEmailHelper->generateSignature(
             $verifyEmailRouteName,
             $user-><?= $id_getter ?>(),
+<?php if ($verify_email_anonymously): ?>
+            $user-><?= $email_getter ?>(),
+            ['id' => $user->getId()]
+<?php else: ?>
             $user-><?= $email_getter ?>()
+<?php endif; ?>
         );
 
         $context = $email->getContext();

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -79,7 +79,8 @@ class MakeRegistrationFormTest extends MakerTestCase
             $this->getMakerInstance(MakeRegistrationForm::class),
             [
                 'n', // add UniqueEntity
-                'y', // no verify user
+                'y', // verify user
+                'y', // require authentication to verify user email
                 'jr@rushlow.dev', // from email address
                 'SymfonyCasts', // From Name
                 'n', // no authenticate after
@@ -110,7 +111,8 @@ class MakeRegistrationFormTest extends MakerTestCase
             $this->getMakerInstance(MakeRegistrationForm::class),
             [
                 'n', // add UniqueEntity
-                'y', // no verify user
+                'y', // verify user
+                'n', // require authentication to verify user email
                 'jr@rushlow.dev', // from email address
                 'SymfonyCasts', // From Name
                 '', // yes authenticate after
@@ -118,6 +120,27 @@ class MakeRegistrationFormTest extends MakerTestCase
             ])
             ->setRequiredPhpVersion(70200)
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeRegistrationFormVerifyEmailFunctionalTest')
+            ->addExtraDependencies('symfonycasts/verify-email-bundle')
+            ->configureDatabase()
+            ->updateSchemaAfterCommand()
+            // needed for internal functional test
+            ->addExtraDependencies('symfony/web-profiler-bundle')
+            ->addExtraDependencies('mailer'),
+        ];
+
+        yield 'verify_email_no_auth_functional_test' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeRegistrationForm::class),
+            [
+                'n', // add UniqueEntity
+                'y', // verify user's email
+                'y', // require authentication to verify user email
+                'jr@rushlow.dev', // from email address
+                'SymfonyCasts', // From Name
+                '', // yes authenticate after
+                'main', // redirect to route after registration
+            ])
+            ->setRequiredPhpVersion(70200)
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest')
             ->addExtraDependencies('symfonycasts/verify-email-bundle')
             ->configureDatabase()
             ->updateSchemaAfterCommand()

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/config/packages/mailer.yaml
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/config/packages/mailer.yaml
@@ -1,0 +1,3 @@
+framework:
+    mailer:
+        dsn: 'null://null'

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/config/packages/security.yaml
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/config/packages/security.yaml
@@ -1,0 +1,20 @@
+security:
+    encoders:
+        App\Entity\User: bcrypt
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        app_user_provider:
+            entity:
+                class: App\Entity\User
+                property: email
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+#            guard:
+#                authenticators:
+#                    - App\Security\StubAuthenticator

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/src/Controller/MyController.php
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/src/Controller/MyController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class MyController extends AbstractController
+{
+    /**
+     * @Route("/", name="main")
+     */
+    public function index(): Response
+    {
+        return new Response();
+    }
+}

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/src/Entity/User.php
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/src/Entity/User.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @ORM\Entity()
+ */
+class User implements UserInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=180, unique=true)
+     */
+    private $email;
+
+    /**
+     * @ORM\Column(type="array")
+     */
+    private $roles = [];
+
+    /**
+     * @var string The hashed password
+     * @ORM\Column(type="string")
+     */
+    private $password;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getUsername(): string
+    {
+        return (string) $this->email;
+    }
+
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        // guarantee every user at least has ROLE_USER
+        $roles[] = 'ROLE_USER';
+
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return (string) $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/src/Repository/UserRepository.php
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/src/Repository/UserRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method User|null find($id, $lockMode = null, $lockVersion = null)
+ * @method User|null findOneBy(array $criteria, array $orderBy = null)
+ * @method User[]    findAll()
+ * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+}

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/tests/VerifyEmailTest.php
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailNoAuthFunctionalTest/tests/VerifyEmailTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\fixtures\MakeRegistrationFormVerifyEmailFunctionalTest\tests;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class VerifyEmailTest extends WebTestCase
+{
+    public function testRegistrationSuccessful()
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/register');
+
+        $form = $crawler->selectButton('Register')->form();
+        $form['registration_form[email]'] = 'jr@rushlow.dev';
+        $form['registration_form[plainPassword]'] = 'noAuth';
+        $form['registration_form[agreeTerms]'] = true;
+
+        $client->submit($form);
+
+        $messages = $this->getMailerMessages();
+        self::assertCount(1, $messages);
+
+        /** @var EntityManager $em */
+        $em = self::$kernel->getContainer()
+            ->get('doctrine')
+            ->getManager()
+        ;
+
+        $query = $em->createQuery('SELECT u FROM App\\Entity\\User u WHERE u.email = \'jr@rushlow.dev\'');
+
+        self::assertFalse(($query->getSingleResult())->isVerified());
+
+        $context = $messages[0]->getContext();
+
+        $client->request('GET', $context['signedUrl']);
+
+        self::assertTrue(($query->getSingleResult())->isVerified());
+    }
+}


### PR DESCRIPTION
By passing the user id as an extra query param to `VerifyEmailHelper::generateSignature()` - users are able to verify their email address without being authenticated.

As a precautionary note, answering `no` to `Do you want to require the user to be authenticated to verify their email?` will allow anyone with the link generated by `VerifyEmailHelper` to validated that users email address. It should also be advised that answering `no` could possibly leak personally identifiable information in log files if the user `id` is changed to say, a users email address.