### PR TITLE
[make:crud] use POST method instead of DELETE

### DIFF
--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -114,10 +114,10 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 
 <?php if ($use_attributes) { ?>
-    #[Route('/{<?= $entity_identifier ?>}', name: '<?= $route_name ?>_delete', methods: ['DELETE'])]
+    #[Route('/{<?= $entity_identifier ?>}', name: '<?= $route_name ?>_delete', methods: ['POST'])]
 <?php } else { ?>
     /**
-     * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_delete", methods={"DELETE"})
+     * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_delete", methods={"POST"})
      */
 <?php } ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response

--- a/src/Resources/skeleton/crud/templates/_delete_form.tpl.php
+++ b/src/Resources/skeleton/crud/templates/_delete_form.tpl.php
@@ -1,5 +1,4 @@
 <form method="post" action="{{ path('<?= $route_name ?>_delete', {'<?= $entity_identifier ?>': <?= $entity_twig_var_singular ?>.<?= $entity_identifier ?>}) }}" onsubmit="return confirm('Are you sure you want to delete this item?');">
-    <input type="hidden" name="_method" value="DELETE">
     <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ <?= $entity_twig_var_singular ?>.<?= $entity_identifier ?>) }}">
     <button class="btn">Delete</button>
 </form>


### PR DESCRIPTION
Starting in Symfony 5.3, `framework.http_method_override` defaults to `false`. This prevents CRUD form submission for `PUT`, `PATCH` &/or `DELETE` methods.  See symfony/recipes#892

~This PR conditionally sets  `http_method_override` to true when using `make:crud` if using Symfony 5.3+~

We stop using the `DELETE` method override in favor of using `POST` on the delete operation.