### PR TITLE
[ResetPassword] add api platform support

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -271,12 +271,39 @@ class MakeResetPassword extends AbstractMaker
             'reset_password/reset.html.twig',
             'resetPassword/twig_reset.tpl.php'
         );
-        
+
         if ($this->generateApi) {
-            // @TODO - Create DTO
-            // @TODO - Create Data Transformer
-            // @TODO - Create Data Persister
-            // @TODO - Add API DocBlocks to Entity 
+            $dtoClassNameDetails = $generator->createClassNameDetails(
+                'ResetPasswordInput',
+                'Dto\\'
+            );
+
+            $generator->generateClass(
+                $dtoClassNameDetails->getFullName(),
+                'resetPassword/ResetPasswordInput.tpl.php'
+            );
+
+            $dataTransformerClassNameDetails = $generator->createClassNameDetails(
+                'ResetPasswordInputDataTransformer',
+                'DataTransformer\\'
+            );
+
+            $generator->generateClass(
+                $dataTransformerClassNameDetails->getFullName(),
+                'resetPassword/ResetPasswordInputDataTransformer.tpl.php',
+            );
+
+            $dataPersisterClassNameDetails = $generator->createClassNameDetails(
+                'ResetPasswordDataPersister',
+                'DataPersister\\'
+            );
+
+            $generator->generateClass(
+                $dataPersisterClassNameDetails->getFullName(),
+                'resetPassword/ResetPasswordDataPersister.tpl.php'
+            );
+
+//             @TODO - Add API DocBlocks to Entity
         }
 
         $generator->writeChanges();

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -188,6 +188,26 @@ class MakeResetPassword extends AbstractMaker
             'Entity\\'
         );
 
+        $userDoctrineDetails = $this->doctrineHelper->createDoctrineDetails($userClassNameDetails->getFullName());
+
+        $userRepoVars = [
+            'repository_full_class_name' => 'Doctrine\ORM\EntityManagerInterface',
+            'repository_class_name' => 'EntityManagerInterface',
+            'repository_property_var' => 'manager',
+            'repository_var' => '$manager',
+        ];
+
+        if (null !== $userDoctrineDetails && null !== ($userRepository = $userDoctrineDetails->getRepositoryClass())) {
+            $userRepoClassDetails = $generator->createClassNameDetails('\\'.$userRepository, 'Repository\\', 'Repository');
+
+            $userRepoVars = [
+                'repository_full_class_name' => $userRepoClassDetails->getFullName(),
+                'repository_class_name' => $userRepoClassDetails->getShortName(),
+                'repository_property_var' => lcfirst($userRepoClassDetails->getShortName()),
+                'repository_var' => sprintf('$%s', lcfirst($userRepoClassDetails->getShortName())),
+            ];
+        }
+
         $controllerClassNameDetails = $generator->createClassNameDetails(
             'ResetPasswordController',
             'Controller\\'
@@ -300,7 +320,13 @@ class MakeResetPassword extends AbstractMaker
 
             $generator->generateClass(
                 $dataPersisterClassNameDetails->getFullName(),
-                'resetPassword/ResetPasswordDataPersister.tpl.php'
+                'resetPassword/ResetPasswordDataPersister.tpl.php',
+                array_merge([
+                    'user_full_class_name' => $userClassNameDetails->getFullName(),
+                    'user_class_name' => $userClassNameDetails->getShortName(),
+                    ],
+                    $userRepoVars
+                )
             );
 
 //             @TODO - Add API DocBlocks to Entity

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -55,6 +55,7 @@ class MakeResetPassword extends AbstractMaker
     private $fileManager;
     private $doctrineHelper;
     private $entityClassGenerator;
+    private $generateApi = false;
 
     public function __construct(FileManager $fileManager, DoctrineHelper $doctrineHelper, EntityClassGenerator $entityClassGenerator)
     {
@@ -172,6 +173,11 @@ class MakeResetPassword extends AbstractMaker
             [Validator::class, 'notBlank']
         )
         );
