### PR TITLE
[ci] handle new 5.4 branch & make dev tests green

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ on:
 env:
     PHPUNIT_FLAGS: "-v"
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
-    SYMFONY_REQUIRE: ">=4.0"
 
 jobs:
     coding-standards:

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -460,18 +460,17 @@ echo json_encode($missingDependencies);
 
             switch ($stability) {
                 case 'stable-dev':
-                    $httpClient = HttpClient::create();
-                    $response = $httpClient->request('GET', 'https://symfony.com/versions.json');
-                    $data = $response->toArray();
-
-                    $version = $data['latest'];
+                    $version = ($this->getSymfonyVersions())['latest'];
                     $parts = explode('.', $version);
 
                     $this->targetSkeletonVersion = sprintf('%s.%s.x-dev', $parts[0], $parts[1]);
 
                     break;
                 case 'dev':
-                    $this->targetSkeletonVersion = '5.x-dev';
+                    $version = ($this->getSymfonyVersions())['dev'];
+                    $parts = explode('.', $version);
+
+                    $this->targetSkeletonVersion = sprintf('%s.%s.x-dev', $parts[0], $parts[1]);
 
                     break;
                 default:
@@ -480,5 +479,13 @@ echo json_encode($missingDependencies);
         }
 
         return $this->targetSkeletonVersion;
+    }
+
+    private function getSymfonyVersions(): array
+    {
+        $httpClient = HttpClient::create();
+        $response = $httpClient->request('GET', 'https://symfony.com/versions.json');
+
+        return $response->toArray();
     }
 }

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -29,6 +29,12 @@ class MakeMigrationTest extends MakerTestCase
             // only requires doctrine/dbal. But we're testing with the ORM,
             // so let's install it
             ->addExtraDependencies('doctrine/orm:@stable')
+            /*
+             * @legacy doctrine/migrations does not support psr/log >=2
+             *         some symfony components use psr/log ^1 || ^2 || ^3
+             *         once doctrine/migrations supports psr log >= 2, this line can be removed.
+             */
+            ->addExtraDependencies('psr/log:^1.1.4')
             ->assert(function (string $output, string $directory) {
                 $this->assertStringContainsString('Success', $output);
 
@@ -54,6 +60,12 @@ class MakeMigrationTest extends MakerTestCase
             // sync the database, so no changes are needed
             ->configureDatabase()
             ->addExtraDependencies('doctrine/orm:@stable')
+            /*
+             * @legacy doctrine/migrations does not support psr/log >=2
+             *         some symfony components use psr/log ^1 || ^2 || ^3
+             *         once doctrine/migrations supports psr log >= 2, this line can be removed.
+             */
+            ->addExtraDependencies('psr/log:^1.1.4')
             ->assert(function (string $output, string $directory) {
                 $this->assertStringNotContainsString('Success', $output);
 
@@ -71,6 +83,12 @@ class MakeMigrationTest extends MakerTestCase
             ->configureDatabase(false)
             ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
             ->addExtraDependencies('doctrine/orm:@stable')
+            /*
+             * @legacy doctrine/migrations does not support psr/log >=2
+             *         some symfony components use psr/log ^1 || ^2 || ^3
+             *         once doctrine/migrations supports psr log >= 2, this line can be removed.
+             */
+            ->addExtraDependencies('psr/log:^1.1.4')
             // generate a migration first
             ->addPreMakeCommand('php bin/console make:migration')
             ->assert(function (string $output, string $directory) {
@@ -90,6 +108,12 @@ class MakeMigrationTest extends MakerTestCase
             ->configureDatabase(false)
             ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
             ->addExtraDependencies('doctrine/orm:@stable')
+            /*
+             * @legacy doctrine/migrations does not support psr/log >=2
+             *         some symfony components use psr/log ^1 || ^2 || ^3
+             *         once doctrine/migrations supports psr log >= 2, this line can be removed.
+             */
+            ->addExtraDependencies('psr/log:^1.1.4')
             // generate a migration first
             ->addPreMakeCommand('php bin/console make:migration')
             ->assert(function (string $output, string $directory) {


### PR DESCRIPTION
- We don't have a `5.x` branch anymore on `symfony/symfony` - let's use the `dev` version specified in `versions.json` in place of the `5.x` branch.
- `SYMFONY_REQUIRE` env param in CI overrides the stability version specified for the run, resulting in a mixed set of versioned packages for each test. e.g. `symfony/http === v5.3.0` && `symfony/twig-bridge === v5.4.x-dev` even though `SYMFONY_SKELETON_STABILITY=dev` is set. 
- some symfony components now use `psr/log` `^1 || ^2 || ^3` but `doctrine/migrations` still uses `^1`. For migrations tests, because `doctrine/orm` is required after the skeleton has been built, there is a version conflict w/ the locked, `psr/log:2.0` and `doctrine/migrations`. Calling `psr/log:^1.1.4` resolves this issue and allows the tests to run.

_contains `@legacy` tags for internal use:_
- Remove `psr/log:^1.1.4` as extraDependency in `MakeMigrationsTest` once https://github.com/doctrine/migrations/pull/1184 is merged, tagged, and released.