### PR TITLE
[CI] Skip Mercure test if not setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ init:
     - SET PHP=0 # This var is connected to PHP install cache
     - SET ANSICON=121x90 (121x90)
     - SET MAKER_DISABLE_FILE_LINKS=1
+    - SET MAKER_SKIP_MERCURE_TEST=1
 
 environment:
     TEST_DATABASE_DSN: mysql://root:Password12!@127.0.0.1:3306/test_maker

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -565,7 +565,7 @@ class MakeEntityTest extends MakerTestCase
             ->updateSchemaAfterCommand(),
         ];
 
-        yield 'entity_new_broadcast' => [MakerTestDetails::createTest(
+        $broadCastTest = MakerTestDetails::createTest(
             $this->getMakerInstance(MakeEntity::class),
             [
                 // entity class name
@@ -577,7 +577,6 @@ class MakeEntityTest extends MakerTestCase
             ])
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('ux-turbo-mercure')
-            ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeEntity')
             ->configureDatabase()
             ->addReplacement(
                 '.env',
@@ -591,8 +590,14 @@ class MakeEntityTest extends MakerTestCase
                 $content = file_get_contents($directory.'/src/Entity/User.php');
                 $this->assertStringContainsString('use Symfony\UX\Turbo\Attribute\Broadcast;', $content);
                 $this->assertStringContainsString(\PHP_VERSION_ID >= 80000 ? '#[Broadcast]' : '@Broadcast', $content);
-            }),
-        ];
+            })
+        ;
+        // use the fixtures - which contains a test for Mercure - unless specified to skip those
+        $skipMercureTest = $_SERVER['MAKER_SKIP_MERCURE_TEST'] ?? false;
+        if (!$skipMercureTest) {
+            $broadCastTest->setFixtureFilesPath(__DIR__.'/../fixtures/MakeEntity');
+        }
+        yield 'entity_new_broadcast' => [$broadCastTest];
 
         yield 'entity_new_with_api_and_broadcast_dependencies' => [MakerTestDetails::createTest(
             $this->getMakerInstance(MakeEntity::class),


### PR DESCRIPTION
This fixes the final failure on AppVeyor, where we don't bother to setup Mercure. Testing this isn't really necessary, as it's covered in the Unix tests anyways - I think that's good enough.