### PR TITLE
[make:auth] handle session deprecations in 5.3

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -403,11 +403,12 @@ final class MakeAuthenticator extends AbstractMaker
     private function providerKeyTypeHint(): string
     {
         $reflectionMethod = new \ReflectionMethod(AbstractFormLoginAuthenticator::class, 'onAuthenticationSuccess');
-        $typeHint = (string) $reflectionMethod->getParameters()[2]->getType();
-        if ($typeHint) {
-            $typeHint .= ' ';
+        $type = $reflectionMethod->getParameters()[2]->getType();
+
+        if (!$type instanceof \ReflectionNamedType) {
+            return '';
         }
 
-        return $typeHint;
+        return sprintf('%s ', $type->getName());
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -21,7 +21,7 @@ class GeneratorTest extends TestCase
     /**
      * @dataProvider getClassNameDetailsTests
      */
-    public function testCreateClassNameDetails(string $name, string $prefix, string $suffix = '', string $expectedFullClassName, string $expectedRelativeClassName)
+    public function testCreateClassNameDetails(string $name, string $prefix, string $suffix, string $expectedFullClassName, string $expectedRelativeClassName): void
     {
         $fileManager = $this->createMock(FileManager::class);
         $fileManager->expects($this->any())
@@ -38,7 +38,7 @@ class GeneratorTest extends TestCase
         $this->assertSame($expectedRelativeClassName, $classNameDetails->getRelativeName());
     }
 
-    public function getClassNameDetailsTests()
+    public function getClassNameDetailsTests(): \Generator
     {
         yield 'simple_class' => [
             'foo',

--- a/tests/fixtures/MakeAuthenticatorLoginFormUserEntity/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorLoginFormUserEntity/tests/SecurityControllerTest.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use App\Security\AppCustomAuthenticator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\Kernel;
 
 class SecurityControllerTest extends WebTestCase
 {
@@ -60,7 +61,17 @@ class SecurityControllerTest extends WebTestCase
         $client->submit($form);
 
         $this->assertStringContainsString('TODO: provide a valid redirect', $client->getResponse()->getContent());
-        $this->assertNotNull($token = $client->getContainer()->get('security.token_storage')->getToken());
+
+        $tokenStorage = static::$container->get('security.token_storage');
+
+        // Handle Session deprecations in Symfony 5.3+
+        if (Kernel::VERSION_ID >= 50300) {
+            $tokenStorage->disableUsageTracking();
+        }
+
+        $token = $tokenStorage->getToken();
+
+        self::assertNotNull($token);
         $this->assertInstanceOf(User::class, $token->getUser());
     }
 }

--- a/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/tests/SecurityControllerTest.php
+++ b/tests/fixtures/MakeAuthenticatorSecurity52LoginForm/tests/SecurityControllerTest.php
@@ -6,6 +6,7 @@ use App\Entity\User;
 use App\Security\AppTestSecurity52LoginFormAuthenticator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -68,7 +69,17 @@ class SecurityControllerTest extends WebTestCase
         $client->submit($form);
 
         self::assertStringContainsString('TODO: provide a valid redirect', $client->getResponse()->getContent());
-        self::assertNotNull($token = $client->getContainer()->get('security.token_storage')->getToken());
+
+        $tokenStorage = static::$container->get('security.token_storage');
+
+        // Handle Session deprecations in Symfony 5.3+
+        if (Kernel::VERSION_ID >= 50300) {
+            $tokenStorage->disableUsageTracking();
+        }
+
+        $token = $tokenStorage->getToken();
+
+        self::assertNotNull($token);
         self::assertInstanceOf(User::class, $token->getUser());
     }
 }


### PR DESCRIPTION
- fixed deprecated ReflectionType::__toString() (MakeAuthenticatorTest) Deprecated in PHP 7.1
- removes unneeded optional param - triggers required param order deprecation in PHP8 (GeneratorTest)
- handles Session deprecation's introduced in Symfony 5.3 in test suites