### PR TITLE
[ci] set server version in dsn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
 
         services:
             mysql:
-                image: mysql:5.7
+                image: mysql:5.7 # Update server_version in phpunit.xml.dist if this changes.
                 env:
                     MYSQL_ROOT_PASSWORD: root
                     MYSQL_DATABASE: test_maker

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="TEST_DATABASE_DSN" value="mysql://root:root@127.0.0.1:3306/test_maker" />
+        <env name="TEST_DATABASE_DSN" value="mysql://root:root@127.0.0.1:3306/test_maker?serverVersion=5.7" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -144,13 +144,6 @@ final class MakerTestDetails
             )
         ;
 
-        // use MySQL 5.6, which is what's currently available on Travis
-        $this->addReplacement(
-            'config/packages/doctrine.yaml',
-            "#server_version: '13'",
-            "server_version: '5.7'"
-        );
-
         // this looks silly, but it's the only way to drop the database *for sure*,
         // as doctrine:database:drop will error if there is no database
         // also, skip for SQLITE, as it does not support --if-not-exists


### PR DESCRIPTION
`doctrine.dbal.server_version` is no longer available - set the server version explicitly in the dsn.

https://github.com/symfony/recipes/pull/939

- [x] `dev` stability testing failing until https://github.com/symfony/recipes/pull/945