### PR TITLE
[tests] housekeeping

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -78,7 +78,7 @@ final class MakerTestEnvironment
         return file_get_contents($this->path.'/'.$path);
     }
 
-    private function changeRootNamespaceIfNeeded()
+    private function changeRootNamespaceIfNeeded(): void
     {
         if ('App' === ($rootNamespace = $this->testDetails->getRootNamespace())) {
             return;
@@ -128,7 +128,7 @@ final class MakerTestEnvironment
         $this->processReplacements($replacements, $this->path);
     }
 
-    public function prepare()
+    public function prepare(): void
     {
         if (!$this->fs->exists($this->flexPath)) {
             $this->buildFlexSkeleton();
@@ -198,7 +198,7 @@ final class MakerTestEnvironment
             ->run();
     }
 
-    private function preMake()
+    private function preMake(): void
     {
         foreach ($this->testDetails->getPreMakeCommands() as $preCommand) {
             MakerTestProcess::create($preCommand, $this->path)
@@ -206,7 +206,7 @@ final class MakerTestEnvironment
         }
     }
 
-    public function runMaker()
+    public function runMaker(): MakerTestProcess
     {
         // Lets remove cache
         $this->fs->remove($this->path.'/var/cache');
@@ -248,7 +248,7 @@ final class MakerTestEnvironment
         return $this->runnedMakerProcess;
     }
 
-    public function getGeneratedFilesFromOutputText()
+    public function getGeneratedFilesFromOutputText(): array
     {
         $output = $this->runnedMakerProcess->getOutput();
 
@@ -259,37 +259,37 @@ final class MakerTestEnvironment
         return array_map('trim', $matches[3]);
     }
 
-    public function fileExists(string $file)
+    public function fileExists(string $file): bool
     {
         return $this->fs->exists($this->path.'/'.$file);
     }
 
-    public function runPhpCSFixer(string $file)
+    public function runPhpCSFixer(string $file): MakerTestProcess
     {
         return MakerTestProcess::create(sprintf('php vendor/bin/php-cs-fixer --config=%s fix --dry-run --diff %s', __DIR__.'/../Resources/test/.php_cs.test', $this->path.'/'.$file), $this->rootPath)
                                ->run(true);
     }
 
-    public function runTwigCSLint(string $file)
+    public function runTwigCSLint(string $file): MakerTestProcess
     {
         return MakerTestProcess::create(sprintf('php vendor/bin/twigcs --config ./.twig_cs.dist %s', $this->path.'/'.$file), $this->rootPath)
                                ->run(true);
     }
 
-    public function runInternalTests()
+    public function runInternalTests(): ?MakerTestProcess
     {
         $finder = new Finder();
         $finder->in($this->path.'/tests')->files();
         if ($finder->count() > 0) {
             // execute the tests that were moved into the project!
-            return MakerTestProcess::create(sprintf('php %s', $this->rootPath.'/vendor/bin/simple-phpunit'), $this->path)
+            return MakerTestProcess::create(sprintf('php %s', $this->path.'/bin/phpunit'), $this->path)
                                    ->run(true);
         }
 
         return null;
     }
 
-    private function postMake()
+    private function postMake(): void
     {
         $this->processReplacements($this->testDetails->getPostMakeReplacements(), $this->path);
 
@@ -318,7 +318,7 @@ final class MakerTestEnvironment
         }
     }
 
-    private function buildFlexSkeleton()
+    private function buildFlexSkeleton(): void
     {
         $targetVersion = $this->getTargetSkeletonVersion();
         $versionString = $targetVersion ? sprintf(':%s', $targetVersion) : '';
@@ -397,7 +397,7 @@ final class MakerTestEnvironment
         )->run();
     }
 
