### PR TITLE
[make:voter] generate type hints

### DIFF
--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 /**
@@ -36,7 +37,7 @@ final class MakeVoter extends AbstractMaker
         return 'Creates a new security voter class';
     }
 
-    public function configureCommand(Command $command, InputConfiguration $inputConf)
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the security voter class (e.g. <fg=yellow>BlogPostVoter</>)')
@@ -44,7 +45,7 @@ final class MakeVoter extends AbstractMaker
         ;
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $voterClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
@@ -55,7 +56,9 @@ final class MakeVoter extends AbstractMaker
         $generator->generateClass(
             $voterClassNameDetails->getFullName(),
             'security/Voter.tpl.php',
-            []
+            [
+                'use_type_hints' => 50000 <= Kernel::VERSION_ID,
+            ]
         );
 
         $generator->writeChanges();
@@ -68,7 +71,7 @@ final class MakeVoter extends AbstractMaker
         ]);
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public function configureDependencies(DependencyBuilder $dependencies): void
     {
         $dependencies->addClassDependency(
             Voter::class,

--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -8,7 +8,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class <?= $class_name ?> extends Voter
 {
-    protected function supports($attribute, $subject)
+    protected function supports(<?= $use_type_hints ? 'string ' : null ?>$attribute, $subject): bool
     {
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
@@ -16,7 +16,7 @@ class <?= $class_name ?> extends Voter
             && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;
     }
 
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    protected function voteOnAttribute(<?= $use_type_hints ? 'string ' : null ?>$attribute, $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access


### PR DESCRIPTION
starting in Symfony 5.0 the abstract voter methods introduced type hints (https://github.com/symfony/symfony/commit/8c46b95ec2958cec3e3f7e6dab858c4c29b20770). We now conditionally generate the `string` type hint for the `$attribute` argument.

Minor cleanup of the maker itself.