### PR TITLE
[make:user] user entities implement PasswordAuthenticatedUserInterface

### DIFF
--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -15,6 +15,8 @@ use Doctrine\Common\Persistence\ManagerRegistry as LegacyManagerRegistry;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @internal
@@ -69,6 +71,15 @@ final class EntityClassGenerator
     {
         $shortEntityClass = Str::getShortClassName($entityClass);
         $entityAlias = strtolower($shortEntityClass[0]);
+
+        $passwordUserInterfaceName = UserInterface::class;
+
+        if (interface_exists(PasswordAuthenticatedUserInterface::class)) {
+            $passwordUserInterfaceName = PasswordAuthenticatedUserInterface::class;
+        }
+
+        $interfaceClassNameDetails = new ClassNameDetails($passwordUserInterfaceName, 'Symfony\Component\Security\Core\User');
+
         $this->generator->generateClass(
             $repositoryClass,
             'doctrine/Repository.tpl.php',
@@ -77,6 +88,7 @@ final class EntityClassGenerator
                 'entity_class_name' => $shortEntityClass,
                 'entity_alias' => $entityAlias,
                 'with_password_upgrade' => $withPasswordUpgrade,
+                'password_upgrade_user_interface' => $interfaceClassNameDetails,
                 'doctrine_registry_class' => $this->managerRegistryClassName,
                 'include_example_comments' => $includeExampleComments,
             ]

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -159,10 +159,8 @@ final class MakeUser extends AbstractMaker
             true
         );
         $manipulator->setIo($io);
-        $this->userClassBuilder->addUserInterfaceImplementation(
-            $manipulator,
-            $userClassConfiguration
-        );
+
+        $this->userClassBuilder->addUserInterfaceImplementation($manipulator, $userClassConfiguration);
 
         $generator->dumpFile($classPath, $manipulator->getSourceCode());
 

--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -6,8 +6,9 @@ use <?= $entity_full_class_name; ?>;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use <?= $doctrine_registry_class; ?>;
 <?= $with_password_upgrade ? "use Symfony\Component\Security\Core\Exception\UnsupportedUserException;\n" : '' ?>
+<?= ($with_password_upgrade && str_contains($password_upgrade_user_interface->getFullName(), 'Password')) ? sprintf("use %s;\n", $password_upgrade_user_interface->getFullName()) : null ?>
 <?= $with_password_upgrade ? "use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;\n" : '' ?>
-<?= $with_password_upgrade ? "use Symfony\Component\Security\Core\User\UserInterface;\n" : '' ?>
+<?= ($with_password_upgrade && str_contains($password_upgrade_user_interface->getFullName(), '\UserInterface')) ? sprintf("use %s;\n", $password_upgrade_user_interface->getFullName()) : null ?>
 
 /**
  * @method <?= $entity_class_name; ?>|null find($id, $lockMode = null, $lockVersion = null)
@@ -28,7 +29,7 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
     /**
      * Used to upgrade (rehash) the user's password automatically over time.
      */
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    public function upgradePassword(<?= sprintf('%s ', $password_upgrade_user_interface->getShortName()); ?>$user, string $newEncodedPassword): void
     {
         if (!$user instanceof <?= $entity_class_name ?>) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));

--- a/tests/Maker/MakeUserTest.php
+++ b/tests/Maker/MakeUserTest.php
@@ -27,7 +27,7 @@ class MakeUserTest extends MakerTestCase
                 'y', // entity
                 'email', // identity property
                 'y', // with password
-                'y', // argon
+                'y', // argon   @TODO This should only be done in <5.0
             ])
             ->addExtraDependencies('doctrine')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeUserEntityPassword')
@@ -35,6 +35,20 @@ class MakeUserTest extends MakerTestCase
             ->addExtraDependencies('doctrine')
             ->setGuardAuthenticator('main', 'App\\Security\\AutomaticAuthenticator')
             ->updateSchemaAfterCommand(),
