### PR TITLE
[make:crud] send the proper HTTP status codes and use renderForm() when available

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -15,6 +15,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Common\Inflector\Inflector as LegacyInflector;
 use Doctrine\Inflector\InflectorFactory;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
@@ -168,6 +169,7 @@ final class MakeCrud extends AbstractMaker
                     'entity_var_singular' => $entityVarSingular,
                     'entity_twig_var_singular' => $entityTwigVarSingular,
                     'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
+                    'use_render_form' => method_exists(AbstractController::class, 'renderForm'),
                 ],
                 $repositoryVars
             )

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -66,13 +66,20 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             $entityManager->persist($<?= $entity_var_singular ?>);
             $entityManager->flush();
 
-            return $this->redirectToRoute('<?= $route_name ?>_index');
+            return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
         }
 
+<?php if ($use_render_form) { ?>
+        return $this->renderForm('<?= $templates_path ?>/new.html.twig', [
+            '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
+            'form' => $form,
+        ]);
+<?php } else { ?>
         return $this->render('<?= $templates_path ?>/new.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form->createView(),
         ]);
+<?php } ?>
     }
 
 <?php if ($use_attributes) { ?>
@@ -104,13 +111,20 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         if ($form->isSubmitted() && $form->isValid()) {
             $this->getDoctrine()->getManager()->flush();
 
-            return $this->redirectToRoute('<?= $route_name ?>_index');
+            return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
         }
 
+<?php if ($use_render_form) { ?>
+        return $this->renderForm('<?= $templates_path ?>/edit.html.twig', [
+            '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
+            'form' => $form,
+        ]);
+<?php } else { ?>
         return $this->render('<?= $templates_path ?>/edit.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form->createView(),
         ]);
+<?php } ?>
     }
 
 <?php if ($use_attributes) { ?>
@@ -128,6 +142,6 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
             $entityManager->flush();
         }
 
-        return $this->redirectToRoute('<?= $route_name ?>_index');
+        return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
     }
 }


### PR DESCRIPTION
This makes `make:crud` compatible with Symfony Turbo by default.