### PR TITLE
[make:command] lets use attributes if possible

### DIFF
--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -63,6 +64,7 @@ final class MakeCommand extends AbstractMaker
             [
                 'command_name' => $commandName,
                 'set_description' => !class_exists(LazyCommand::class),
+                'use_command_attribute' => 80000 <= \PHP_VERSION_ID && class_exists(AsCommand::class),
             ]
         );
 

--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -2,6 +2,9 @@
 
 namespace <?= $namespace; ?>;
 
+<?php if ($use_attributes && $use_command_attribute): ?>
+use Symfony\Component\Console\Attribute\AsCommand;
+<?php endif; ?>
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -9,11 +12,19 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+<?php if ($use_attributes && $use_command_attribute): ?>
+#[AsCommand(
+    name: '<?= $command_name; ?>',
+    description: 'Add a short description for your command',
+)]
+<?php endif; ?>
 class <?= $class_name; ?> extends Command
 {
+<?php if (!$use_attributes || !$use_command_attribute): ?>
     protected static $defaultName = '<?= $command_name; ?>';
     protected static $defaultDescription = 'Add a short description for your command';
 
+<?php endif; ?>
     protected function configure()
     {
         $this

--- a/tests/Maker/MakeCommandTest.php
+++ b/tests/Maker/MakeCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
 
 class MakeCommandTest extends MakerTestCase
 {
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'command' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeCommand::class),
@@ -36,6 +36,25 @@ class MakeCommandTest extends MakerTestCase
             ])
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeCommandInCustomRootNamespace')
             ->changeRootNamespace('Custom'),
+        ];
+
+        yield 'command_with_attributes' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeCommand::class),
+            [
+                // command name
+                'app:foo',
+            ])
+            ->setRequiredPhpVersion(80000)
+            ->addRequiredPackageVersion('symfony/console', '>=5.3')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeCommand')
+            ->assert(
+                static function (string $output, string $directory) {
+                    $commandFileContents = file_get_contents(sprintf('%s/src/Command/FooCommand.php', $directory));
+
+                    self::assertStringContainsString('use Symfony\Component\Console\Attribute\AsCommand;', $commandFileContents);
+                    self::assertStringContainsString('#[AsCommand(', $commandFileContents);
+                }
+            ),
         ];
     }
 }


### PR DESCRIPTION
Console command attribute class renamed from `ConsoleCommand` => `AsCommand` https://github.com/symfony/symfony/pull/40556

closes #820 