### PR TITLE
[security] fix cve-2021-21424 legacy Symfony 3.x + MakerBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Changelog
+
+## [v1.29.2](https://github.com/symfony/maker-bundle/releases/tag/v1.29.2)
+
+*May 18th, 2021*
+
+### Security
+
+- [#882](https://github.com/symfony/maker-bundle/pull/882) - [security] fix cve-2021-21424 legacy Symfony 3.x + MakerBundle- *@jrushlow*
+
 1.29
 ====
 

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -9,8 +9,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 <?= $user_needs_encoder ? "use Symfony\\Component\\Security\\Core\\Encoder\\UserPasswordEncoderInterface;\n" : null ?>
-use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -74,7 +74,7 @@ class <?= $class_name; ?> extends AbstractFormLoginAuthenticator<?= $password_au
 
         if (!$user) {
             // fail authentication with a custom error
-            throw new CustomUserMessageAuthenticationException('<?= ucfirst($username_field_label) ?> could not be found.');
+            throw new UsernameNotFoundException('<?= ucfirst($username_field_label) ?> could not be found.');
         }
 
         return $user;

--- a/tests/fixtures/MakeRegistrationFormVerifyEmailFunctionalTest/src/Security/LoginFormAuthenticator.php
+++ b/tests/fixtures/MakeRegistrationFormVerifyEmailFunctionalTest/src/Security/LoginFormAuthenticator.php
@@ -9,8 +9,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -70,7 +70,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator implements P
         $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $credentials['email']]);
 
         if (!$user) {
-            throw new CustomUserMessageAuthenticationException('Email could not be found.');
+            throw new UsernameNotFoundException('Email could not be found.');
         }
 
         return $user;


### PR DESCRIPTION
Applies security fix for CVE-2021-21424 in newly generated authenticators created by MakerBundle in Symfony 3.x applications.

fixes #880