### PR TITLE
[make:user] Keep implementing deprecated username methods

### DIFF
--- a/src/Resources/skeleton/security/UserProvider.tpl.php
+++ b/src/Resources/skeleton/security/UserProvider.tpl.php
@@ -36,8 +36,8 @@ class <?= $class_name ?> implements UserProviderInterface<?= $password_upgrader 
     {
         return $this->loadUserByIdentifier($username);
     }
-<?php endif ?>
 
+<?php endif ?>
     /**
      * Refreshes the user after being reloaded from the session.
      *

--- a/src/Resources/skeleton/security/UserProvider.tpl.php
+++ b/src/Resources/skeleton/security/UserProvider.tpl.php
@@ -28,6 +28,16 @@ class <?= $class_name ?> implements UserProviderInterface<?= $password_upgrader 
         throw new \Exception('TODO: fill in <?= $uses_user_identifier ? 'loadUserByIdentifier()' : 'loadUserByUsername()' ?> inside '.__FILE__);
     }
 
+<?php if ($uses_user_identifier) : ?>
+    /**
+     * @deprecated since Symfony 5.3, loadUserByIdentifier() is used instead
+     */
+    public function loadUserByUsername($username): UserInterface
+    {
+        return $this->loadUserByIdentifier($username);
+    }
+<?php endif ?>
+
     /**
      * Refreshes the user after being reloaded from the session.
      *

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -103,6 +103,16 @@ final class UserClassBuilder
         // Check if we're using Symfony 5.3+ - UserInterface::getUsername() was replaced with UserInterface::getUserIdentifier()
         if (class_exists(InMemoryUser::class)) {
             $getterIdentifierName = 'getUserIdentifier';
+
+            // also add the deprecated getUsername method
+            $manipulator->addAccessorMethod(
+                $userClassConfig->getIdentityPropertyName(),
+                'getUsername',
+                'string',
+                false,
+                ['@deprecated since Symfony 5.3, use getUserIdentifier instead'],
+                true
+            );
         }
 
         // define getUsername (if it was defined above, this will override)

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -98,22 +98,9 @@ final class UserClassBuilder
             );
         }
 
-        $getterIdentifierName = 'getUsername';
-
         // Check if we're using Symfony 5.3+ - UserInterface::getUsername() was replaced with UserInterface::getUserIdentifier()
-        if (class_exists(InMemoryUser::class)) {
-            $getterIdentifierName = 'getUserIdentifier';
-
-            // also add the deprecated getUsername method
-            $manipulator->addAccessorMethod(
-                $userClassConfig->getIdentityPropertyName(),
-                'getUsername',
-                'string',
-                false,
-                ['@deprecated since Symfony 5.3, use getUserIdentifier instead'],
-                true
-            );
-        }
+        $symfony53GTE = class_exists(InMemoryUser::class);
+        $getterIdentifierName = $symfony53GTE ? 'getUserIdentifier' : 'getUsername';
 
         // define getUsername (if it was defined above, this will override)
         $manipulator->addAccessorMethod(
@@ -128,6 +115,18 @@ final class UserClassBuilder
             ],
             true
         );
+
+        if ($symfony53GTE) {
+            // also add the deprecated getUsername method
+            $manipulator->addAccessorMethod(
+                $userClassConfig->getIdentityPropertyName(),
+                'getUsername',
+                'string',
+                false,
+                ['@deprecated since Symfony 5.3, use getUserIdentifier instead'],
+                true
+            );
+        }
     }
 
     private function addGetRoles(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig)

--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -62,6 +62,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * @deprecated since Symfony 5.3, use getUserIdentifier instead
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->email;
+    }
+
+    /**
      * @see UserInterface
      */
     public function getRoles(): array

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -57,6 +57,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * @deprecated since Symfony 5.3, use getUserIdentifier instead
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->userIdentifier;
+    }
+
+    /**
      * @see UserInterface
      */
     public function getRoles(): array

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -57,6 +57,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * @deprecated since Symfony 5.3, use getUserIdentifier instead
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->user_identifier;
+    }
+
+    /**
      * @see UserInterface
      */
     public function getRoles(): array

--- a/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
@@ -51,6 +51,14 @@ class User implements UserInterface
     }
 
     /**
+     * @deprecated since Symfony 5.3, use getUserIdentifier instead
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->userIdentifier;
+    }
+
+    /**
      * @see UserInterface
      */
     public function getRoles(): array

--- a/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
@@ -39,6 +39,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * @deprecated since Symfony 5.3, use getUserIdentifier instead
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->email;
+    }
+
+    /**
      * @see UserInterface
      */
     public function getRoles(): array

--- a/tests/Security/fixtures/expected/UserModelWithPassword.php
+++ b/tests/Security/fixtures/expected/UserModelWithPassword.php
@@ -34,6 +34,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
+     * @deprecated since Symfony 5.3, use getUserIdentifier instead
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->userIdentifier;
+    }
+
+    /**
      * @see UserInterface
      */
     public function getRoles(): array

--- a/tests/Security/fixtures/expected/UserModelWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserModelWithoutPassword.php
@@ -29,6 +29,14 @@ class User implements UserInterface
     }
 
     /**
+     * @deprecated since Symfony 5.3, use getUserIdentifier instead
+     */
+    public function getUsername(): string
+    {
+        return (string) $this->userIdentifier;
+    }
+
+    /**
      * @see UserInterface
      */
     public function getRoles(): array


### PR DESCRIPTION
This updates the makers for https://github.com/symfony/symfony/pull/41493 (where these methods are reintroduced to the interface for 5.3.1)