### PR TITLE
[make:entity] Add @method tags to Doctrine repositories

### DIFF
--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -129,7 +129,6 @@ final class DoctrineHelper
         if ($this->isDoctrineInstalled()) {
             $allMetadata = $this->getMetadata();
 
-            /* @var ClassMetadata $metadata */
             foreach (array_keys($allMetadata) as $classname) {
                 $entityClassDetails = new ClassNameDetails($classname, $this->entityNamespace);
                 $entities[] = $entityClassDetails->getRelativeName();
@@ -142,7 +141,7 @@ final class DoctrineHelper
     }
 
     /**
-     * @return array|ClassMetadata|LegacyClassMetadata
+     * @return ClassMetadata|ClassMetadata[]|LegacyClassMetadata|LegacyClassMetadata[]
      */
     public function getMetadata(string $classOrNamespace = null, bool $disconnected = false)
     {

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -81,7 +81,7 @@ final class EntityClassGenerator
 
         $interfaceClassNameDetails = new ClassNameDetails($passwordUserInterfaceName, 'Symfony\Component\Security\Core\User');
 
-        $this->generator->generateClass(
+        return $this->generator->generateClass(
             $repositoryClass,
             'doctrine/Repository.tpl.php',
             [

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -334,6 +334,89 @@ final class ClassSourceManipulator
     public function addAnnotationToClass(string $annotationClass, array $options)
     {
         $annotationClassAlias = $this->addUseStatementIfNecessary($annotationClass);
+
+        $this->modifyClassDocBlock(function (array $docLines) use ($annotationClassAlias, $options) {
+            array_splice(
+                $docLines,
+                \count($docLines) - 1,
+                0,
+                ' * '.$this->buildAnnotationLine('@'.$annotationClassAlias, $options)
+            );
+
+            return $docLines;
+        });
+
+        $this->updateSourceCodeFromNewStmts();
+    }
+
+    public function addEntityRepositoryAtMethodDocBlock(string $propertyName, string $className)
+    {
+        $shortClassName = $this->addUseStatementIfNecessary($className);
+        $methodNameSuffix = Str::asCamelCase($propertyName);
+        $argumentName = Str::asLowerCamelCase($propertyName);
+
+        $methodTags = [
+            $methodName = 'findOneBy'.$methodNameSuffix => sprintf(
+                ' * @method %s|null %s($%s, array $orderBy = null)',
+                $shortClassName,
+                $methodName,
+                $argumentName
+            ),
+            $methodName = 'findBy'.$methodNameSuffix => sprintf(
+                ' * @method %s[]    %s($%s, array $orderBy = null, $limit = null, $offset = null)',
+                $shortClassName,
+                $methodName,
+                $argumentName
+            ),
+            $methodName = 'countBy'.$methodNameSuffix => sprintf(
+                ' * @method int%s   %s($%s)',
+                str_repeat(' ', \strlen($shortClassName)),
+                $methodName,
+                $argumentName
+            ),
+        ];
+
+        $this->modifyClassDocBlock(function (array $docLines) use ($methodTags) {
+            // Loop through the existing tags to avoid duplication
+            foreach ($docLines as &$docLine) {
+                if (empty($methodTags)) {
+                    break;
+                }
+
+                foreach ($methodTags as $methodName => $methodTag) {
+                    if (false === strpos($docLine, '@method') || false === strpos($docLine, $methodName.'(')) {
+                        continue;
+                    }
+
+                    // If overwrite is true, replace the existing tag
+                    if ($this->overwrite) {
+                        $docLine = $methodTag;
+                    }
+
+                    unset($methodTags[$methodName]);
+
+                    break;
+                }
+            }
+
+            // Append new tags
+            foreach ($methodTags as $methodTag) {
+                array_splice(
+                    $docLines,
+                    \count($docLines) - 1,
+                    0,
+                    $methodTag
+                );
+            }
+
+            return $docLines;
+        });
+
+        $this->updateSourceCodeFromNewStmts();
+    }
+
+    private function modifyClassDocBlock(callable $modifierCallback)
+    {
         $docComment = $this->getClassNode()->getDocComment();
 
         $docLines = $docComment ? explode("\n", $docComment->getText()) : [];
@@ -357,16 +440,10 @@ final class ClassSourceManipulator
             $docLines = $newDocLines;
         }
 
-        array_splice(
-            $docLines,
-            \count($docLines) - 1,
-            0,
-            ' * '.$this->buildAnnotationLine('@'.$annotationClassAlias, $options)
-        );
+        $docLines = $modifierCallback($docLines);
 
         $docComment = new Doc(implode("\n", $docLines));
         $this->getClassNode()->setDocComment($docComment);
-        $this->updateSourceCodeFromNewStmts();
     }
 
     private function addCustomGetter(string $propertyName, string $methodName, $returnType, bool $isReturnTypeNullable, array $commentLines = [], $typeCast = null)

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
@@ -11,6 +11,9 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method UserXml|null findOneBy(array $criteria, array $orderBy = null)
  * @method UserXml[]    findAll()
  * @method UserXml[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @method UserXml|null findOneByName($name, array $orderBy = null)
+ * @method UserXml[]    findByName($name, array $orderBy = null, $limit = null, $offset = null)
+ * @method int          countByName($name)
  */
 class UserRepository extends ServiceEntityRepository
 {


### PR DESCRIPTION
Doctrine supports querying by a certain field through the use of [the `__call` magic method](https://www.doctrine-project.org/projects/doctrine-orm/en/2.8/reference/working-with-objects.html#by-simple-conditions).

The idea here is to add the appropriate `@method` tags to custom repositories for each field that supports this functionality.
The following three methods are added:
 - `@method <Class>|null findOneBy<Field>($<Field>, array $orderBy = null)`
 - `@method <Class>[]      findBy<Field>($<Field>, array $orderBy = null, $limit = null, $offset = null)`
 - `@method int          countBy<Field>($<Field>)`

I still need to write some tests, but would like to hear your thoughts on this idea.

### TODO
 - [ ] Tests