+        ];
+
+        yield 'user_security_entity_with_password_authenticated_user_interface' => [MakerTestDetails::createTest(
+            $this->getMakerInstance(MakeUser::class),
+            [
+                // user class name
+                'User',
+                'y', // entity
+                'email', // identity property
+                'y', // with password
+            ])
+            ->addRequiredPackageVersion('symfony/security-bundle', '>=5.3')
+            ->addExtraDependencies('doctrine')
+            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeUserEntityPasswordAuthenticatedUserInterface'),
         ];
 
         yield 'user_security_model_no_password' => [MakerTestDetails::createTest(

--- a/tests/Security/UserClassBuilderTest.php
+++ b/tests/Security/UserClassBuilderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Security\UserClassBuilder;
 use Symfony\Bundle\MakerBundle\Security\UserClassConfiguration;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 class UserClassBuilderTest extends TestCase
 {
@@ -33,7 +34,15 @@ class UserClassBuilderTest extends TestCase
         $classBuilder = new UserClassBuilder();
         $classBuilder->addUserInterfaceImplementation($manipulator, $userClassConfig);
 
-        $expectedPath = __DIR__.'/fixtures/expected/'.$expectedFilename;
+        $expectedPath = __DIR__.'/fixtures/expected';
+
+        // Can be removed when < Symfony 6 support is dropped.
+        if (!interface_exists(PasswordAuthenticatedUserInterface::class)) {
+            $expectedPath = sprintf('%s/legacy', $expectedPath);
+        }
+
+        $expectedPath = sprintf('%s/%s', $expectedPath, $expectedFilename);
+
         if (!file_exists($expectedPath)) {
             throw new \Exception(sprintf('Expected file missing: "%s"', $expectedPath));
         }

--- a/tests/Security/fixtures/expected/UserEntityEmailWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityEmailWithPassword.php
@@ -3,12 +3,13 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @ORM\Entity()
  */
-class User implements UserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * @ORM\Id
@@ -80,11 +81,11 @@ class User implements UserInterface
     }
 
     /**
-     * @see UserInterface
+     * @see PasswordAuthenticatedUserInterface
      */
     public function getPassword(): string
     {
-        return (string) $this->password;
+        return $this->password;
     }
 
     public function setPassword(string $password): self

--- a/tests/Security/fixtures/expected/UserEntityUser_nameWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityUser_nameWithPassword.php
@@ -3,12 +3,13 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @ORM\Entity()
  */
-class User implements UserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * @ORM\Id
@@ -75,11 +76,11 @@ class User implements UserInterface
     }
 
     /**
-     * @see UserInterface
+     * @see PasswordAuthenticatedUserInterface
      */
     public function getPassword(): string
     {
-        return (string) $this->password;
+        return $this->password;
     }
 
     public function setPassword(string $password): self

--- a/tests/Security/fixtures/expected/UserEntityUsernameNoPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityUsernameNoPassword.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -69,9 +70,9 @@ class User implements UserInterface
     }
 
     /**
-     * This method is not needed for apps that do not check user passwords.
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
      *
-     * @see UserInterface
+     * @see PasswordAuthenticatedUserInterface
      */
     public function getPassword(): ?string
     {
@@ -79,7 +80,7 @@ class User implements UserInterface
     }
 
     /**
-     * This method is not needed for apps that do not check user passwords.
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
      *
      * @see UserInterface
      */

--- a/tests/Security/fixtures/expected/UserEntityUsernameWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityUsernameWithPassword.php
@@ -3,12 +3,13 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @ORM\Entity()
  */
-class User implements UserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * @ORM\Id
@@ -75,11 +76,11 @@ class User implements UserInterface
     }
 
     /**
-     * @see UserInterface
+     * @see PasswordAuthenticatedUserInterface
      */
     public function getPassword(): string
     {
-        return (string) $this->password;
+        return $this->password;
     }
 
     public function setPassword(string $password): self

--- a/tests/Security/fixtures/expected/UserModelUsernameNoPassword.php
+++ b/tests/Security/fixtures/expected/UserModelUsernameNoPassword.php
@@ -2,6 +2,7 @@
 
 namespace App\Security;
 
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class User implements UserInterface
@@ -47,9 +48,9 @@ class User implements UserInterface
     }
 
     /**
-     * This method is not needed for apps that do not check user passwords.
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
      *
-     * @see UserInterface
+     * @see PasswordAuthenticatedUserInterface
      */
     public function getPassword(): ?string
     {
@@ -57,7 +58,7 @@ class User implements UserInterface
     }
 
     /**
-     * This method is not needed for apps that do not check user passwords.
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
      *
      * @see UserInterface
      */

