### PR TITLE
Enhancement: Fullfill interface and move comments to the method description

### DIFF
--- a/tests/Security/fixtures/expected/UserEntityEmailWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityEmailWithPassword.php
@@ -95,11 +95,14 @@ class User implements UserInterface
     }
 
     /**
+     * Returning a salt is only needed, if you are not using a modern
+     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     *
      * @see UserInterface
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
-        // not needed when using the "bcrypt" algorithm in security.yaml
+        return null;
     }
 
     /**

--- a/tests/Security/fixtures/expected/UserEntityUser_nameWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityUser_nameWithPassword.php
@@ -90,11 +90,14 @@ class User implements UserInterface
     }
 
     /**
+     * Returning a salt is only needed, if you are not using a modern
+     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     *
      * @see UserInterface
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
-        // not needed when using the "bcrypt" algorithm in security.yaml
+        return null;
     }
 
     /**

--- a/tests/Security/fixtures/expected/UserEntityUsernameNoPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityUsernameNoPassword.php
@@ -69,19 +69,23 @@ class User implements UserInterface
     }
 
     /**
+     * This method is not needed for apps that do not check user passwords.
+     *
      * @see UserInterface
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
-        // not needed for apps that do not check user passwords
+        return null;
     }
 
     /**
+     * This method is not needed for apps that do not check user passwords.
+     *
      * @see UserInterface
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
-        // not needed for apps that do not check user passwords
+        return null;
     }
 
     /**

--- a/tests/Security/fixtures/expected/UserEntityUsernameWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityUsernameWithPassword.php
@@ -90,11 +90,14 @@ class User implements UserInterface
     }
 
     /**
+     * Returning a salt is only needed, if you are not using a modern
+     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     *
      * @see UserInterface
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
-        // not needed when using the "bcrypt" algorithm in security.yaml
+        return null;
     }
 
     /**

--- a/tests/Security/fixtures/expected/UserModelEmailWithPassword.php
+++ b/tests/Security/fixtures/expected/UserModelEmailWithPassword.php
@@ -72,11 +72,14 @@ class User implements UserInterface
     }
 
     /**
+     * Returning a salt is only needed, if you are not using a modern
+     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     *
      * @see UserInterface
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
-        // not needed when using the "bcrypt" algorithm in security.yaml
+        return null;
     }
 
     /**

--- a/tests/Security/fixtures/expected/UserModelUsernameNoPassword.php
+++ b/tests/Security/fixtures/expected/UserModelUsernameNoPassword.php
@@ -47,19 +47,23 @@ class User implements UserInterface
     }
 
     /**
+     * This method is not needed for apps that do not check user passwords.
+     *
      * @see UserInterface
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
-        // not needed for apps that do not check user passwords
+        return null;
     }
 
     /**
+     * This method is not needed for apps that do not check user passwords.
+     *
      * @see UserInterface
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
-        // not needed for apps that do not check user passwords
+        return null;
     }
 
     /**

--- a/tests/Security/fixtures/expected/UserModelUsernameWithPassword.php
+++ b/tests/Security/fixtures/expected/UserModelUsernameWithPassword.php
@@ -67,11 +67,14 @@ class User implements UserInterface
     }
 
     /**
+     * Returning a salt is only needed, if you are not using a modern
+     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     *
      * @see UserInterface
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
-        // not needed when using the "bcrypt" algorithm in security.yaml
+        return null;
     }
 
     /**


### PR DESCRIPTION
Before this fix, static analyzers are complaining:
```
Return type (void) of method App\Entity\User::getSalt() should be compatible with return type (string|null) of method Symfony\Component\Security\Core\User\UserInterface::getSalt()
```

cc @chalasr 