### PR TITLE
[make:serializer:encoder] set public constant visibility modifier

### DIFF
--- a/src/Resources/skeleton/serializer/Encoder.tpl.php
+++ b/src/Resources/skeleton/serializer/Encoder.tpl.php
@@ -7,7 +7,7 @@ use Symfony\Component\Serializer\Encoder\EncoderInterface;
 
 class <?= $class_name ?> implements EncoderInterface, DecoderInterface
 {
-    const FORMAT = '<?= $format ?>';
+    public const FORMAT = '<?= $format ?>';
 
     public function encode($data, $format, array $context = [])
     {


### PR DESCRIPTION
Since PHP 7.1 - class constants can have a visibility modifier. The Symfony coding standards require the visibility modifier to be set. 

`make:serializer:encoder` now defaults to the `public` modifier for the `FORMAT` const.