### PR TITLE
[ci] fix incompatible flex branches globally vs tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,11 @@ jobs:
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: "Require symfony/flex"
+              if: contains('stable', env.SYMFONY_SKELETON_STABILITY)
+              run: composer global require --no-progress --no-scripts --no-plugins symfony/flex
+
+            - name: "Require symfony/flex dev-main"
+              if: contains('dev', env.SYMFONY_SKELETON_STABILITY)
               run: composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-main
 
             - name: "Composer install"


### PR DESCRIPTION
Problem: In CI globally we were requiring `symfony/flex@dev-main` && in stable tests `symfony/flex` (versioned release). This caused tests to explode when `dev-main` was out of sync with `stable`.

Solution: Conditionally require `dev-main` || `stable` for `symfony/flex` depending on `SYMFONY_SKELETON_STABILITY` 