+
+        $this->generateApi = $io->confirm('Do you want to implement API based Password Resets?', false);
+        
+        //@TODO Check if API Platform is installed, if true - continue, if false - alert user composer require api-platform
+        // @TODO May make more sense to ask this at the top and fail if yes and api platform is not installed. 
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
@@ -265,6 +271,13 @@ class MakeResetPassword extends AbstractMaker
             'reset_password/reset.html.twig',
             'resetPassword/twig_reset.tpl.php'
         );
+        
+        if ($this->generateApi) {
+            // @TODO - Create DTO
+            // @TODO - Create Data Transformer
+            // @TODO - Create Data Persister
+            // @TODO - Add API DocBlocks to Entity 
+        }
 
         $generator->writeChanges();
 

--- a/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
@@ -5,23 +5,23 @@ namespace <?= $namespace ?>;
 use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use App\Dto\ResetPasswordInput;
-use App\Entity\User;
+use <?= $user_full_class_name ?>;
 use App\Message\SendResetPasswordMessage;
-use App\Repository\UserRepository;
+use <?= $repository_full_class_name ?>;
 use Symfony\Component\Messenger\MessageBusInterface;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
 class <?= $class_name ?> implements ContextAwareDataPersisterInterface
 {
-    private DataPersisterInterface $decoratedDataPersister;
-    private UserRepository $userRepository;
-    private ResetPasswordHelperInterface $resetPasswordHelper;
-    private MessageBusInterface $messageBus;
+    private <?= $use_typed_properties ? 'DataPersisterInterface ' : null ?> $decoratedDataPersister;
+    private <?= $use_typed_properties ? sprintf('%s %s', $repository_class_name, $repository_var) : $repository_var ?>;
+    private <?= $use_typed_properties ? 'ResetPasswordHelperInterface ' : null ?>$resetPasswordHelper;
+    private <?= $use_typed_properties ? 'MessageBusInterface ' : null ?>$messageBus;
 
-    public function __construct(DataPersisterInterface $decoratedDataPersister, UserRepository $userRepository, ResetPasswordHelperInterface $resetPasswordHelper, MessageBusInterface $messageBus)
+    public function __construct(DataPersisterInterface $decoratedDataPersister, <?= $repository_class_name ?> <?= $repository_var ?>, ResetPasswordHelperInterface $resetPasswordHelper, MessageBusInterface $messageBus)
     {
         $this->decoratedDataPersister = $decoratedDataPersister;
-        $this->userRepository = $userRepository;
+        $this-><?= $repository_property_var ?> = <?= $repository_var?>;
         $this->resetPasswordHelper = $resetPasswordHelper;
         $this->messageBus = $messageBus;
     }
@@ -36,9 +36,14 @@ class <?= $class_name ?> implements ContextAwareDataPersisterInterface
      */
     public function persist($data, array $context = []): void
     {
-        $user = $this->userRepository->findOneBy(['email' => $data->email]);
+<?php if ('$manager' === $repository_var): ?>
+        $repository = $this-><?= $repository_property_var ?>->getRepository(<?= $user_class_name ?>::class);
+        $user = $repository->findOneBy(['email' => $data->email]);
+<?php else: ?>
+        $user = $this-><?= $repository_property_var ?>->findOneBy(['email' => $data->email]);
+<?php endif; ?>
 
-        if (!$user instanceof User) {
+        if (!$user instanceof <?= $user_class_name?>) {
             return;
         }
 

--- a/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
@@ -1,6 +1,6 @@
-<?php
+<?= "<?php\n" ?>
 
-namespace App\DataPersister;
+namespace <?= $namespace ?>;
 
 use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
@@ -11,7 +11,7 @@ use App\Repository\UserRepository;
 use Symfony\Component\Messenger\MessageBusInterface;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
-class ResetPasswordDataPersister implements ContextAwareDataPersisterInterface
+class <?= $class_name ?> implements ContextAwareDataPersisterInterface
 {
     private DataPersisterInterface $decoratedDataPersister;
     private UserRepository $userRepository;
@@ -44,7 +44,6 @@ class ResetPasswordDataPersister implements ContextAwareDataPersisterInterface
 
         $token = $this->resetPasswordHelper->generateResetToken($user);
 
-        /** @psalm-suppress PossiblyNullArgument */
         $this->messageBus->dispatch(new SendResetPasswordMessage($user->getEmail(), $token));
 
         return;

--- a/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
@@ -3,38 +3,72 @@
 namespace <?= $namespace ?>;
 
 use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
-use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use App\Dto\ResetPasswordInput;
 use <?= $user_full_class_name ?>;
 use App\Message\SendResetPasswordMessage;
 use <?= $repository_full_class_name ?>;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 
 class <?= $class_name ?> implements ContextAwareDataPersisterInterface
 {
-    private <?= $use_typed_properties ? 'DataPersisterInterface ' : null ?> $decoratedDataPersister;
     private <?= $use_typed_properties ? sprintf('%s %s', $repository_class_name, $repository_var) : $repository_var ?>;
     private <?= $use_typed_properties ? 'ResetPasswordHelperInterface ' : null ?>$resetPasswordHelper;
     private <?= $use_typed_properties ? 'MessageBusInterface ' : null ?>$messageBus;
+    private <?= $use_typed_properties ? 'UserPasswordEncoderInterface ' : null ?>$userPasswordEncoder;
 
-    public function __construct(DataPersisterInterface $decoratedDataPersister, <?= $repository_class_name ?> <?= $repository_var ?>, ResetPasswordHelperInterface $resetPasswordHelper, MessageBusInterface $messageBus)
+    public function __construct(<?= $repository_class_name ?> <?= $repository_var ?>, ResetPasswordHelperInterface $resetPasswordHelper, MessageBusInterface $messageBus, UserPasswordEncoderInterface $userPasswordEncoder)
     {
-        $this->decoratedDataPersister = $decoratedDataPersister;
         $this-><?= $repository_property_var ?> = <?= $repository_var?>;
         $this->resetPasswordHelper = $resetPasswordHelper;
         $this->messageBus = $messageBus;
+        $this->userPasswordEncoder = $userPasswordEncoder;
     }
 
     public function supports($data, array $context = []): bool
     {
-        return $data instanceof ResetPasswordInput;
+        if (!$data instanceof ResetPasswordInput) {
+            return false;
+        }
+
+        if (isset($context['collection_operation_name']) && 'post' === $context['collection_operation_name']) {
+            return true;
+        }
+
+        if (isset($context['item_operation_name']) && 'put' === $context['item_operation_name']) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
      * @param ResetPasswordInput $data
      */
     public function persist($data, array $context = []): void
+    {
+        if (isset($context['collection_operation_name']) && 'post' === $context['collection_operation_name']) {
+            $this->generateRequest($data->email);
+
+            return;
+        }
+
+        if (isset($context['item_operation_name']) && 'put' === $context['item_operation_name']) {
+            if (!$context['previous_data'] instanceof <?= $user_class_name ?>) {
+                return;
+            }
+
+            $this->changePassword($context['previous_data'], $data->plainTextPassword);
+        }
+    }
+
+    public function remove($data, array $context = []): void
+    {
+        throw new \RuntimeException('Operation not supported.');
+    }
+
+    private function generateRequest(string $email): void
     {
 <?php if ('$manager' === $repository_var): ?>
         $repository = $this-><?= $repository_property_var ?>->getRepository(<?= $user_class_name ?>::class);
@@ -50,12 +84,31 @@ class <?= $class_name ?> implements ContextAwareDataPersisterInterface
         $token = $this->resetPasswordHelper->generateResetToken($user);
 
         $this->messageBus->dispatch(new SendResetPasswordMessage($user->getEmail(), $token));
-
-        return;
     }
 
-    public function remove($data, array $context = []): void
+    private function changePassword(<?= $user_class_name?> $previousUser, string $plainTextPassword): void
     {
-        $this->decoratedDataPersister->remove($data);
+        $userId = $previousUser->getId();
+
+<?php if ('$manager' === $repository_var): ?>
+        $repository = $this-><?= $repository_property_var ?>->getRepository(<?= $user_class_name ?>::class);
+        $user = $repository->find($userId);
+<?php else: ?>
+        $user = $this-><?= $repository_property_var ?>->find($userId);
+<?php endif; ?>
+
+        if (null === $user) {
+            return;
+        }
+
+        $encoded = $this->userPasswordEncoder->encodePassword($user, $plainTextPassword);
+
+<?php if ('$manager' === $repository_var): ?>
+        $user->setPassword($encoded);
+
+        $repository->flush();
+<?php else: ?>
+        $this-><?= $repository_property_var ?>->upgradePassword($user, $encoded);
+<?php endif; ?>
     }
 }

--- a/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordDataPersister.tpl.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\DataPersister;
+
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use ApiPlatform\Core\DataPersister\DataPersisterInterface;
+use App\Dto\ResetPasswordInput;
+use App\Entity\User;
+use App\Message\SendResetPasswordMessage;
+use App\Repository\UserRepository;
+use Symfony\Component\Messenger\MessageBusInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+class ResetPasswordDataPersister implements ContextAwareDataPersisterInterface
+{
+    private DataPersisterInterface $decoratedDataPersister;
+    private UserRepository $userRepository;
+    private ResetPasswordHelperInterface $resetPasswordHelper;
+    private MessageBusInterface $messageBus;
+
+    public function __construct(DataPersisterInterface $decoratedDataPersister, UserRepository $userRepository, ResetPasswordHelperInterface $resetPasswordHelper, MessageBusInterface $messageBus)
+    {
+        $this->decoratedDataPersister = $decoratedDataPersister;
+        $this->userRepository = $userRepository;
+        $this->resetPasswordHelper = $resetPasswordHelper;
+        $this->messageBus = $messageBus;
+    }
+
+    public function supports($data, array $context = []): bool
+    {
+        return $data instanceof ResetPasswordInput;
+    }
+
+    /**
+     * @param ResetPasswordInput $data
+     */
+    public function persist($data, array $context = []): void
+    {
+        $user = $this->userRepository->findOneBy(['email' => $data->email]);
+
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $token = $this->resetPasswordHelper->generateResetToken($user);
+
+        /** @psalm-suppress PossiblyNullArgument */
+        $this->messageBus->dispatch(new SendResetPasswordMessage($user->getEmail(), $token));
+
+        return;
+    }
+
+    public function remove($data, array $context = []): void
+    {
+        $this->decoratedDataPersister->remove($data);
+    }
+}

--- a/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
@@ -12,5 +12,5 @@ class <?= $class_name."\n" ?>
      * @Assert\NotBlank
      * @Assert\Email()
      */
-    public ?string $email = null;
+    public <?= $use_typed_properties ? '?string ' : null ?>$email = null;
 }

--- a/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Dto;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ResetPasswordInput
+{
+    /**
+     * @Groups({"reset-password:write"})
+     * @Assert\NotBlank
+     * @Assert\Email()
+     */
+    public ?string $email = null;
+}

--- a/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
@@ -8,9 +8,21 @@ use Symfony\Component\Validator\Constraints as Assert;
 class <?= $class_name."\n" ?>
 {
     /**
-     * @Groups({"reset-password:write"})
-     * @Assert\NotBlank
-     * @Assert\Email()
-     */
+    * @Assert\NotBlank(groups={"postValidation"})
+    * @Assert\Email(groups={"postValidation"})
+    * @Groups({"reset-password:post"})
+    */
     public <?= $use_typed_properties ? '?string ' : null ?>$email = null;
+
+    /**
+    * @Assert\NotBlank(groups={"putValidation"})
+    * @Groups({"reset-password:put"})
+    */
+    public <?= $use_typed_properties ? '?string ' : null ?>$token = null;
+
+    /**
+    * @Assert\NotBlank(groups={"putValidation"})
+    * @Groups({"reset-password:put"})
+    */
+    public <?= $use_typed_properties ? '?string ' : null ?>$plainTextPassword = null;
 }

--- a/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordInput.tpl.php
@@ -1,11 +1,11 @@
-<?php
+<?= "<?php\n" ?>
 
-namespace App\Dto;
+namespace <?= $namespace ?>;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class ResetPasswordInput
+class <?= $class_name."\n" ?>
 {
     /**
      * @Groups({"reset-password:write"})

--- a/src/Resources/skeleton/resetPassword/ResetPasswordInputDataTransformer.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordInputDataTransformer.tpl.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\DataTransformer;
+
+use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
+use App\Dto\ResetPasswordInput;
+use App\Entity\ResetPasswordRequest;
+
+class ResetPasswordInputDataTransformer implements DataTransformerInterface
+{
+    public function transform($object, string $to, array $context = []): object
+    {
+        return $object;
+    }
+
+    public function supportsTransformation($data, string $to, array $context = []): bool
+    {
+        if ($data instanceof ResetPasswordRequest) {
+            return false;
+        }
+
+        return ResetPasswordRequest::class === $to && ($context['input']['class'] ?? null) === ResetPasswordInput::class;
+    }
+}

--- a/src/Resources/skeleton/resetPassword/ResetPasswordInputDataTransformer.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordInputDataTransformer.tpl.php
@@ -1,12 +1,12 @@
-<?php
+<?= "<?php\n" ?>
 
-namespace App\DataTransformer;
+namespace <?= $namespace ?>;
 
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use App\Dto\ResetPasswordInput;
 use App\Entity\ResetPasswordRequest;
 
-class ResetPasswordInputDataTransformer implements DataTransformerInterface
+class <?= $class_name ?> implements DataTransformerInterface
 {
     public function transform($object, string $to, array $context = []): object
     {

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -24,11 +24,11 @@ class MakeResetPasswordTest extends MakerTestCase
         yield 'reset_password_replaces_flex_config' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeResetPassword::class),
             [
-                'App\Entity\User',
-                'app_home',
-                'jr@rushlow.dev',
-                'SymfonyCasts',
-                false, // No Api
+                'App\Entity\User', // User Entity
+                'app_home', // Redirect route after successful reset
+                'jr@rushlow.dev', // Email from address
+                'SymfonyCasts', // Email from name
+                'n', // Generate API templates
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -71,11 +71,11 @@ class MakeResetPasswordTest extends MakerTestCase
         yield 'reset_password_custom_config' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeResetPassword::class),
             [
-                'App\Entity\User',
-                'app_home',
-                'jr@rushlow.dev',
-                'SymfonyCasts',
-                false, // No Api
+                'App\Entity\User', // User Entity
+                'app_home', // Redirect route after successful reset
+                'jr@rushlow.dev', // Email from address
+                'SymfonyCasts', // Email from name
+                'n', // Generate API templates
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -99,11 +99,11 @@ class MakeResetPasswordTest extends MakerTestCase
         yield 'reset_password_amends_config' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeResetPassword::class),
             [
-                'App\Entity\User',
-                'app_home',
-                'jr@rushlow.dev',
-                'SymfonyCasts',
-                false, // No Api
+                'App\Entity\User', // User Entity
+                'app_home', // Redirect route after successful reset
+                'jr@rushlow.dev', // Email from address
+                'SymfonyCasts', // Email from name
+                'n', // Generate API templates
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -131,11 +131,11 @@ class MakeResetPasswordTest extends MakerTestCase
         yield 'reset_password_functional_test' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeResetPassword::class),
             [
-                'App\Entity\User',
-                'app_home',
-                'jr@rushlow.dev',
-                'SymfonyCasts',
-                false, // No Api
+                'App\Entity\User', // User Entity
+                'app_home', // Redirect route after successful reset
+                'jr@rushlow.dev', // Email from address
+                'SymfonyCasts', // Email from name
+                'n', // Generate API templates
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('doctrine')
@@ -151,13 +151,13 @@ class MakeResetPasswordTest extends MakerTestCase
         yield 'reset_password_custom_user' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeResetPassword::class),
             [
-                'App\Entity\UserCustom',
-                'emailAddress',
-                'setMyPassword',
-                'app_home',
-                'jr@rushlow.dev',
-                'SymfonyCasts',
-                false, // No Api
+                'App\Entity\UserCustom', // User Entity
+                'emailAddress', // Email property
+                'setMyPassword', // Email setter
+                'app_home', // Redirect route after successful reset
+                'jr@rushlow.dev', // Email from address
+                'SymfonyCasts', // Email from name
+                'n', // Generate API Templates
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -189,22 +189,19 @@ class MakeResetPasswordTest extends MakerTestCase
         yield 'reset_password_api' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeResetPassword::class),
             [
-                'App\Entity\User',
-                'emailAddress',
-                'setMyPassword',
-                'app_home',
-                'jr@rushlow.dev',
-                'SymfonyCasts',
-                true, // Generate API Objects
+                'App\Entity\User', // User Entity
+                'app_home', // Redirect route after successful reset
+                'jr@rushlow.dev', // Email from address
+                'SymfonyCasts', // Email from name
+                'y', // Generate API templates
             ])
             ->setRequiredPhpVersion(70200)
-            ->addExtraDependencies('api-platform')
+            ->addExtraDependencies('api')
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
-            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordApiFixtures')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordApi')
             ->assert(
                 function (string $output, string $directory) {
-                    $this->markTestIncomplete('NOT YET IMPLEMENTED');
 
                     $this->assertStringContainsString('Success', $output);
 
@@ -212,8 +209,8 @@ class MakeResetPasswordTest extends MakerTestCase
 
                     $generatedFiles = [
                         'src/DataPersister/ResetPasswordDataPersister.php',
-                        'src/DataTransformer/ResetPasswordInputDateTransformer.php',
-                        'src/Dto/ResetPasswordInput',
+                        'src/DataTransformer/ResetPasswordInputDataTransformer.php',
+                        'src/Dto/ResetPasswordInput.php',
                     ];
 
                     foreach ($generatedFiles as $file) {
@@ -237,11 +234,11 @@ class MakeResetPasswordTest extends MakerTestCase
         yield 'reset_password_api_functional_test' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeResetPassword::class),
             [
-                'App\Entity\User',
-                'app_home',
-                'jr@rushlow.dev',
-                'SymfonyCasts',
-                true, // Generate API Objects
+                'App\Entity\User', // User Entity
+                'app_home', // Redirect route after successful reset
+                'jr@rushlow.dev', // Email from address
+                'SymfonyCasts', // Email from name
+                'y', // Generate API templates
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('api-platform')
@@ -255,5 +252,4 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordApiFunctionalTest'),
         ];
     }
-
 }

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -28,6 +28,7 @@ class MakeResetPasswordTest extends MakerTestCase
                 'app_home',
                 'jr@rushlow.dev',
                 'SymfonyCasts',
+                false, // No Api
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -74,6 +75,7 @@ class MakeResetPasswordTest extends MakerTestCase
                 'app_home',
                 'jr@rushlow.dev',
                 'SymfonyCasts',
+                false, // No Api
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -101,6 +103,7 @@ class MakeResetPasswordTest extends MakerTestCase
                 'app_home',
                 'jr@rushlow.dev',
                 'SymfonyCasts',
+                false, // No Api
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -132,6 +135,7 @@ class MakeResetPasswordTest extends MakerTestCase
                 'app_home',
                 'jr@rushlow.dev',
                 'SymfonyCasts',
+                false, // No Api
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('doctrine')
@@ -153,6 +157,7 @@ class MakeResetPasswordTest extends MakerTestCase
                 'app_home',
                 'jr@rushlow.dev',
                 'SymfonyCasts',
+                false, // No Api
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
@@ -180,5 +185,75 @@ class MakeResetPasswordTest extends MakerTestCase
                 }
             ),
         ];
+
+        yield 'reset_password_api' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeResetPassword::class),
+            [
+                'App\Entity\User',
+                'emailAddress',
+                'setMyPassword',
+                'app_home',
+                'jr@rushlow.dev',
+                'SymfonyCasts',
+                true, // Generate API Objects
+            ])
+            ->setRequiredPhpVersion(70200)
+            ->addExtraDependencies('api-platform')
+            ->addExtraDependencies('security-bundle')
+            ->addExtraDependencies('twig')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordApiFixtures')
+            ->assert(
+                function (string $output, string $directory) {
+                    $this->markTestIncomplete('NOT YET IMPLEMENTED');
+
+                    $this->assertStringContainsString('Success', $output);
+
+                    $fs = new Filesystem();
+
+                    $generatedFiles = [
+                        'src/DataPersister/ResetPasswordDataPersister.php',
+                        'src/DataTransformer/ResetPasswordInputDateTransformer.php',
+                        'src/Dto/ResetPasswordInput',
+                    ];
+
+                    foreach ($generatedFiles as $file) {
+                        $this->assertTrue($fs->exists(sprintf('%s/%s', $directory, $file)));
+                    }
+
+                    // check ResetPasswordDto
+                    $contentResetPasswordInput = file_get_contents($directory.'/src/Dto/ResetPasswordInput.php');
+                    $this->assertStringContainsString('@Groups({"reset-password:write"})', $contentResetPasswordInput);
+                    $this->assertStringContainsString('public ?string $email = null;', $contentResetPasswordInput);
+
+                    // check ResetPasswordInputDataTransformer
+                    $contentResetPasswordDataTransformer = file_get_contents($directory.'/src/DataTransformer/ResetPasswordInputDataTransformer.php');
+
+                    // check ResetPasswordDataPersister
+                    $contentResetPasswordRequestFormType = file_get_contents($directory.'/src/DataPersister/ResetPasswordDataPersister.php');
+                }
+            ),
+        ];
+
+        yield 'reset_password_api_functional_test' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeResetPassword::class),
+            [
+                'App\Entity\User',
+                'app_home',
+                'jr@rushlow.dev',
+                'SymfonyCasts',
+                true, // Generate API Objects
+            ])
+            ->setRequiredPhpVersion(70200)
+            ->addExtraDependencies('api-platform')
+            ->addExtraDependencies('doctrine')
+            ->addExtraDependencies('doctrine/annotations')
+            ->addExtraDependencies('mailer')
+            ->addExtraDependencies('security-bundle')
+            ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/validator')
+            ->addExtraDependencies('twig')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordApiFunctionalTest'),
+        ];
     }
+
 }

--- a/tests/fixtures/MakeResetPasswordApi/config/packages/security.yml
+++ b/tests/fixtures/MakeResetPasswordApi/config/packages/security.yml
@@ -1,0 +1,3 @@
+security:
+    encoders:
+        App\Entity\User: bcrypt

--- a/tests/fixtures/MakeResetPasswordApi/src/Entity/User.php
+++ b/tests/fixtures/MakeResetPasswordApi/src/Entity/User.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Entity;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    private $email;
+
+    public function getEmail()
+    {
+    }
+
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function setPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}


### PR DESCRIPTION
Goal is to provide out of the box support for API Platform keeping REST & GraphQL capabilities intact.

- [ ] support for Messenger
- [ ] allow API Only
- [ ] allow No API
- [ ] allow both

refs https://github.com/SymfonyCasts/reset-password-bundle/issues/128