### PR TITLE
[make:auth] fix user email field with capital `E`

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -283,7 +283,7 @@ final class MakeAuthenticator extends AbstractMaker
                 'user_class_name' => $userClassNameDetails->getShortName(),
                 'username_field' => $userNameField,
                 'username_field_label' => Str::asHumanWords($userNameField),
-                'username_field_var' => Str::asCamelCase($userNameField),
+                'username_field_var' => Str::asLowerCamelCase($userNameField),
                 'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
                 'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
                 'provider_key_type_hint' => $this->providerKeyTypeHint(),


### PR DESCRIPTION
We were using the wrong `Str` camel case method to generate the username field variable for the authenticator template.

```diff
// class ACustomAuthenticator extends AbstractLoginFormAuthenticator

...

public function authenticate(Request $request): PassportInterface
{
- $Email = $request->request->get('email', '');
+ $email = $request->request->get('email', '');

...
}
```