### PR TITLE
[make:entity] Default to "datetime_immutable" when creating entities

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -353,7 +353,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         $snakeCasedField = Str::asSnakeCase($fieldName);
 
         if ('_at' === $suffix = substr($snakeCasedField, -3)) {
-            $defaultType = 'datetime';
+            $defaultType = 'datetime_immutable';
         } elseif ('_id' === $suffix) {
             $defaultType = 'integer';
         } elseif (0 === strpos($snakeCasedField, 'is_')) {


### PR DESCRIPTION
datetime should die, it's a footgun.