### PR TITLE
[BC BREAK] fix (DoctrineHelper): Doctrine bundle 2.3.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "composer/semver": "^3.0@dev",
-        "doctrine/doctrine-bundle": "^1.8|^2.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.8",
         "friendsoftwig/twigcs": "^4.1.0|^5.0.0",

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -97,11 +97,11 @@ final class DoctrineHelper
 
         $metadataDriver = $em->getConfiguration()->getMetadataDriverImpl();
 
-        if (!$this->isInstanceOf($metadataDriver, MappingDriverChain::class)) {
+        if (!$this->isInstanceOf($metadataDriver->getDriver(), MappingDriverChain::class)) {
             return $metadataDriver;
         }
 
-        foreach ($metadataDriver->getDrivers() as $namespace => $driver) {
+        foreach ($metadataDriver->getDriver()->getDrivers() as $namespace => $driver) {
             if (0 === strpos($className, $namespace)) {
                 return $driver;
             }


### PR DESCRIPTION
Fixes #841 

Doctrine Bundle 2.3.0 introduced a new Mapping\MappingDriver class, which doesn't give access to the MappingDriverChain anymore.
A PR has been made for it [1304](https://github.com/doctrine/DoctrineBundle/pull/1304) and is required for this to work.