### PR TITLE
drop symfony 3.x support && firm up PHP 8 tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 env:
     PHPUNIT_FLAGS: "-v"
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
-    SYMFONY_REQUIRE: ">=3.4"
+    SYMFONY_REQUIRE: ">=4.0"
 
 jobs:
     coding-standards:
@@ -43,7 +43,7 @@ jobs:
                 name: "Composer install"
                 uses: "ramsey/composer-install@v1"
                 with:
-                    composer-options: "--no-suggest --no-scripts"
+                    composer-options: "--no-scripts"
 
             -
                 name: "Run friendsofphp/php-cs-fixer"
@@ -84,11 +84,9 @@ jobs:
                 include:
                     - php-version: '7.4'
                       symfony-skeleton-stability: 'dev'
-                      composer-options: '--no-suggest'
                       allow-failures: true
                     - php-version: '8.0'
                       symfony-skeleton-stability: 'dev'
-                      composer-options: '--no-suggest --ignore-platform-req=php'
                       allow-failures: true
 
         steps:

--- a/.twig_cs.dist
+++ b/.twig_cs.dist
@@ -1,0 +1,8 @@
+<?php
+
+use FriendsOfTwig\Twigcs\Config\Config;
+use Symfony\Bundle\MakerBundle\Test\MakerTwigRuleSet;
+
+return Config::create()
+    ->setRuleSet(MakerTwigRuleSet::class)
+;

--- a/composer.json
+++ b/composer.json
@@ -16,26 +16,26 @@
         "php": ">=7.1.3",
         "doctrine/inflector": "^1.2|^2.0",
         "nikic/php-parser": "^4.0",
-        "symfony/config": "^3.4|^4.0|^5.0",
-        "symfony/console": "^3.4|^4.0|^5.0",
-        "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+        "symfony/config": "^4.0|^5.0",
+        "symfony/console": "^4.0|^5.0",
+        "symfony/dependency-injection": "^4.0|^5.0",
         "symfony/deprecation-contracts": "^2.2",
-        "symfony/filesystem": "^3.4|^4.0|^5.0",
-        "symfony/finder": "^3.4|^4.0|^5.0",
-        "symfony/framework-bundle": "^3.4|^4.0|^5.0",
-        "symfony/http-kernel": "^3.4|^4.0|^5.0"
+        "symfony/filesystem": "^4.0|^5.0",
+        "symfony/finder": "^4.0|^5.0",
+        "symfony/framework-bundle": "^4.0|^5.0",
+        "symfony/http-kernel": "^4.0|^5.0"
     },
     "require-dev": {
         "composer/semver": "^3.0@dev",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.8",
-        "friendsoftwig/twigcs": "^3.1.2",
+        "friendsoftwig/twigcs": "^4.1.0|^5.0.0",
         "symfony/http-client": "^4.3|^5.0",
         "symfony/phpunit-bridge": "^4.3|^5.0",
-        "symfony/process": "^3.4|^4.0|^5.0",
-        "symfony/security-core": "^3.4|^4.0|^5.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0"
+        "symfony/process": "^4.0|^5.0",
+        "symfony/security-core": "^4.0|^5.0",
+        "symfony/yaml": "^4.0|^5.0"
     },
     "config": {
         "preferred-install": "dist",

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -272,7 +272,7 @@ final class MakerTestEnvironment
 
     public function runTwigCSLint(string $file)
     {
-        return MakerTestProcess::create(sprintf('php vendor/bin/twigcs lint %s', $this->path.'/'.$file), $this->rootPath)
+        return MakerTestProcess::create(sprintf('php vendor/bin/twigcs --config ./.twig_cs.dist %s', $this->path.'/'.$file), $this->rootPath)
                                ->run(true);
     }
 

--- a/src/Test/MakerTwigRuleSet.php
+++ b/src/Test/MakerTwigRuleSet.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Test;
+
+use FriendsOfTwig\Twigcs\RegEngine\RulesetBuilder;
+use FriendsOfTwig\Twigcs\RegEngine\RulesetConfigurator;
+use FriendsOfTwig\Twigcs\Rule;
+use FriendsOfTwig\Twigcs\Ruleset\RulesetInterface;
+use FriendsOfTwig\Twigcs\Validator\Violation;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+final class MakerTwigRuleSet implements RulesetInterface
+{
+    private $twigMajorVersion;
+
+    public function __construct(int $twigMajorVersion)
+    {
+        $this->twigMajorVersion = $twigMajorVersion;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRules(): array
+    {
+        $configurator = new RulesetConfigurator();
+        $configurator->setTwigMajorVersion($this->twigMajorVersion);
+        $builder = new RulesetBuilder($configurator);
+
+        return [
+            new Rule\RegEngineRule(Violation::SEVERITY_ERROR, $builder->build()),
+            new Rule\TrailingSpace(Violation::SEVERITY_ERROR),
+            new Rule\UnusedMacro(Violation::SEVERITY_WARNING),
+            new Rule\UnusedVariable(Violation::SEVERITY_WARNING),
+        ];
+    }
+}


### PR DESCRIPTION
- upgrade `twigcs` to version 5.x for PHP8 support. `twigcs` v4.x is required for PHP 7.1 support
- drops official support for Symfony 3.x in MakerBundle