### PR TITLE
Move symfony/process dependency from require-dev to require

### DIFF
--- a/src/Test/MakerTestCase.php
+++ b/src/Test/MakerTestCase.php
@@ -15,6 +15,7 @@ use Composer\Semver\Semver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Component\Process\Process;
 
 abstract class MakerTestCase extends TestCase
 {
@@ -32,6 +33,10 @@ abstract class MakerTestCase extends TestCase
 
     protected function executeMakerCommand(MakerTestDetails $testDetails)
     {
+        if (!class_exists(Process::class)) {
+            throw new \LogicException('The MakerTestCase cannot be run as the Process component is not installed. Try running "compose require --dev symfony/process".');
+        }
+
         if (!$testDetails->isSupportedByCurrentPhpVersion()) {
             $this->markTestSkipped();
         }


### PR DESCRIPTION
Hi!

I was trying to use [`MakerTestCase`](https://github.com/symfony/maker-bundle/blob/a47408fa6e39034a5abe324a46f4e6733266267a/src/Test/MakerTestCase.php) and I'm finding some little things. 

In this case, `symfony/process` is being used under the src directory in two files:
- [src/Test/MakerTestProcess.php](https://github.com/symfony/maker-bundle/blob/a47408fa6e39034a5abe324a46f4e6733266267a/src/Test/MakerTestProcess.php#L14)
- [src/Test/MakerTestEnvironment.php](https://github.com/symfony/maker-bundle/blob/a47408fa6e39034a5abe324a46f4e6733266267a/src/Test/MakerTestEnvironment.php#L18-L19)

So trying to execute tests I'm getting: `Error: Class 'Symfony\Component\Process\Process' not found`