### PR TITLE
Sort doctrine entities for autocomplete

### DIFF
--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -124,6 +124,8 @@ final class DoctrineHelper
             }
         }
 
+        sort($entities);
+
         return $entities;
     }
 


### PR DESCRIPTION
It make autocomplete more predictable and much better in some cases. For example I have entities `Invoice` and `InvoiceTransaction`, with sort first suggestion will be `Invoice` but now it can be `InvoiceTransaction` and you must press `TAB` and `BACKSPACE` several times to edit `Invoice` entity.

![изображение](https://user-images.githubusercontent.com/12619075/104320651-54883000-552e-11eb-89eb-f66b7e34182f.png)
