### PR TITLE
[Reset-Password] use expiration translation in check email route

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -33,6 +33,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Yaml\Yaml;
+use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestTrait;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
@@ -84,13 +85,11 @@ class MakeResetPassword extends AbstractMaker
 
         $dependencies->addClassDependency(Annotation::class, 'annotations');
 
-        // reset-password-bundle 1.2.1 includes support for translations and a fix for the bad expiration time bug.
-        // we need to check that version 1.2.1 is installed
+        // reset-password-bundle 1.3 includes helpers to get/set a ResetPasswordToken object from the session.
+        // we need to check that version 1.3 is installed
         if (class_exists(ResetPasswordToken::class)) {
-            $reflectedToken = new \ReflectionClass(ResetPasswordToken::class);
-
-            if (!$reflectedToken->hasMethod('getExpirationMessageKey')) {
-                throw new RuntimeCommandException('Please upgrade symfonycasts/reset-password-bundle to version 1.2.1 or greater.');
+            if (!method_exists(ResetPasswordControllerTrait::class, 'getTokenObjectFromSession')) {
+                throw new RuntimeCommandException('Please upgrade symfonycasts/reset-password-bundle to version 1.3 or greater.');
             }
         }
     }

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -76,12 +76,12 @@ class <?= $class_name ?> extends AbstractController
     public function checkEmail(): Response
     {
         // We prevent users from directly accessing this page
-        if (!$this->canCheckEmail()) {
+        if (null === ($resetToken = $this->getTokenObjectFromSession())) {
             return $this->redirectToRoute('app_forgot_password_request');
         }
 
         return $this->render('reset_password/check_email.html.twig', [
-            'tokenLifetime' => $this->resetPasswordHelper->getTokenLifetime(),
+            'resetToken' => $resetToken,
         ]);
     }
 
@@ -155,9 +155,6 @@ class <?= $class_name ?> extends AbstractController
             '<?= $email_field ?>' => $emailFormData,
         ]);
 
-        // Marks that you are allowed to see the app_check_email page.
-        $this->setCanCheckEmailInSession();
-
         // Do not reveal whether a user account was found or not.
         if (!$user) {
             return $this->redirectToRoute('app_check_email');
@@ -189,6 +186,9 @@ class <?= $class_name ?> extends AbstractController
         ;
 
         $mailer->send($email);
+
+        // Store the token object in session for retrieval in check-email route.
+        $this->setTokenObjectInSession($resetToken);
 
         return $this->redirectToRoute('app_check_email');
     }

--- a/src/Resources/skeleton/resetPassword/twig_check_email.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_check_email.tpl.php
@@ -3,6 +3,9 @@
 {% block title %}Password Reset Email Sent{% endblock %}
 
 {% block body %}
-    <p>An email has been sent that contains a link that you can click to reset your password. This link will expire in {{ tokenLifetime|date('g') }} hour(s).</p>
+    <p>
+        An email has been sent that contains a link that you can click to reset your password.
+        This link will expire in {{ resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle') }}.
+    </p>
     <p>If you don't receive an email please check your spam folder or <a href="{{ path('app_forgot_password_request') }}">try again</a>.</p>
 {% endblock %}


### PR DESCRIPTION
I missed this template in #770

- [x] Depends on https://github.com/SymfonyCasts/reset-password-bundle/pull/143