### PR TITLE
[make:entity] Remove deprecated json_array type from available list types.

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -422,6 +422,8 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
     private function printAvailableTypes(ConsoleStyle $io)
     {
         $allTypes = Type::getTypesMap();
+        // remove deprecated json_array
+        unset($allTypes[Type::JSON_ARRAY]);
 
         if ('Hyper' === getenv('TERM_PROGRAM')) {
             $wizard = 'wizard 🧙';


### PR DESCRIPTION
In a fix #482 json_array type was removed from using but it's available in a list of types. In section Other Types