### PR TITLE
[CI] run CI at least once per day

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     push:
         branches:
             - 'main'
+    schedule:
+        -   cron: '0 0 * * *'
 
 env:
     PHPUNIT_FLAGS: "-v"


### PR DESCRIPTION
Having a scheduled CI run will make it easier to track down upstream stream breaking changes. Especially when we don't have any push activity for days on end. 

As a side effect, this will also give us better insight into the state of the Symfony eco-system as a whole as maker bundle tests just about every Symfony package in a simulated "real life" application. 