### PR TITLE
[CI] run tests on ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     coding-standards:
         name: "Coding Standards (${{ matrix.php-version }})"
 
-        runs-on: "ubuntu-latest"
+        runs-on: "ubuntu-18.04"
 
         strategy:
             fail-fast: false
@@ -52,7 +52,7 @@ jobs:
     test:
         name: "PHP ${{ matrix.php-version }} + symfony/skeleton@${{ matrix.symfony-skeleton-stability }}"
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
 
         services:
             mysql:


### PR DESCRIPTION
Use ubuntu 1804 for tests that rely on PHP `<7.4`. Github released base image `ubuntu-latest` which uses `ubuntu-20.04` - the 20.04 does not have PHP 7.0 - 7.3. Previously, `ubuntu-latest` was based on `ubuntu-18.04`

In maker this caused our stable tests against 7.1, .2 & .3 to fail with a PDO Driver Error. Which is ultimately because the base 18.04 image does not have the required PHP version.