### PR TITLE
Fixed PHP 7.1.3 tests by using PHPUnit 8.5

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -373,12 +373,18 @@ final class MakerTestEnvironment
             $this->fs->symlink($rootPath.'/vendor/symfony/phpunit-bridge', $this->flexPath.'/vendor/symfony/phpunit-bridge');
         }
 
-        // temporarily ignoring indirect deprecations - see #237
         $replacements = [
+            // temporarily ignoring indirect deprecations - see #237
             [
                 'filename' => '.env.test',
                 'find' => 'SYMFONY_DEPRECATIONS_HELPER=999999',
                 'replace' => 'SYMFONY_DEPRECATIONS_HELPER=max[self]=0',
+            ],
+            // do not explicitly set the PHPUnit version
+            [
+                'filename' => 'phpunit.xml.dist',
+                'find' => '<server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />',
+                'replace' => '',
             ],
         ];
         $this->processReplacements($replacements, $this->flexPath);


### PR DESCRIPTION
This fixes the broken PHP 8 tests, as they were using PHPUnit 7.5 (which doesn't support PHP 8).

This version is also proposed to the official recipes and will probably be merged shortly: https://github.com/symfony/recipes/pull/868