### PR TITLE
Make commands compatible with LazyCommand

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -73,10 +73,14 @@ final class MakeAuthenticator extends AbstractMaker
         return 'make:auth';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a Guard authenticator of different flavors';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConfig)
     {
         $command
-            ->setDescription('Creates a Guard authenticator of different flavors')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeAuth.txt'));
     }
 

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -31,10 +32,14 @@ final class MakeCommand extends AbstractMaker
         return 'make:command';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new console command class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new console command class')
             ->addArgument('name', InputArgument::OPTIONAL, sprintf('Choose a command name (e.g. <fg=yellow>app:%s</>)', Str::asCommand(Str::getRandomTerm())))
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCommand.txt'))
         ;
@@ -57,6 +62,7 @@ final class MakeCommand extends AbstractMaker
             'command/Command.tpl.php',
             [
                 'command_name' => $commandName,
+                'set_description' => !class_exists(LazyCommand::class),
             ]
         );
 

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -34,10 +34,14 @@ final class MakeController extends AbstractMaker
         return 'make:controller';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new controller class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new controller class')
             ->addArgument('controller-class', InputArgument::OPTIONAL, sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
             ->addOption('no-template', null, InputOption::VALUE_NONE, 'Use this option to disable template generation')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeController.txt'))

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -59,13 +59,17 @@ final class MakeCrud extends AbstractMaker
         return 'make:crud';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates CRUD for Doctrine entity class';
+    }
+
     /**
      * {@inheritdoc}
      */
     public function configureCommand(Command $command, InputConfiguration $inputConfig)
     {
         $command
-            ->setDescription('Creates CRUD for Doctrine entity class')
             ->addArgument('entity-class', InputArgument::OPTIONAL, sprintf('The class name of the entity to create CRUD (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCrud.txt'))
         ;

--- a/src/Maker/MakeDockerDatabase.php
+++ b/src/Maker/MakeDockerDatabase.php
@@ -64,10 +64,14 @@ final class MakeDockerDatabase extends AbstractMaker
         return 'make:docker:database';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Adds a database container to your docker-compose.yaml file';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
-            ->setDescription('Adds a database container to your docker-compose.yaml file')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeDockerDatabase.txt'))
         ;
     }

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -75,10 +75,14 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         return 'make:entity';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates or updates a Doctrine entity class, and optionally an API Platform resource';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates or updates a Doctrine entity class, and optionally an API Platform resource')
             ->addArgument('name', InputArgument::OPTIONAL, sprintf('Class name of the entity to create or update (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
             ->addOption('api-resource', 'a', InputOption::VALUE_NONE, 'Mark this class as an API Platform resource (expose a CRUD API for it)')
             ->addOption('regenerate', null, InputOption::VALUE_NONE, 'Instead of adding new fields, simply generate the methods (e.g. getter/setter) for existing fields')

--- a/src/Maker/MakeFixtures.php
+++ b/src/Maker/MakeFixtures.php
@@ -34,10 +34,14 @@ final class MakeFixtures extends AbstractMaker
         return 'make:fixtures';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new class to load Doctrine fixtures';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new class to load Doctrine fixtures')
             ->addArgument('fixtures-class', InputArgument::OPTIONAL, 'The class name of the fixtures to create (e.g. <fg=yellow>AppFixtures</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeFixture.txt'))
         ;

--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -48,10 +48,14 @@ final class MakeForm extends AbstractMaker
         return 'make:form';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new form class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new form class')
             ->addArgument('name', InputArgument::OPTIONAL, sprintf('The name of the form class (e.g. <fg=yellow>%sType</>)', Str::asClassName(Str::getRandomTerm())))
             ->addArgument('bound-class', InputArgument::OPTIONAL, 'The name of Entity or fully qualified model class name that the new form will be bound to (empty for none)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeForm.txt'))

--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -34,10 +34,14 @@ class MakeFunctionalTest extends AbstractMaker
         return 'make:functional-test';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new functional test class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new functional test class')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the functional test class (e.g. <fg=yellow>DefaultControllerTest</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeFunctionalTest.txt'))
         ;

