### PR TITLE
Fix: usage of deprecated $container property

### DIFF
--- a/src/Resources/skeleton/test/KernelTestCase.tpl.php
+++ b/src/Resources/skeleton/test/KernelTestCase.tpl.php
@@ -11,7 +11,7 @@ class <?= $class_name ?> extends KernelTestCase
         $kernel = self::bootKernel();
 
         $this->assertSame('test', $kernel->getEnvironment());
-        //$routerService = self::$container->get('router');
-        //$myCustomService = self::$container->get(CustomService::class);
+        //$routerService = self::getContainer()->get('router');
+        //$myCustomService = self::getContainer()->get(CustomService::class);
     }
 }


### PR DESCRIPTION
This is a deprecation that arrived with Symfony 5.3. 

This should be merged only before Symfony 6.0 IMO. Or another solution depending on the Symfony version should be implemented. Your call.