### PR TITLE
[make:registration] conditionally generate verify email flash in template

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -266,7 +266,7 @@ final class MakeRegistrationForm extends AbstractMaker
             'Security\\'
         );
 
-        if ($input->getArgument('will-verify-email')) {
+        if (($willVerify = $input->getArgument('will-verify-email'))) {
             $generator->generateClass(
                 $verifyEmailServiceClassNameDetails->getFullName(),
                 'verifyEmail/EmailVerifier.tpl.php',
@@ -332,6 +332,7 @@ final class MakeRegistrationForm extends AbstractMaker
             'registration/twig_template.tpl.php',
             [
                 'username_field' => $usernameField,
+                'will_verify_email' => $willVerify,
             ]
         );
 

--- a/src/Resources/skeleton/registration/twig_template.tpl.php
+++ b/src/Resources/skeleton/registration/twig_template.tpl.php
@@ -1,10 +1,12 @@
 <?= $helper->getHeadPrintCode('Register'); ?>
 
 {% block body %}
+<?php if ($will_verify_email): ?>
     {% for flashError in app.flashes('verify_email_error') %}
         <div class="alert alert-danger" role="alert">{{ flashError }}</div>
     {% endfor %}
 
+<?php endif; ?>
     <h1>Register</h1>
 
     {{ form_start(registrationForm) }}


### PR DESCRIPTION
fixes #905 - previously the generated registration form included a loop to display verify-email flash message regardless if the `SymfonyCasts/verify-email-bundle` was used. This PR only generates the loop if the user chooses to utilize the verify email bundle when running `make:registration`