### PR TITLE
[internal] add route generator for controllers

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
+use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -28,8 +29,9 @@ class Generator
     private $pendingOperations = [];
     private $namespacePrefix;
     private $phpCompatUtil;
+    private $templateComponentGenerator;
 
-    public function __construct(FileManager $fileManager, string $namespacePrefix, PhpCompatUtil $phpCompatUtil = null)
+    public function __construct(FileManager $fileManager, string $namespacePrefix, PhpCompatUtil $phpCompatUtil = null, TemplateComponentGenerator $templateComponentGenerator = null)
     {
         $this->fileManager = $fileManager;
         $this->twigHelper = new GeneratorTwigHelper($fileManager);
@@ -42,6 +44,7 @@ class Generator
         }
 
         $this->phpCompatUtil = $phpCompatUtil;
+        $this->templateComponentGenerator = $templateComponentGenerator;
     }
 
     /**
@@ -224,6 +227,7 @@ class Generator
             $controllerTemplatePath,
             $parameters +
             [
+                'generator' => $this->templateComponentGenerator,
                 'parent_class_name' => static::getControllerBaseClass()->getShortName(),
             ]
         );

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -50,6 +50,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument /> <!-- root namespace -->
                 <argument type="service" id="maker.php_compat_util" />
+                <argument type="service" id="maker.template_component_generator" />
             </service>
 
             <service id="maker.entity_class_generator" class="Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator">
@@ -67,6 +68,10 @@
 
             <service id="maker.php_compat_util" class="Symfony\Bundle\MakerBundle\Util\PhpCompatUtil">
                 <argument type="service" id="maker.file_manager" />
+            </service>
+
+            <service id="maker.template_component_generator" class="Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator">
+                <argument type="service" id="maker.php_compat_util" />
             </service>
         </services>
 </container>

--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -8,13 +8,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
-<?php if ($use_attributes) { ?>
-    #[Route('<?= $route_path ?>', name: '<?= $route_name ?>')]
-<?php } else { ?>
-    /**
-     * @Route("<?= $route_path ?>", name="<?= $route_name ?>")
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod($route_path, $route_name); ?>
     public function index(): Response
     {
 <?php if ($with_template) { ?>

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -21,13 +21,7 @@ use Symfony\Component\Routing\Annotation\Route;
 <?php } ?>
 class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
-<?php if ($use_attributes) { ?>
-    #[Route('/', name: '<?= $route_name ?>_index', methods: ['GET'])]
-<?php } else { ?>
-    /**
-     * @Route("/", name="<?= $route_name ?>_index", methods={"GET"})
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod('/', sprintf('%s_index', $route_name), ['GET']) ?>
 <?php if (isset($repository_full_class_name)): ?>
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>): Response
     {
@@ -48,13 +42,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 <?php endif ?>
 
-<?php if ($use_attributes) { ?>
-    #[Route('/new', name: '<?= $route_name ?>_new', methods: ['GET', 'POST'])]
-<?php } else { ?>
-    /**
-     * @Route("/new", name="<?= $route_name ?>_new", methods={"GET","POST"})
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod('/new', sprintf('%s_new', $route_name), ['GET', 'POST']) ?>
     public function new(Request $request): Response
     {
         $<?= $entity_var_singular ?> = new <?= $entity_class_name ?>();
@@ -82,13 +70,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 <?php } ?>
     }
 
-<?php if ($use_attributes) { ?>
-    #[Route('/{<?= $entity_identifier ?>}', name: '<?= $route_name ?>_show', methods: ['GET'])]
-<?php } else { ?>
-    /**
-     * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_show", methods={"GET"})
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_show', $route_name), ['GET']) ?>
     public function show(<?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
         return $this->render('<?= $templates_path ?>/show.html.twig', [
@@ -96,13 +78,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         ]);
     }
 
-<?php if ($use_attributes) { ?>
-    #[Route('/{<?= $entity_identifier ?>}/edit', name: '<?= $route_name ?>_edit', methods: ['GET', 'POST'])]
-<?php } else { ?>
-    /**
-     * @Route("/{<?= $entity_identifier ?>}/edit", name="<?= $route_name ?>_edit", methods={"GET","POST"})
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod(sprintf('/{%s}/edit', $entity_identifier), sprintf('%s_edit', $route_name), ['GET', 'POST']) ?>
     public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
         $form = $this->createForm(<?= $form_class_name ?>::class, $<?= $entity_var_singular ?>);
@@ -127,13 +103,7 @@ class <?= $class_name ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 <?php } ?>
     }
 
-<?php if ($use_attributes) { ?>
-    #[Route('/{<?= $entity_identifier ?>}', name: '<?= $route_name ?>_delete', methods: ['POST'])]
-<?php } else { ?>
-    /**
-     * @Route("/{<?= $entity_identifier ?>}", name="<?= $route_name ?>_delete", methods={"POST"})
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_delete', $route_name), ['POST']) ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
         if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->request->get('_token'))) {

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -15,13 +15,7 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 
 <?php endif; ?>
-<?php if ($use_attributes) { ?>
-    #[Route('<?= $route_path ?>', name: '<?= $route_name ?>')]
-<?php } else { ?>
-    /**
-     * @Route("<?= $route_path ?>", name="<?= $route_name ?>")
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod($route_path, $route_name) ?>
     public function register(Request $request, UserPasswordEncoderInterface $passwordEncoder<?= $authenticator_full_class_name ? sprintf(', GuardAuthenticatorHandler $guardHandler, %s $authenticator', $authenticator_class_name) : '' ?>): Response
     {
         $user = new <?= $user_class_name ?>();
@@ -71,13 +65,7 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
     }
 <?php if ($will_verify_email): ?>
 
-<?php if ($use_attributes) { ?>
-    #[Route('/verify/email', name: 'app_verify_email')]
-<?php } else { ?>
-    /**
-     * @Route("/verify/email", name="app_verify_email")
-     */
-<?php } ?>
+<?= $generator->generateRouteForControllerMethod('/verify/email', 'app_verify_email') ?>
     public function verifyUserEmail(Request $request<?= $verify_email_anonymously ? sprintf(', %s %s', $repository_class_name, $repository_var) : null ?>): Response
     {
 <?php if (!$verify_email_anonymously): ?>

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -18,6 +18,13 @@ namespace Symfony\Bundle\MakerBundle\Util;
  */
 final class TemplateComponentGenerator
 {
+    private $phpCompatUtil;
+
+    public function __construct(PhpCompatUtil $phpCompatUtil)
+    {
+        $this->phpCompatUtil = $phpCompatUtil;
+    }
+
     public static function generateUseStatements(array $classesToBeImported): string
     {
         $transformed = [];
@@ -35,5 +42,49 @@ final class TemplateComponentGenerator
         }
 
         return $statements;
+    }
+
+    /** @legacy Annotation Support can be dropped w/ Symfony 6 LTS */
+    public function generateRouteForControllerMethod(string $routePath, string $routeName, array $methods = [], bool $indent = true, bool $trailingNewLine = true): string
+    {
+        if ($this->phpCompatUtil->canUseAttributes()) {
+            $attribute = sprintf('%s#[Route(\'%s\', name: \'%s\'', $indent ? '    ' : null, $routePath, $routeName);
+
+            if (!empty($methods)) {
+                $attribute .= ', methods: [';
+
+                foreach ($methods as $method) {
+                    $attribute .= sprintf('\'%s\',', $method);
+                }
+
+                $attribute = rtrim($attribute, ',');
+
+                $attribute .= ']';
+            }
+
+            $attribute .= sprintf(')]%s', $trailingNewLine ? "\n" : null);
+
+            return $attribute;
+        }
+
+        $annotation = sprintf('%s/**%s', $indent ? '    ' : null, "\n");
+        $annotation .= sprintf('%s * @Route("%s", name="%s"', $indent ? '    ' : null, $routePath, $routeName);
+
+        if (!empty($methods)) {
+            $annotation .= ', methods={';
+
+            foreach ($methods as $method) {
+                $annotation .= sprintf('"%s",', $method);
+            }
+
+            $annotation = rtrim($annotation, ',');
+
+            $annotation .= '}';
+        }
+
+        $annotation .= sprintf(')%s', "\n");
+        $annotation .= sprintf('%s */%s', $indent ? '    ' : null, $trailingNewLine ? "\n" : null);
+
+        return $annotation;
     }
 }

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\Sorter;
 use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 