--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -42,10 +42,14 @@ final class MakeMessage extends AbstractMaker
         return 'make:message';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new message and handler';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new message and handler')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the message class (e.g. <fg=yellow>SendEmailMessage</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeMessage.txt'))
         ;

--- a/src/Maker/MakeMessengerMiddleware.php
+++ b/src/Maker/MakeMessengerMiddleware.php
@@ -32,10 +32,14 @@ final class MakeMessengerMiddleware extends AbstractMaker
         return 'make:messenger-middleware';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new messenger middleware';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConfig)
     {
         $command
-            ->setDescription('Creates a new messenger middleware')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the middleware class (e.g. <fg=yellow>CustomMiddleware</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeMessage.txt'));
     }

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -48,6 +48,11 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         return 'make:migration';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new migration based on database changes';
+    }
+
     public function setApplication(Application $application)
     {
         $this->application = $application;
@@ -56,7 +61,6 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new migration based on database changes')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeMigration.txt'))
         ;
 

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -71,10 +71,14 @@ final class MakeRegistrationForm extends AbstractMaker
         return 'make:registration-form';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new registration form system';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new registration form system')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeRegistrationForm.txt'))
         ;
     }

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -68,10 +68,14 @@ class MakeResetPassword extends AbstractMaker
         return 'make:reset-password';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Create controller, entity, and repositories for use with symfonycasts/reset-password-bundle';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConfig)
     {
         $command
-            ->setDescription('Create controller, entity, and repositories for use with symfonycasts/reset-password-bundle')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeResetPassword.txt'))
         ;
     }

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -30,10 +30,14 @@ final class MakeSerializerEncoder extends AbstractMaker
         return 'make:serializer:encoder';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new serializer encoder class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new serializer encoder class')
             ->addArgument('name', InputArgument::OPTIONAL, 'Choose a class name for your encoder (e.g. <fg=yellow>YamlEncoder</>)')
             ->addArgument('format', InputArgument::OPTIONAL, 'Pick your format name (e.g. <fg=yellow>yaml</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeSerializerEncoder.txt'))

--- a/src/Maker/MakeSerializerNormalizer.php
+++ b/src/Maker/MakeSerializerNormalizer.php
@@ -30,10 +30,14 @@ final class MakeSerializerNormalizer extends AbstractMaker
         return 'make:serializer:normalizer';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new serializer normalizer class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new serializer normalizer class')
             ->addArgument('name', InputArgument::OPTIONAL, 'Choose a class name for your normalizer (e.g. <fg=yellow>UserNormalizer</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeSerializerNormalizer.txt'))
         ;

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -41,10 +41,14 @@ final class MakeSubscriber extends AbstractMaker
         return 'make:subscriber';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new event subscriber class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new event subscriber class')
             ->addArgument('name', InputArgument::OPTIONAL, 'Choose a class name for your event subscriber (e.g. <fg=yellow>ExceptionSubscriber</>)')
             ->addArgument('event', InputArgument::OPTIONAL, 'What event do you want to subscribe to?')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeSubscriber.txt'))

--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -31,10 +31,14 @@ final class MakeTwigExtension extends AbstractMaker
         return 'make:twig-extension';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new Twig extension class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new Twig extension class')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the Twig extension class (e.g. <fg=yellow>AppExtension</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeTwigExtension.txt'))
         ;

--- a/src/Maker/MakeUnitTest.php
+++ b/src/Maker/MakeUnitTest.php
@@ -30,10 +30,14 @@ final class MakeUnitTest extends AbstractMaker
         return 'make:unit-test';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new unit test class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new unit test class')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the unit test class (e.g. <fg=yellow>UtilTest</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeUnitTest.txt'))
         ;

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -67,10 +67,14 @@ final class MakeUser extends AbstractMaker
         return 'make:user';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new security user class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new security user class')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the security user class (e.g. <fg=yellow>User</>)')
             ->addOption('is-entity', null, InputOption::VALUE_NONE, 'Do you want to store user data in the database (via Doctrine)?')
             ->addOption('identity-property-name', null, InputOption::VALUE_REQUIRED, 'Enter a property name that will be the unique "display" name for the user (e.g. <comment>email, username, uuid</comment>)')

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -32,10 +32,14 @@ final class MakeValidator extends AbstractMaker
         return 'make:validator';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new validator and constraint class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new validator and constraint class')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the validator class (e.g. <fg=yellow>EnabledValidator</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeValidator.txt'))
         ;

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -31,10 +31,14 @@ final class MakeVoter extends AbstractMaker
         return 'make:voter';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new security voter class';
+    }
+
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
-            ->setDescription('Creates a new security voter class')
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the security voter class (e.g. <fg=yellow>BlogPostVoter</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeVoter.txt'))
         ;

--- a/src/MakerInterface.php
+++ b/src/MakerInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Input\InputInterface;
 /**
  * Interface that all maker commands must implement.
  *
+ * @method string getCommandDescription()
+ *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
 interface MakerInterface

--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -12,11 +12,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class <?= $class_name; ?> extends Command
 {
     protected static $defaultName = '<?= $command_name; ?>';
+    protected static $defaultDescription = 'Add a short description for your command';
 
     protected function configure()
     {
         $this
-            ->setDescription('Add a short description for your command')
+<?= $set_description ? "            ->setDescription(self::\$defaultDescription)\n" : '' ?>
             ->addArgument('arg1', InputArgument::OPTIONAL, 'Argument description')
             ->addOption('option1', null, InputOption::VALUE_NONE, 'Option description')
         ;


### PR DESCRIPTION
Sidekick of https://github.com/symfony/symfony/pull/39851

When run with Symfony < 5.3, the generated commands are made forward-compatible with 5.3+