### PR TITLE
[tests][make:migration] handle shebang line in output

### DIFF
--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -76,7 +76,15 @@ class MakeMigrationTest extends MakerTestCase
             ->assert(function (string $output, string $directory) {
                 $this->assertStringContainsString('You have 1 available migrations to execute', $output);
                 $this->assertStringContainsString('Success', $output);
-                $this->assertCount(14, explode("\n", $output), 'Asserting that very specific output is shown - some should be hidden');
+
+                $output = explode("\n", $output);
+
+                $expectedCount = str_contains($output[0], 'php') ? 15 : 14;
+
+                $this->assertCount(
+                    $expectedCount,
+                    $output, 'Asserting that very specific output is shown - some should be hidden'
+                );
             }),
         ];
 


### PR DESCRIPTION
PHP 7.4 dev tests failing due to 

```
1) Symfony\Bundle\MakerBundle\Tests\Maker\MakeMigrationTest::testExecute with data set "migration_with_previous_migration_question" (Symfony\Bundle\MakerBundle\Test\MakerTestDetails Object (...))
Asserting that very specific output is shown - some should be hidden
Failed asserting that actual size 15 matches expected size 14.
```

![image](https://user-images.githubusercontent.com/40327885/112362640-08ced100-8cab-11eb-851d-737b42121dd0.png)

This PR accounts for the shebang line in the make:migration test assertion.