### PR TITLE
[make:subscriber] Improve MakeSubscriber to use KernelEvents constant instead hardcoded event

### DIFF
--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -127,17 +127,12 @@ final class MakeSubscriber extends AbstractMaker
 
     private function getEventConstant(string $event): ?string
     {
-        $constants = $this->getKernelEventsConstants();
+        $constants = (new \ReflectionClass(KernelEvents::class))->getConstants();
 
         if (false !== ($name = array_search($event, $constants, true))) {
             return sprintf('KernelEvents::%s', $name);
         }
 
         return null;
-    }
-
-    private function getKernelEventsConstants(): array
-    {
-        return (new \ReflectionClass(KernelEvents::class))->getConstants();
     }
 }

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -121,10 +121,7 @@ final class MakeSubscriber extends AbstractMaker
     {
     }
 
-    /**
-     * @param $event
-     */
-    private function getEventConstant($event): string
+    private function getEventConstant(string $event): string
     {
         $constants = $this->getKernelEventsConstants();
 
@@ -137,10 +134,7 @@ final class MakeSubscriber extends AbstractMaker
         return sprintf('\'%s\'', $event);
     }
 
-    /**
-     * @param $event
-     */
-    private function isNeedImportConstantsClass($event): bool
+    private function isNeedImportConstantsClass(string $event): bool
     {
         $constants = $this->getKernelEventsConstants();
 
@@ -155,8 +149,6 @@ final class MakeSubscriber extends AbstractMaker
 
     private function getKernelEventsConstants(): array
     {
-        $class = new \ReflectionClass(KernelEvents::class);
-
-        return $class->getConstants();
+        return (new \ReflectionClass(KernelEvents::class))->getConstants();
     }
 }

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -23,8 +23,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -101,7 +101,7 @@ final class MakeSubscriber extends AbstractMaker
             'event/Subscriber.tpl.php',
             [
                 'use_statements' => $useStatements,
-                'event' =>  class_exists($event) ? sprintf('%s::class', $eventClassName) : $this->getEventConstant($event),
+                'event' => class_exists($event) ? sprintf('%s::class', $eventClassName) : $this->getEventConstant($event),
                 'event_arg' => $eventClassName ? sprintf('%s $event', $eventClassName) : '$event',
                 'method_name' => class_exists($event) ? Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
             ]

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -88,6 +88,10 @@ final class MakeSubscriber extends AbstractMaker
             EventSubscriberInterface::class,
         ]);
 
+        if ($this->isNeedImportConstantsClass($event)) {
+            $useStatements->addUseStatement(KernelEvents::class);
+        }
+
         if (null !== $eventFullClassName) {
             $useStatements->addUseStatement($eventFullClassName);
         }
@@ -99,8 +103,6 @@ final class MakeSubscriber extends AbstractMaker
                 'use_statements' => $useStatements,
                 'event' =>  class_exists($event) ? sprintf('%s::class', $eventClassName) : $this->getEventConstant($event),
                 'event_arg' => $eventClassName ? sprintf('%s $event', $eventClassName) : '$event',
-                'import_constant_class' => $this->isNeedImportConstantsClass($event),
-                'event_full_class_name' => $eventFullClassName,
                 'method_name' => class_exists($event) ? Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
             ]
         );

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -121,7 +121,6 @@ final class MakeSubscriber extends AbstractMaker
 
     /**
      * @param $event
-     * @return string
      */
     private function getEventConstant($event): string
     {
@@ -129,7 +128,7 @@ final class MakeSubscriber extends AbstractMaker
 
         foreach ($constants as $name => $value) {
             if ($value === $event) {
-                return 'KernelEvents::' . $name;
+                return 'KernelEvents::'.$name;
             }
         }
 
@@ -138,7 +137,6 @@ final class MakeSubscriber extends AbstractMaker
 
     /**
      * @param $event
-     * @return bool
      */
     private function isNeedImportConstantsClass($event): bool
     {
@@ -153,12 +151,10 @@ final class MakeSubscriber extends AbstractMaker
         return false;
     }
 
-    /**
-     * @return array
-     */
     private function getKernelEventsConstants(): array
     {
         $class = new \ReflectionClass(KernelEvents::class);
+
         return $class->getConstants();
     }
 }

--- a/tests/Maker/MakeSubscriberTest.php
+++ b/tests/Maker/MakeSubscriberTest.php
@@ -42,6 +42,24 @@ class MakeSubscriberTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_makes_subscriber_for_custom_event_class' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // subscriber name
+                        'FooBar',
+                        // event name
+                        \Symfony\Bundle\MakerBundle\Generator::class,
+                    ]
+                );
+
+                self::assertStringContainsString(
+                    'Generator::class => \'onGenerator\'',
+                    file_get_contents($runner->getPath('src/EventSubscriber/FooBarSubscriber.php'))
+                );
+            }),
+        ];
+
         yield 'it_makes_subscriber_for_unknown_event_class' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(

--- a/tests/Maker/MakeSubscriberTest.php
+++ b/tests/Maker/MakeSubscriberTest.php
@@ -22,7 +22,7 @@ class MakeSubscriberTest extends MakerTestCase
         return MakeSubscriber::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_makes_subscriber_for_known_event' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {

--- a/tests/Maker/MakeSubscriberTest.php
+++ b/tests/Maker/MakeSubscriberTest.php
@@ -54,7 +54,7 @@ class MakeSubscriberTest extends MakerTestCase
                 );
 
                 self::assertStringContainsString(
-                    'foo.unknown_event => \'onFooUnknownEvent\',',
+                    '\'foo.unknown_event\' => \'onFooUnknownEvent\',',
                     file_get_contents($runner->getPath('src/EventSubscriber/FooBarSubscriber.php'))
                 );
             }),

--- a/tests/Maker/MakeSubscriberTest.php
+++ b/tests/Maker/MakeSubscriberTest.php
@@ -34,6 +34,11 @@ class MakeSubscriberTest extends MakerTestCase
                         'kernel.request',
                     ]
                 );
+
+                self::assertStringContainsString(
+                    'KernelEvents::REQUEST => \'onKernelRequest\'',
+                    file_get_contents($runner->getPath('src/EventSubscriber/FooBarSubscriber.php'))
+                );
             }),
         ];
 
@@ -46,6 +51,11 @@ class MakeSubscriberTest extends MakerTestCase
                         // event name
                         'foo.unknown_event',
                     ]
+                );
+
+                self::assertStringContainsString(
+                    'foo.unknown_event => \'onFooUnknownEvent\',',
+                    file_get_contents($runner->getPath('src/EventSubscriber/FooBarSubscriber.php'))
                 );
             }),
         ];


### PR DESCRIPTION
Use KernelEvents constant instead hardcoded event type in MakeSubscriber.
#744 