### PR TITLE
[make:crud] Fix templates path use in include

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -193,6 +193,7 @@ final class MakeCrud extends AbstractMaker
                 'entity_twig_var_singular' => $entityTwigVarSingular,
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath,
             ],
             'index' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
@@ -205,6 +206,7 @@ final class MakeCrud extends AbstractMaker
             'new' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath,
             ],
             'show' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
@@ -212,6 +214,7 @@ final class MakeCrud extends AbstractMaker
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                 'entity_fields' => $entityDoctrineDetails->getDisplayFields(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath,
             ],
         ];
 

--- a/src/Resources/skeleton/crud/templates/edit.tpl.php
+++ b/src/Resources/skeleton/crud/templates/edit.tpl.php
@@ -3,9 +3,9 @@
 {% block body %}
     <h1>Edit <?= $entity_class_name ?></h1>
 
-    {{ include('<?= $route_name ?>/_form.html.twig', {'button_label': 'Update'}) }}
+    {{ include('<?= $templates_path ?>/_form.html.twig', {'button_label': 'Update'}) }}
 
     <a href="{{ path('<?= $route_name ?>_index') }}">back to list</a>
 
-    {{ include('<?= $route_name ?>/_delete_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_delete_form.html.twig') }}
 {% endblock %}

--- a/src/Resources/skeleton/crud/templates/new.tpl.php
+++ b/src/Resources/skeleton/crud/templates/new.tpl.php
@@ -3,7 +3,7 @@
 {% block body %}
     <h1>Create new <?= $entity_class_name ?></h1>
 
-    {{ include('<?= $route_name ?>/_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_form.html.twig') }}
 
     <a href="{{ path('<?= $route_name ?>_index') }}">back to list</a>
 {% endblock %}

--- a/src/Resources/skeleton/crud/templates/show.tpl.php
+++ b/src/Resources/skeleton/crud/templates/show.tpl.php
@@ -18,5 +18,5 @@
 
     <a href="{{ path('<?= $route_name ?>_edit', {'<?= $entity_identifier ?>': <?= $entity_twig_var_singular ?>.<?= $entity_identifier ?>}) }}">edit</a>
 
-    {{ include('<?= $route_name ?>/_delete_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_delete_form.html.twig') }}
 {% endblock %}


### PR DESCRIPTION
The maker CRUD allow to set a namespace in the controller name (example : `Admin\ArticleController`). In this case, maker create namespace and folders for the templates.

```
s.leblanc@cronos $ symfony console make:crud Article

 Choose a name for your controller class (e.g. ArticleController) [ArticleController]:
 > Admin\ArticleController

 created: src/Controller/Admin/ArticleController.php
 created: src/Form/ArticleType.php
 created: templates/admin/article/_delete_form.html.twig
 created: templates/admin/article/_form.html.twig
 created: templates/admin/article/edit.html.twig
 created: templates/admin/article/index.html.twig
 created: templates/admin/article/new.html.twig
 created: templates/admin/article/show.html.twig
```

The controller is OK, the render function is call with the good path : `admin/article/index.html.twig`

But in the template, when we include the form or the delete form, the path is build with route name (`admin_article`) instead of path (`admin/article`)

This path fix this issue