### PR TITLE
use password hasher for make:registration & make:reset-password, includes other improvements

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -247,7 +247,7 @@ class Generator
 
     public static function getControllerBaseClass(): ClassNameDetails
     {
-        // Support for Controller::class can be dropped when FrameworkBundle minimum supported version is >=4.1
+        // @legacy Support for Controller::class can be dropped when FrameworkBundle minimum supported version is >=4.1
         $class = method_exists(AbstractController::class, 'getParameter') ? AbstractController::class : Controller::class;
 
         return new ClassNameDetails($class, '\\');

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -7,16 +7,16 @@ namespace <?= $namespace; ?>;
 class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 {
 <?php if ($will_verify_email): ?>
-    private $emailVerifier;
+    private <?= $generator->getPropertyType($email_verifier_class_details) ?>$emailVerifier;
 
-    public function __construct(EmailVerifier $emailVerifier)
+    public function __construct(<?= $email_verifier_class_details->getShortName() ?> $emailVerifier)
     {
         $this->emailVerifier = $emailVerifier;
     }
 
 <?php endif; ?>
 <?= $generator->generateRouteForControllerMethod($route_path, $route_name) ?>
-    public function register(Request $request, UserPasswordEncoderInterface $passwordEncoder<?= $authenticator_full_class_name ? sprintf(', GuardAuthenticatorHandler $guardHandler, %s $authenticator', $authenticator_class_name) : '' ?>): Response
+    public function register(Request $request, <?= $password_class_details->getShortName() ?> <?= $password_variable_name ?><?= $authenticator_full_class_name ? sprintf(', GuardAuthenticatorHandler $guardHandler, %s $authenticator', $authenticator_class_name) : '' ?>): Response
     {
         $user = new <?= $user_class_name ?>();
         $form = $this->createForm(<?= $form_class_name ?>::class, $user);
@@ -25,7 +25,7 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         if ($form->isSubmitted() && $form->isValid()) {
             // encode the plain password
             $user->set<?= ucfirst($password_field) ?>(
-                $passwordEncoder->encodePassword(
+            <?= $password_variable_name ?>-><?= $use_password_hasher ? 'hashPassword' : 'encodePassword' ?>(
                     $user,
                     $form->get('plainPassword')->getData()
                 )

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -2,21 +2,7 @@
 
 namespace <?= $namespace ?>;
 
-use <?= $user_full_class_name ?>;
-use <?= $reset_form_type_full_class_name ?>;
-use <?= $request_form_type_full_class_name ?>;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Mailer\MailerInterface;
-use Symfony\Component\Mime\Address;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
-use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
-use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+<?= $use_statements; ?>
 
 <?php if ($use_attributes) { ?>
 #[Route('/reset-password')]
@@ -96,7 +82,7 @@ class <?= $class_name ?> extends AbstractController
      * @Route("/reset/{token}", name="app_reset_password")
      */
 <?php } ?>
-    public function reset(Request $request, UserPasswordEncoderInterface $passwordEncoder, string $token = null): Response
+    public function reset(Request $request, <?= $password_class_details->getShortName() ?> <?= $password_variable_name ?>, string $token = null): Response
     {
         if ($token) {
             // We store the token in session and remove it from the URL, to avoid the URL being
@@ -130,8 +116,8 @@ class <?= $class_name ?> extends AbstractController
             // A password reset token should be used only once, remove it.
             $this->resetPasswordHelper->removeResetRequest($token);
 
-            // Encode the plain password, and set it.
-            $encodedPassword = $passwordEncoder->encodePassword(
+            // Encode(hash) the plain password, and set it.
+            $encodedPassword = <?= $password_variable_name ?>-><?= $use_password_hasher ? 'hashPassword' : 'encodePassword' ?>(
                 $user,
                 $form->get('plainPassword')->getData()
             );

--- a/src/Util/ClassNameDetails.php
+++ b/src/Util/ClassNameDetails.php
@@ -16,9 +16,7 @@ use Symfony\Bundle\MakerBundle\Str;
 final class ClassNameDetails
 {
     private $fullClassName;
-
     private $namespacePrefix;
-
     private $suffix;
 
     public function __construct(string $fullClassName, string $namespacePrefix, string $suffix = null)

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -87,4 +87,13 @@ final class TemplateComponentGenerator
 
         return $annotation;
     }
+
+    public function getPropertyType(ClassNameDetails $classNameDetails): ?string
+    {
+        if (!$this->phpCompatUtil->canUseTypedProperties()) {
+            return null;
+        }
+
+        return sprintf('%s ', $classNameDetails->getShortName());
+    }
 }


### PR DESCRIPTION
Use the new password hasher if it exists, or fallback to the old password encoder for `make:reset-password` & `make:registration`.

- introduces the concept of using `ClassNameDetails` objects in `make:registration` templates.
- adds a new `TemplateComponentsGenerator::getPropertyType($classNameDetails)` object that simplifies using typed properties in templates.

_contains `@legacy` tags for internal use:_
- Remove `Generator::getControllerBaseClass()` when `FrameworkBundle`  min supported version >= 4.1
- make:registration `$passwordHasher` conditional can be removed when min Symfony supported version >=5.3
- make:reset-password `$passwordHasher` conditional can be removed when min Symfony supported version >=5.3
- injected controller var's `password_variable_name` & `use_password_hasher` can be removed when min Symfony supported version >=5.3

refs #821 