### PR TITLE
Add support for Symfony UX Turbo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,17 @@ jobs:
                 ports:
                     - 3306
                 options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+            mercure:
+                image: dunglas/mercure
+                env:
+                    SERVER_NAME: :1337
+                    MERCURE_PUBLISHER_JWT_KEY: '!ChangeMe!'
+                    MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeMe!'
+                    MERCURE_EXTRA_DIRECTIVES: |
+                        anonymous
+                        cors_origins *
+                ports:
+                    - 1337:1337
 
         continue-on-error: ${{ matrix.allow-failures }}
 

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -33,7 +33,7 @@ final class EntityClassGenerator
         $this->doctrineHelper = $doctrineHelper;
     }
 
-    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true): string
+    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true, bool $broadcast = false): string
     {
         $repoClassDetails = $this->generator->createClassNameDetails(
             $entityClassDetails->getRelativeName(),
@@ -50,6 +50,7 @@ final class EntityClassGenerator
                 'repository_full_class_name' => $repoClassDetails->getFullName(),
                 'repository_class_name' => $repoClassDetails->getShortName(),
                 'api_resource' => $apiResource,
+                'broadcast' => $broadcast,
                 'should_escape_table_name' => $this->doctrineHelper->isKeyword($tableName),
                 'table_name' => $tableName,
             ]

--- a/src/Resources/help/MakeEntity.txt
+++ b/src/Resources/help/MakeEntity.txt
@@ -9,6 +9,11 @@ automatically be available for this entity class:
 
 <info>php %command.full_name% --api-resource</info>
 
+Symfony can also broadcast all changes made to the entity to the client using Symfony
+UX Turbo.
+
+<info>php %command.full_name% --broadcast</info>
+
 You can also generate all the getter/setter/adder/remover methods
 for the properties of existing entities:
 

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -6,9 +6,13 @@ namespace <?= $namespace ?>;
 <?php endif ?>
 use <?= $repository_full_class_name ?>;
 use Doctrine\ORM\Mapping as ORM;
+<?php if ($broadcast): ?>use Symfony\UX\Turbo\Attribute\Broadcast;
+<?php endif ?>
 
 /**
 <?php if ($api_resource && !$use_attributes): ?> * @ApiResource()
+<?php endif ?>
+<?php if ($broadcast && !$use_attributes): ?> * @Broadcast()
 <?php endif ?>
  * @ORM\Entity(repositoryClass=<?= $repository_class_name ?>::class)
 <?php if ($should_escape_table_name): ?> * @ORM\Table(name="`<?= $table_name ?>`")
@@ -16,6 +20,9 @@ use Doctrine\ORM\Mapping as ORM;
  */
 <?php if ($api_resource && $use_attributes): ?>
 #[ApiResource]
+<?php endif ?>
+<?php if ($broadcast && $use_attributes): ?>
+#[Broadcast]
 <?php endif ?>
 class <?= $class_name."\n" ?>
 {

--- a/src/Resources/skeleton/doctrine/broadcast_twig_template.tpl.php
+++ b/src/Resources/skeleton/doctrine/broadcast_twig_template.tpl.php
@@ -1,0 +1,22 @@
+{# Learn how to use Turbo Streams: https://github.com/symfony/ux-turbo#broadcast-doctrine-entities-update #}
+{% block create %}
+<turbo-stream action="append" target="<?= $class_name_plural ?>">
+    <template>
+        <div id="{{ '<?= $class_name ?>_' ~ id }}">
+            #{{ id }} created
+        </div>
+    </template>
+</turbo-stream>
+{% endblock %}
+
+{% block update %}
+<turbo-stream action="update" target="<?= $class_name ?>_{{ id }}">
+    <template>
+        #{{ id }} updated
+    </template>
+</turbo-stream>
+{% endblock %}
+
+{% block remove %}
+<turbo-stream action="remove" target="<?= $class_name ?>_{{ id }}"></turbo-stream>
+{% endblock %}


### PR DESCRIPTION
This PR adds a new `--broadcast` to the `make:entity` command. This generates the required template to use the broadcasting feature of UX Turbo, and also add the `#[Broadcast]` attribute to the generated entity.