@@ -76,5 +77,133 @@ use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
 EOT;
         self::assertSame($expected, $result);
+    }
+
+    public function testRouteAttributes(): void
+    {
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+        $mockPhpCompatUtil
+            ->expects(self::once())
+            ->method('canUseAttributes')
+            ->willReturn(true)
+        ;
+
+        $generator = new TemplateComponentGenerator($mockPhpCompatUtil);
+
+        $expected = "    #[Route('/', name: 'app_home')]\n";
+
+        self::assertSame($expected, $generator->generateRouteForControllerMethod('/', 'app_home'));
+    }
+
+    public function testRouteAnnotations(): void
+    {
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+        $mockPhpCompatUtil
+            ->expects(self::once())
+            ->method('canUseAttributes')
+            ->willReturn(false)
+        ;
+
+        $generator = new TemplateComponentGenerator($mockPhpCompatUtil);
+
+        $expected = "    /**\n";
+        $expected .= "     * @Route(\"/\", name=\"app_home\")\n";
+        $expected .= "     */\n";
+
+        self::assertSame($expected, $generator->generateRouteForControllerMethod('/', 'app_home'));
+    }
+
+    /**
+     * @dataProvider routeMethodDataProvider
+     */
+    public function testRouteMethods(string $expected, bool $useAttribute, array $methods): void
+    {
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+        $mockPhpCompatUtil
+            ->expects(self::once())
+            ->method('canUseAttributes')
+            ->willReturn($useAttribute)
+        ;
+
+        $generator = new TemplateComponentGenerator($mockPhpCompatUtil);
+
+        if (!$useAttribute) {
+            $annotation = "    /**\n";
+            $annotation .= $expected;
+            $annotation .= "     */\n";
+
+            $expected = $annotation;
+        }
+
+        self::assertSame($expected, $generator->generateRouteForControllerMethod(
+            '/',
+            'app_home',
+            $methods
+        ));
+    }
+
+    public function routeMethodDataProvider(): \Generator
+    {
+        yield ["    #[Route('/', name: 'app_home', methods: ['GET'])]\n", true, ['GET']];
+        yield ["     * @Route(\"/\", name=\"app_home\", methods={\"GET\"})\n", false, ['GET']];
+        yield ["    #[Route('/', name: 'app_home', methods: ['GET','POST'])]\n", true, ['GET', 'POST']];
+        yield ["     * @Route(\"/\", name=\"app_home\", methods={\"GET\",\"POST\"})\n", false, ['GET', 'POST']];
+    }
+
+    /**
+     * @dataProvider routeIndentationDataProvider
+     */
+    public function testRouteIndentation(string $expected, bool $useAttribute): void
+    {
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+        $mockPhpCompatUtil
+            ->expects(self::once())
+            ->method('canUseAttributes')
+            ->willReturn($useAttribute)
+        ;
+
+        $generator = new TemplateComponentGenerator($mockPhpCompatUtil);
+
+        self::assertSame($expected, $generator->generateRouteForControllerMethod(
+            '/',
+            'app_home',
+            [],
+            false
+        ));
+    }
+
+    public function routeIndentationDataProvider(): \Generator
+    {
+        yield ["#[Route('/', name: 'app_home')]\n", true];
+        yield ["/**\n * @Route(\"/\", name=\"app_home\")\n */\n", false];
+    }
+
+    /**
+     * @dataProvider routeTrailingNewLineDataProvider
+     */
+    public function testRouteTrailingNewLine(string $expected, bool $useAttribute): void
+    {
+        $mockPhpCompatUtil = $this->createMock(PhpCompatUtil::class);
+        $mockPhpCompatUtil
+            ->expects(self::once())
+            ->method('canUseAttributes')
+            ->willReturn($useAttribute)
+        ;
+
+        $generator = new TemplateComponentGenerator($mockPhpCompatUtil);
+
+        self::assertSame($expected, $generator->generateRouteForControllerMethod(
+            '/',
+            'app_home',
+            [],
+            false,
+            false
+        ));
+    }
+
+    public function routeTrailingNewLineDataProvider(): \Generator
+    {
+        yield ["#[Route('/', name: 'app_home')]", true];
+        yield ["/**\n * @Route(\"/\", name=\"app_home\")\n */", false];
     }
 }


### PR DESCRIPTION
Concept to cleanup templates that depend on route annotations / attributes for better DX when contributing to MakerBundle.

The `ResetPasswordController` is an exception due to the existing docBlocks that are generated. Will revisit that controller in the future.