### PR TITLE
[make:reset-password] Add required packages to MakeResetPassword.

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -102,6 +102,8 @@ class MakeResetPassword extends AbstractMaker
     {
         $dependencies->addClassDependency(SymfonyCastsResetPasswordBundle::class, 'symfonycasts/reset-password-bundle');
         $dependencies->addClassDependency(MailerInterface::class, 'symfony/mailer');
+        $dependencies->addClassDependency(Forms::class, 'symfony/form');
+        $dependencies->addClassDependency(Validation::class, 'symfony/validator');
 
         ORMDependencyBuilder::buildDependencies($dependencies);
 

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -32,6 +32,7 @@ use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Form\Forms;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,6 +41,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
 use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
@@ -50,8 +52,6 @@ use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepository
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelper;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 use SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle;
-use Symfony\Component\Form\Forms;
-use Symfony\Component\Validator\Validation;
 
 /**
  * @author Romaric Drigon <romaric.drigon@gmail.com>

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -50,6 +50,8 @@ use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepository
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelper;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
 use SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Romaric Drigon <romaric.drigon@gmail.com>

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -32,8 +32,6 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
-            ->addExtraDependencies('symfony/form')
-            ->addExtraDependencies('symfony/validator')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPassword')
             ->assert(
                 function (string $output, string $directory) {
@@ -80,8 +78,6 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
-            ->addExtraDependencies('symfony/form')
-            ->addExtraDependencies('symfony/validator')
             ->deleteFile('config/packages/reset_password.yaml')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordCustomConfig')
             ->assert(
@@ -109,8 +105,6 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
-            ->addExtraDependencies('symfony/form')
-            ->addExtraDependencies('symfony/validator')
             ->addReplacement(
                 'config/packages/reset_password.yaml',
                 'symfonycasts_reset_password:',
@@ -163,8 +157,6 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
-            ->addExtraDependencies('symfony/form')
-            ->addExtraDependencies('symfony/validator')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordCustomUserAttribute')
             ->assert(
                 function (string $output, string $directory) {

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -32,6 +32,8 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
+            ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/validator')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPassword')
             ->assert(
                 function (string $output, string $directory) {
@@ -78,6 +80,8 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
+            ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/validator')
             ->deleteFile('config/packages/reset_password.yaml')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordCustomConfig')
             ->assert(
@@ -105,6 +109,8 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
+            ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/validator')
             ->addReplacement(
                 'config/packages/reset_password.yaml',
                 'symfonycasts_reset_password:',
@@ -157,6 +163,8 @@ class MakeResetPasswordTest extends MakerTestCase
             ->setRequiredPhpVersion(70200)
             ->addExtraDependencies('security-bundle')
             ->addExtraDependencies('twig')
+            ->addExtraDependencies('symfony/form')
+            ->addExtraDependencies('symfony/validator')
             ->setFixtureFilesPath(__DIR__.'/../fixtures/MakeResetPasswordCustomUserAttribute')
             ->assert(
                 function (string $output, string $directory) {


### PR DESCRIPTION
As mentioned in issue: https://github.com/symfony/maker-bundle/issues/911 add the packages `symfony/form` and `symfony/validator` as required.  