### PR TITLE
Use proper name for parameter of upgradePassword

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -29,13 +29,13 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
     /**
      * Used to upgrade (rehash) the user's password automatically over time.
      */
-    public function upgradePassword(<?= sprintf('%s ', $password_upgrade_user_interface->getShortName()); ?>$user, string $newEncodedPassword): void
+    public function upgradePassword(<?= sprintf('%s ', $password_upgrade_user_interface->getShortName()); ?>$user, string $newHashedPassword): void
     {
         if (!$user instanceof <?= $entity_class_name ?>) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
         }
 
-        $user->setPassword($newEncodedPassword);
+        $user->setPassword($newHashedPassword);
         $this->_em->persist($user);
         $this->_em->flush();
     }


### PR DESCRIPTION
encode is the wrong term symfony tries to remove. The paramter is also called $newHashedPassword in the PasswordUpgraderInterface