### PR TITLE
[YamlSourceManipulator] Tweak regex pattern for regex key

### DIFF
--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -684,7 +684,7 @@ class YamlSourceManipulator
 
     private function getKeyRegex($key)
     {
-        return sprintf('#\b%s\'?( )*:#', preg_quote($key));
+        return sprintf('#(?<!\w)\$?%s\'?( )*:#', preg_quote($key));
     }
 
     private function updateContents(string $newContents, array $newData, int $newPosition)

--- a/tests/Util/yaml_fixtures/add_item_on_config_with_bind.test
+++ b/tests/Util/yaml_fixtures/add_item_on_config_with_bind.test
@@ -1,0 +1,29 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    bind:
+      $httpClient: '@http.client'
+
+  app.service:
+    class: App\Services\Service
+    arguments:
+      - argument_1: something
+        argument_2: something
+===
+$data['services']['app.service']['arguments'][0]['argument_3'] = 'something_new';
+===
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    bind:
+      $httpClient: '@http.client'
+
+  app.service:
+    class: App\Services\Service
+    arguments:
+      - argument_1: something
+        argument_2: something
+        argument_3: something_new
+        

--- a/tests/Util/yaml_fixtures/add_item_on_config_with_bind.test
+++ b/tests/Util/yaml_fixtures/add_item_on_config_with_bind.test
@@ -10,6 +10,7 @@ services:
     arguments:
       - argument_1: something
         argument_2: something
+
 ===
 $data['services']['app.service']['arguments'][0]['argument_3'] = 'something_new';
 ===
@@ -26,4 +27,3 @@ services:
       - argument_1: something
         argument_2: something
         argument_3: something_new
-        


### PR DESCRIPTION
We need to tweak a regex pattern, because at the moment if you try to update yaml with following config:

```
services:
  _defaults:
    autowire: true
    autoconfigure: true
    bind:
      $tracer: 'something'
```

You will receive:
![Screenshot from 2021-06-27 17-02-02](https://user-images.githubusercontent.com/10156301/123547959-86ebb980-d76b-11eb-87ea-7373cd193af5.png)

