### PR TITLE
[tests] bump symfony phpunit version for CI

### DIFF
--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -144,6 +144,14 @@ final class MakerTestDetails
             )
         ;
 
+        // Flex includes a recipe to suffix the dbname w/ "_test" - lets keep
+        // things simple for these tests and not do that.
+        $this->addReplacement(
+            'config/packages/test/doctrine.yaml',
+            "dbname_suffix: '_test%env(default::TEST_TOKEN)%'",
+            '')
+        ;
+
         // this looks silly, but it's the only way to drop the database *for sure*,
         // as doctrine:database:drop will error if there is no database
         // also, skip for SQLITE, as it does not support --if-not-exists

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -383,7 +383,7 @@ final class MakerTestEnvironment
             // do not explicitly set the PHPUnit version
             [
                 'filename' => 'phpunit.xml.dist',
-                'find' => '<server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />',
+                'find' => '<server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />',
                 'replace' => '',
             ],
         ];


### PR DESCRIPTION
Flex recipe now uses PHPUnit `9.5` for the `SYMFONY_PHPUNIT_VERSION` https://github.com/symfony/recipes/pull/952/files#diff-7e77caa90dde27086b747cb093fb643bbed3d7dbb37baa4fd81a992504d18d99R15

Updates the test environment to look for and remove `<server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />` from the phpunit config. 

---

- disable the `_test` dbname suffix functionality in the test environment