### PR TITLE
[make:controller] avoid require doctrine/annotation when can use attributes

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -15,7 +15,6 @@ use Doctrine\Common\Annotations\Annotation;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
-use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
@@ -38,10 +37,10 @@ final class MakeController extends AbstractMaker
 {
     private $phpCompatUtil;
 
-    public function __construct(FileManager $fileManager, PhpCompatUtil $phpCompatUtil = null)
+    public function __construct(PhpCompatUtil $phpCompatUtil = null)
     {
         if (null === $phpCompatUtil) {
-            $phpCompatUtil = new PhpCompatUtil($fileManager);
+            @trigger_error(sprintf('Passing a "%s" instance is mandatory since version 1.42.0', PhpCompatUtil::class), \E_USER_DEPRECATED);
         }
 
         $this->phpCompatUtil = $phpCompatUtil;
@@ -114,7 +113,8 @@ final class MakeController extends AbstractMaker
 
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
-        if (60000 <= Kernel::VERSION_ID && $this->phpCompatUtil->canUseAttributes()) {
+        // @legacy - Remove method when support for Symfony 5.4 is dropped
+        if (null !== $this->phpCompatUtil && 60000 <= Kernel::VERSION_ID && $this->phpCompatUtil->canUseAttributes()) {
             return;
         }
 

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -113,7 +114,7 @@ final class MakeController extends AbstractMaker
 
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
-        if ($this->phpCompatUtil->canUseAttributes()) {
+        if (60000 <= Kernel::VERSION_ID && $this->phpCompatUtil->canUseAttributes()) {
             return;
         }
 

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -15,9 +15,11 @@ use Doctrine\Common\Annotations\Annotation;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
@@ -33,6 +35,17 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 final class MakeController extends AbstractMaker
 {
+    private $phpCompatUtil;
+
+    public function __construct(FileManager $fileManager, PhpCompatUtil $phpCompatUtil = null)
+    {
+        if (null === $phpCompatUtil) {
+            $phpCompatUtil = new PhpCompatUtil($fileManager);
+        }
+
+        $this->phpCompatUtil = $phpCompatUtil;
+    }
+
     public static function getCommandName(): string
     {
         return 'make:controller';
@@ -100,6 +113,10 @@ final class MakeController extends AbstractMaker
 
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
+        if ($this->phpCompatUtil->canUseAttributes()) {
+            return;
+        }
+
         $dependencies->addClassDependency(
             Annotation::class,
             'doctrine/annotations'

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -22,7 +22,6 @@
             </service>
 
             <service id="maker.maker.make_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeController">
-                <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.php_compat_util" />
                 <tag name="maker.command" />
             </service>

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -22,6 +22,8 @@
             </service>
 
             <service id="maker.maker.make_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeController">
+                <argument type="service" id="maker.file_manager" />
+                <argument type="service" id="maker.php_compat_util" />
                 <tag name="maker.command" />
             </service>
 


### PR DESCRIPTION
Hi makers :wave: !

This PR allows to make controller when we can use PHP8 attributes without forcing to install `doctrine/annotation`

But we should be aware that currently, without `doctrine/annotation`, we don't have a nice flex recipe that enable routing annotation read on Controller folder.

See https://github.com/symfony/recipes/pull/916 for reference.

So maybe we should create the config/routes/annotation.yaml in case we can use attributes AND file does not exist ? WDYT ? 
