### PR TITLE
[MakeVoter] add missing type hints inherited from abstract Voter

### DIFF
--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -8,7 +8,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class <?= $class_name ?> extends Voter
 {
-    protected function supports($attribute, $subject)
+    protected function supports(string $attribute, $subject)
     {
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
@@ -16,7 +16,7 @@ class <?= $class_name ?> extends Voter
             && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;
     }
 
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token)
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access


### PR DESCRIPTION
`Symfony\Component\Security\Core\Authorization\Voter\Voter::class` References:

- [Supports Method](https://github.com/symfony/symfony/blob/294195157c3690b869ff6295713a69ff38b3039c/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php#L70)

- [VoteOnAttribute Method](https://github.com/symfony/symfony/blob/294195157c3690b869ff6295713a69ff38b3039c/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php#L80)