### PR TITLE
[make:crud] Fix templates include paths when using namespace.

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -191,6 +191,7 @@ final class MakeCrud extends AbstractMaker
                 'entity_twig_var_singular' => $entityTwigVarSingular,
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath,
             ],
             'index' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
@@ -203,6 +204,7 @@ final class MakeCrud extends AbstractMaker
             'new' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath,
             ],
             'show' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
@@ -210,6 +212,7 @@ final class MakeCrud extends AbstractMaker
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                 'entity_fields' => $entityDoctrineDetails->getDisplayFields(),
                 'route_name' => $routeName,
+                'templates_path' => $templatesPath,
             ],
         ];
 

--- a/src/Resources/skeleton/crud/templates/edit.tpl.php
+++ b/src/Resources/skeleton/crud/templates/edit.tpl.php
@@ -3,9 +3,9 @@
 {% block body %}
     <h1>Edit <?= $entity_class_name ?></h1>
 
-    {{ include('<?= $route_name ?>/_form.html.twig', {'button_label': 'Update'}) }}
+    {{ include('<?= $templates_path ?>/_form.html.twig', {'button_label': 'Update'}) }}
 
     <a href="{{ path('<?= $route_name ?>_index') }}">back to list</a>
 
-    {{ include('<?= $route_name ?>/_delete_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_delete_form.html.twig') }}
 {% endblock %}

--- a/src/Resources/skeleton/crud/templates/new.tpl.php
+++ b/src/Resources/skeleton/crud/templates/new.tpl.php
@@ -3,7 +3,7 @@
 {% block body %}
     <h1>Create new <?= $entity_class_name ?></h1>
 
-    {{ include('<?= $route_name ?>/_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_form.html.twig') }}
 
     <a href="{{ path('<?= $route_name ?>_index') }}">back to list</a>
 {% endblock %}

--- a/src/Resources/skeleton/crud/templates/show.tpl.php
+++ b/src/Resources/skeleton/crud/templates/show.tpl.php
@@ -18,5 +18,5 @@
 
     <a href="{{ path('<?= $route_name ?>_edit', {'<?= $entity_identifier ?>': <?= $entity_twig_var_singular ?>.<?= $entity_identifier ?>}) }}">edit</a>
 
-    {{ include('<?= $route_name ?>/_delete_form.html.twig') }}
+    {{ include('<?= $templates_path ?>/_delete_form.html.twig') }}
 {% endblock %}


### PR DESCRIPTION
This problem got an older PR from 2019 and still not yet merge cause not finished (#479)

####################
In templates, the path to included templates was wrong when using namespace. It previously used the `route_name` to generate the template path. Using `templates_path` is better in this case and fix the problem.

Example:
- Old generated code
```twig
{{ include('admin_comment/_delete_form.html.twig') }}
```
- New generated code
```twig
{{ include('admin/comment/_delete_form.html.twig') }}
```