-    private function processReplacements(array $replacements, $rootDir)
+    private function processReplacements(array $replacements, $rootDir): void
     {
         foreach ($replacements as $replacement) {
             $path = realpath($rootDir.'/'.$replacement['filename']);

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Doctrine;
 
-use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
@@ -41,7 +40,7 @@ class EntityRegeneratorTest extends TestCase
     /**
      * @dataProvider getRegenerateEntitiesTests
      */
-    public function testRegenerateEntities(string $expectedDirName, bool $overwrite)
+    public function testRegenerateEntities(string $expectedDirName, bool $overwrite): void
     {
         /*
          * Prior to symfony/doctrine-bridge 5.0 (which require
@@ -65,7 +64,7 @@ class EntityRegeneratorTest extends TestCase
         );
     }
 
-    public function getRegenerateEntitiesTests()
+    public function getRegenerateEntitiesTests(): \Generator
     {
         yield 'regenerate_no_overwrite' => [
             'expected_no_overwrite',
@@ -78,7 +77,7 @@ class EntityRegeneratorTest extends TestCase
         ];
     }
 
-    public function testXmlRegeneration()
+    public function testXmlRegeneration(): void
     {
         $kernel = new TestXmlEntityRegeneratorKernel('dev', true);
         $this->doTestRegeneration(
@@ -91,7 +90,7 @@ class EntityRegeneratorTest extends TestCase
         );
     }
 
-    private function doTestRegeneration(string $sourceDir, Kernel $kernel, string $namespace, string $expectedDirName, bool $overwrite, string $targetDirName)
+    private function doTestRegeneration(string $sourceDir, Kernel $kernel, string $namespace, string $expectedDirName, bool $overwrite, string $targetDirName): void
     {
         $fs = new Filesystem();
         $tmpDir = __DIR__.'/../tmp/'.$targetDirName;
@@ -157,9 +156,8 @@ class EntityRegeneratorTest extends TestCase
 class TestEntityRegeneratorKernel extends Kernel
 {
     use MicroKernelTrait;
-    use OverrideUrlTraitFixture;
 
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new FrameworkBundle(),
@@ -167,11 +165,11 @@ class TestEntityRegeneratorKernel extends Kernel
         ];
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
     }
 
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
     {
         $c->loadFromExtension('framework', [
             'secret' => 123,
@@ -184,10 +182,6 @@ class TestEntityRegeneratorKernel extends Kernel
             'driver' => 'pdo_sqlite',
             'url' => 'sqlite:///fake',
         ];
-
-        if ($this->canOverrideUrl($c)) {
-            $dbal['override_url'] = true;
-        }
 
         $c->prependExtensionConfig('doctrine', [
             'dbal' => $dbal,
@@ -205,12 +199,7 @@ class TestEntityRegeneratorKernel extends Kernel
         ]);
     }
 
-    public function getProjectDir()
-    {
-        return $this->getRootDir();
-    }
-
-    public function getRootDir()
+    public function getProjectDir(): string
     {
         return __DIR__.'/../tmp/current_project';
     }
@@ -219,9 +208,8 @@ class TestEntityRegeneratorKernel extends Kernel
 class TestXmlEntityRegeneratorKernel extends Kernel
 {
     use MicroKernelTrait;
-    use OverrideUrlTraitFixture;
 
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new FrameworkBundle(),
@@ -229,11 +217,11 @@ class TestXmlEntityRegeneratorKernel extends Kernel
         ];
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
     }
 
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
     {
         $c->loadFromExtension('framework', [
             'secret' => 123,
@@ -246,10 +234,6 @@ class TestXmlEntityRegeneratorKernel extends Kernel
             'driver' => 'pdo_sqlite',
             'url' => 'sqlite:///fake',
         ];
-
-        if ($this->canOverrideUrl($c)) {
-            $dbal['override_url'] = true;
-        }
 
         $c->prependExtensionConfig('doctrine', [
             'dbal' => $dbal,
@@ -268,12 +252,7 @@ class TestXmlEntityRegeneratorKernel extends Kernel
         ]);
     }
 
-    public function getProjectDir()
-    {
-        return $this->getRootDir();
-    }
-
-    public function getRootDir()
+    public function getProjectDir(): string
     {
         return __DIR__.'/../tmp/current_project_xml';
     }
@@ -281,26 +260,8 @@ class TestXmlEntityRegeneratorKernel extends Kernel
 
 class AllButTraitsIterator extends \RecursiveFilterIterator
 {
-    public function accept()
+    public function accept(): bool
     {
         return !\in_array($this->current()->getFilename(), []);
-    }
-}
-
-trait OverrideUrlTraitFixture
-{
-    /**
-     * Quick and dirty way to check if override_url is required since doctrine-bundle 2.3.
-     */
-    public function canOverrideUrl(ContainerBuilder $builder): bool
-    {
-        /** @var DoctrineExtension $ext */
-        $ext = $builder->getExtension('doctrine');
-        $method = new \ReflectionMethod(DoctrineExtension::class, 'getConnectionOptions');
-        $method->setAccessible(true);
-
-        $configOptions = $method->invoke($ext, ['override_url' => 'string', 'shards' => [], 'replicas' => [], 'slaves' => []]);
-
-        return \array_key_exists('connection_override_options', $configOptions);
     }
 }


### PR DESCRIPTION
- removes `override_url` config logic (feature has was introduced && deprecated in doctrine-bundle 2.3)
- remove duplicate directory getter
- run generated projects `bin/phpunit` instead of "makers" `simple-phpunit`
- add return types to touched classes