### PR TITLE
Extend Yaml manipulator add_item_and_sort test

### DIFF
--- a/tests/Util/yaml_fixtures/add_item_and_sort_natural.test
+++ b/tests/Util/yaml_fixtures/add_item_and_sort_natural.test
@@ -1,0 +1,21 @@
+page_types:
+    - App\Entity\Page\ContentPage
+    - App\Entity\Page\ErrorPage
+    - App\Entity\Page\HomePage
+    - App\Entity\Page\OverviewPage
+options:
+    A: 1
+    B: 2
+===
+$data['page_types'][] = 'App\Entity\Page\NewsPage';
+sort($data['page_types'], SORT_NATURAL);
+===
+page_types:
+    - App\Entity\Page\ContentPage
+    - App\Entity\Page\ErrorPage
+    - App\Entity\Page\HomePage
+    - App\Entity\Page\NewsPage
+    - App\Entity\Page\OverviewPage
+options:
+    A: 1
+    B: 2


### PR DESCRIPTION
This case is the subject of issue #618 

Apparently this does work now, because it passes the test. Maybe it still is a good idea to extend this test so no bugs will creep in in the future