--- a/tests/Security/fixtures/expected/legacy/UserEntityEmailWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy/UserEntityEmailWithPassword.php
@@ -1,20 +1,42 @@
 <?php
 
-namespace App\Security;
+namespace App\Entity;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+/**
+ * @ORM\Entity()
+ */
+class User implements UserInterface
 {
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=180, unique=true)
+     */
     private $email;
 
+    /**
+     * @ORM\Column(type="json")
+     */
     private $roles = [];
 
     /**
      * @var string The hashed password
+     * @ORM\Column(type="string")
      */
     private $password;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
 
     public function getEmail(): ?string
     {
@@ -58,7 +80,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see PasswordAuthenticatedUserInterface
+     * @see UserInterface
      */
     public function getPassword(): string
     {

--- a/tests/Security/fixtures/expected/legacy/UserEntityUser_nameWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy/UserEntityUser_nameWithPassword.php
@@ -1,31 +1,41 @@
 <?php
 
-namespace App\Security;
+namespace App\Entity;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+/**
+ * @ORM\Entity()
+ */
+class User implements UserInterface
 {
-    private $email;
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
 
+    /**
+     * @ORM\Column(type="string", length=180, unique=true)
+     */
+    private $user_name;
+
+    /**
+     * @ORM\Column(type="json")
+     */
     private $roles = [];
 
     /**
      * @var string The hashed password
+     * @ORM\Column(type="string")
      */
     private $password;
 
-    public function getEmail(): ?string
+    public function getId(): ?int
     {
-        return $this->email;
-    }
-
-    public function setEmail(string $email): self
-    {
-        $this->email = $email;
-
-        return $this;
+        return $this->id;
     }
 
     /**
@@ -35,7 +45,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getUsername(): string
     {
-        return (string) $this->email;
+        return (string) $this->user_name;
+    }
+
+    public function setUserName(string $user_name): self
+    {
+        $this->user_name = $user_name;
+
+        return $this;
     }
 
     /**
@@ -58,7 +75,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see PasswordAuthenticatedUserInterface
+     * @see UserInterface
      */
     public function getPassword(): string
     {

--- a/tests/Security/fixtures/expected/legacy/UserEntityUsernameNoPassword.php
+++ b/tests/Security/fixtures/expected/legacy/UserEntityUsernameNoPassword.php
@@ -1,31 +1,35 @@
 <?php
 
-namespace App\Security;
+namespace App\Entity;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+/**
+ * @ORM\Entity()
+ */
+class User implements UserInterface
 {
-    private $email;
-
-    private $roles = [];
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
 
     /**
-     * @var string The hashed password
+     * @ORM\Column(type="string", length=180, unique=true)
      */
-    private $password;
+    private $username;
 
-    public function getEmail(): ?string
+    /**
+     * @ORM\Column(type="json")
+     */
+    private $roles = [];
+
+    public function getId(): ?int
     {
-        return $this->email;
-    }
-
-    public function setEmail(string $email): self
-    {
-        $this->email = $email;
-
-        return $this;
+        return $this->id;
     }
 
     /**
@@ -35,7 +39,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getUsername(): string
     {
-        return (string) $this->email;
+        return (string) $this->username;
+    }
+
+    public function setUsername(string $username): self
+    {
+        $this->username = $username;
+
+        return $this;
     }
 
     /**
@@ -58,23 +69,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see PasswordAuthenticatedUserInterface
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
+     *
+     * @see UserInterface
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
-        return $this->password;
-    }
-
-    public function setPassword(string $password): self
-    {
-        $this->password = $password;
-
-        return $this;
+        return null;
     }
 
     /**
-     * Returning a salt is only needed, if you are not using a modern
-     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
      *
      * @see UserInterface
      */

--- a/tests/Security/fixtures/expected/legacy/UserEntityUsernameWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy/UserEntityUsernameWithPassword.php
@@ -1,31 +1,41 @@
 <?php
 
-namespace App\Security;
+namespace App\Entity;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+/**
+ * @ORM\Entity()
+ */
+class User implements UserInterface
 {
-    private $email;
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
 
+    /**
+     * @ORM\Column(type="string", length=180, unique=true)
+     */
+    private $username;
+
+    /**
+     * @ORM\Column(type="json")
+     */
     private $roles = [];
 
     /**
      * @var string The hashed password
+     * @ORM\Column(type="string")
      */
     private $password;
 
-    public function getEmail(): ?string
+    public function getId(): ?int
     {
-        return $this->email;
-    }
-
-    public function setEmail(string $email): self
-    {
-        $this->email = $email;
-
-        return $this;
+        return $this->id;
     }
 
     /**
@@ -35,7 +45,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getUsername(): string
     {
-        return (string) $this->email;
+        return (string) $this->username;
+    }
+
+    public function setUsername(string $username): self
+    {
+        $this->username = $username;
+
+        return $this;
     }
 
     /**
@@ -58,7 +75,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see PasswordAuthenticatedUserInterface
+     * @see UserInterface
      */
     public function getPassword(): string
     {

--- a/tests/Security/fixtures/expected/legacy/UserModelEmailWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy/UserModelEmailWithPassword.php
@@ -2,10 +2,9 @@
 
 namespace App\Security;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+class User implements UserInterface
 {
     private $email;
 
@@ -58,7 +57,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see PasswordAuthenticatedUserInterface
+     * @see UserInterface
      */
     public function getPassword(): string
     {

--- a/tests/Security/fixtures/expected/legacy/UserModelUsernameNoPassword.php
+++ b/tests/Security/fixtures/expected/legacy/UserModelUsernameNoPassword.php
@@ -2,19 +2,13 @@
 
 namespace App\Security;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+class User implements UserInterface
 {
     private $username;
 
     private $roles = [];
-
-    /**
-     * @var string The hashed password
-     */
-    private $password;
 
     /**
      * A visual identifier that represents this user.
@@ -53,23 +47,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see PasswordAuthenticatedUserInterface
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
+     *
+     * @see UserInterface
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
-        return $this->password;
-    }
-
-    public function setPassword(string $password): self
-    {
-        $this->password = $password;
-
-        return $this;
+        return null;
     }
 
     /**
-     * Returning a salt is only needed, if you are not using a modern
-     * hashing algorithm (e.g. bcrypt or sodium) in your security.yaml.
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
      *
      * @see UserInterface
      */

--- a/tests/Security/fixtures/expected/legacy/UserModelUsernameWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy/UserModelUsernameWithPassword.php
@@ -2,12 +2,11 @@
 
 namespace App\Security;
 
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class User implements UserInterface, PasswordAuthenticatedUserInterface
+class User implements UserInterface
 {
-    private $email;
+    private $username;
 
     private $roles = [];
 
@@ -16,18 +15,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     private $password;
 
-    public function getEmail(): ?string
-    {
-        return $this->email;
-    }
-
-    public function setEmail(string $email): self
-    {
-        $this->email = $email;
-
-        return $this;
-    }
-
     /**
      * A visual identifier that represents this user.
      *
@@ -35,7 +22,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getUsername(): string
     {
-        return (string) $this->email;
+        return (string) $this->username;
+    }
+
+    public function setUsername(string $username): self
+    {
+        $this->username = $username;
+
+        return $this;
     }
 
     /**
@@ -58,7 +52,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @see PasswordAuthenticatedUserInterface
+     * @see UserInterface
      */
     public function getPassword(): string
     {

--- a/tests/fixtures/MakeUserEntityPasswordAuthenticatedUserInterface/tests/GeneratedEntityTest.php
+++ b/tests/fixtures/MakeUserEntityPasswordAuthenticatedUserInterface/tests/GeneratedEntityTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+
+class GeneratedEntityTest extends WebTestCase
+{
+    public function testImplementsPasswordAuthenticatedUserInterface()
+    {
+        $reflectedUser = new \ReflectionClass(User::class);
+
+        self::assertTrue($reflectedUser->implementsInterface(PasswordAuthenticatedUserInterface::class));
+        self::assertTrue($reflectedUser->hasMethod('getPassword'));
+    }
+}


### PR DESCRIPTION
Starting in Symfony 5.3 - PR https://github.com/symfony/symfony/pull/40267 introduces the new `PasswordAuthenticatedUserInterface` ~& `LegacyPasswordAuthenticatedUserInterface`~ aimed at decoupling passwords from the `UserInterface`.

- Generated `User` entity implements `PasswordAuthenticatedUserInterface` if it exists.
- Adds correct type hint to the generated `UserRepository::upgradePassword()` method.

Authentication related changes are handled in #824

// cc @chalasr 