### PR TITLE
[ci][make-controller] set framework.test in test env

### DIFF
--- a/tests/fixtures/MakeController/config/packages/framework.yaml
+++ b/tests/fixtures/MakeController/config/packages/framework.yaml
@@ -1,2 +1,0 @@
-framework:
-  ide: 'phpstorm://open?file=%%f&line=%%l'


### PR DESCRIPTION
fixes 
```
1) Symfony\Bundle\MakerBundle\Tests\Maker\MakeControllerTest::testExecute with data set "controller_basic" (Symfony\Bundle\MakerBundle\Test\MakerTestDetails Object (...))
Error while running the PHPUnit tests *in* the project: 

 
PHPUnit 8.5.15 by Sebastian Bergmann and contributors.

Testing Project Test Suite
E                                                                   1 / 1 (100%)

Time: 162 ms, Memory: 20.00 MB

There was 1 error:

1) App\Tests\GeneratedControllerTest::testController
LogicException: You cannot create the client used in functional tests if the "framework.test" config is not set to true.

/var/htdocs/tests/tmp/cache/maker_app_f06e46ebe75d42ea9e9b63872d47e20b5.x-dev/vendor/symfony/framework-bundle/Test/WebTestCase.php:52
/var/htdocs/tests/tmp/cache/maker_app_f06e46ebe75d42ea9e9b63872d47e20b5.x-dev/tests/GeneratedControllerTest.php:11
```