### PR TITLE
[CI] Fixes test error about missing annotation_reader

### DIFF
--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -176,6 +176,9 @@ class TestEntityRegeneratorKernel extends Kernel
             'router' => [
                 'utf8' => true,
             ],
+            'annotations' => [
+                'enabled' => true,
+            ],
         ]);
 
         $dbal = [


### PR DESCRIPTION
Hi!

Starting in Composer 2.1 & Symfony 5.3, whether the annotations system is auto-enabled depends on whether doctrine/annotations will be available *without* taking into account dev dependencies. In MakerBundle, when we boot a test container, doctrine/annotations is a dev dependency only (appropriately), which incorrectly hints to the container
that the system should not be initialized. So, we force it.

Cheers!