### PR TITLE
Fix keys not found when surrounded by quotes

### DIFF
--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -684,7 +684,7 @@ class YamlSourceManipulator
 
     private function getKeyRegex($key)
     {
-        return sprintf('#\b%s( )*:#', preg_quote($key));
+        return sprintf('#\b%s\'?( )*:#', preg_quote($key));
     }
 
     private function updateContents(string $newContents, array $newData, int $newPosition)

--- a/tests/Util/yaml_fixtures/keys_with_simple_quotes.test
+++ b/tests/Util/yaml_fixtures/keys_with_simple_quotes.test
@@ -1,0 +1,19 @@
+framework:
+    messenger:
+        routing:
+            # route all messages that extend this example base class or interface
+            'App\Message\AbstractAsyncMessage': async
+            'App\Message\AsyncMessageInterface': async
+
+            'My\Message\ToBeSentToTwoSenders': [async, audit]
+===
+
+===
+framework:
+    messenger:
+        routing:
+            # route all messages that extend this example base class or interface
+            'App\Message\AbstractAsyncMessage': async
+            'App\Message\AsyncMessageInterface': async
+
+            'My\Message\ToBeSentToTwoSenders': [async, audit]


### PR DESCRIPTION
Fix bug reported in #796 : running ``make:message`` cannot find existing messages when configuring with quotes according to [documentation](https://symfony.com/doc/current/messenger.html#routing-messages-to-a-transport).