### PR TITLE
add return types for symfony 6

### DIFF
--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -50,12 +50,12 @@ final class MakerCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->maker->configureCommand($this, $this->inputConfig);
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->io = new ConsoleStyle($input, $output);
         $this->fileManager->setIO($this->io);
@@ -74,7 +74,7 @@ final class MakerCommand extends Command
         }
     }
 
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         if (!$this->fileManager->isNamespaceConfiguredToAutoload($this->generator->getRootNamespace())) {
             $this->io->note([
@@ -111,7 +111,7 @@ final class MakerCommand extends Command
         return 0;
     }
 
-    public function setApplication(Application $application = null)
+    public function setApplication(Application $application = null): void
     {
         parent::setApplication($application);
 
@@ -127,7 +127,7 @@ final class MakerCommand extends Command
     /**
      * @internal Used for testing commands
      */
-    public function setCheckDependencies(bool $checkDeps)
+    public function setCheckDependencies(bool $checkDeps): void
     {
         $this->checkDependencies = $checkDeps;
     }

--- a/src/ConsoleStyle.php
+++ b/src/ConsoleStyle.php
@@ -30,12 +30,12 @@ final class ConsoleStyle extends SymfonyStyle
         parent::__construct($input, $output);
     }
 
-    public function success($message)
+    public function success($message): void
     {
         $this->writeln('<fg=green;options=bold,underscore>OK</> '.$message);
     }
 
-    public function comment($message)
+    public function comment($message): void
     {
         $this->text($message);
     }

--- a/src/DependencyBuilder.php
+++ b/src/DependencyBuilder.php
@@ -25,7 +25,7 @@ final class DependencyBuilder
      * the user if other required dependencies are missing. An example
      * is the "validator" when trying to work with forms.
      */
-    public function addClassDependency(string $class, string $package, bool $required = true, bool $devDependency = false)
+    public function addClassDependency(string $class, string $package, bool $required = true, bool $devDependency = false): void
     {
         if ($devDependency) {
             $this->devDependencies[] = [
@@ -42,7 +42,7 @@ final class DependencyBuilder
         }
     }
 
-    public function requirePHP71()
+    public function requirePHP71(): void
     {
         // no-op - MakerBundle now required PHP 7.1
     }

--- a/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
+++ b/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
@@ -25,7 +25,7 @@ class MakeCommandRegistrationPass implements CompilerPassInterface
 {
     public const MAKER_TAG = 'maker.command';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         foreach ($container->findTaggedServiceIds(self::MAKER_TAG) as $id => $tags) {
             $def = $container->getDefinition($id);

--- a/src/DependencyInjection/CompilerPass/RemoveMissingParametersPass.php
+++ b/src/DependencyInjection/CompilerPass/RemoveMissingParametersPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RemoveMissingParametersPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasParameter('twig.default_path')) {
             $container->getDefinition('maker.file_manager')

--- a/src/DependencyInjection/CompilerPass/SetDoctrineAnnotatedPrefixesPass.php
+++ b/src/DependencyInjection/CompilerPass/SetDoctrineAnnotatedPrefixesPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class SetDoctrineAnnotatedPrefixesPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $annotatedPrefixes = null;
 

--- a/src/DependencyInjection/CompilerPass/SetDoctrineManagerRegistryClassPass.php
+++ b/src/DependencyInjection/CompilerPass/SetDoctrineManagerRegistryClassPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class SetDoctrineManagerRegistryClassPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasAlias(ManagerRegistry::class)) {
             $definition = $container->getDefinition('maker.entity_class_generator');

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('maker');
         if (method_exists($treeBuilder, 'getRootNode')) {

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -34,7 +34,7 @@ class MakerExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Doctrine/BaseRelation.php
+++ b/src/Doctrine/BaseRelation.php
@@ -26,36 +26,36 @@ abstract class BaseRelation
 
     abstract public function isOwning(): bool;
 
-    public function getPropertyName()
+    public function getPropertyName(): string
     {
         return $this->propertyName;
     }
 
-    public function setPropertyName($propertyName)
+    public function setPropertyName(string $propertyName): self
     {
         $this->propertyName = $propertyName;
 
         return $this;
     }
 
-    public function getTargetClassName()
+    public function getTargetClassName(): string
     {
         return $this->targetClassName;
     }
 
-    public function setTargetClassName($targetClassName)
+    public function setTargetClassName(string $targetClassName): self
     {
         $this->targetClassName = $targetClassName;
 
         return $this;
     }
 
-    public function getTargetPropertyName()
+    public function getTargetPropertyName(): ?string
     {
         return $this->targetPropertyName;
     }
 
-    public function setTargetPropertyName($targetPropertyName)
+    public function setTargetPropertyName(?string $targetPropertyName): self
     {
         $this->targetPropertyName = $targetPropertyName;
 
@@ -67,7 +67,7 @@ abstract class BaseRelation
         return $this->isSelfReferencing;
     }
 
-    public function setIsSelfReferencing(bool $isSelfReferencing)
+    public function setIsSelfReferencing(bool $isSelfReferencing): self
     {
         $this->isSelfReferencing = $isSelfReferencing;
 
@@ -79,7 +79,7 @@ abstract class BaseRelation
         return $this->mapInverseRelation;
     }
 
-    public function setMapInverseRelation(bool $mapInverseRelation)
+    public function setMapInverseRelation(bool $mapInverseRelation): self
     {
         $this->mapInverseRelation = $mapInverseRelation;
 
@@ -91,7 +91,7 @@ abstract class BaseRelation
         return $this->avoidSetter;
     }
 
-    public function avoidSetter(bool $avoidSetter = true)
+    public function avoidSetter(bool $avoidSetter = true): self
     {
         $this->avoidSetter = $avoidSetter;
 

--- a/src/Doctrine/BaseSingleRelation.php
+++ b/src/Doctrine/BaseSingleRelation.php
@@ -27,7 +27,7 @@ abstract class BaseSingleRelation extends BaseRelation
         return false;
     }
 
-    public function setIsNullable($isNullable)
+    public function setIsNullable(bool $isNullable): self
     {
         $this->isNullable = $isNullable;
 

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -213,10 +213,7 @@ final class DoctrineHelper
         return $metadata;
     }
 
-    /**
-     * @return EntityDetails|null
-     */
-    public function createDoctrineDetails(string $entityClassName)
+    public function createDoctrineDetails(string $entityClassName): ?EntityDetails
     {
         $metadata = $this->getMetadata($entityClassName);
 

--- a/src/Doctrine/EntityDetails.php
+++ b/src/Doctrine/EntityDetails.php
@@ -31,7 +31,7 @@ final class EntityDetails
         $this->metadata = $metadata;
     }
 
-    public function getRepositoryClass()
+    public function getRepositoryClass(): ?string
     {
         return $this->metadata->customRepositoryClassName;
     }
@@ -41,12 +41,12 @@ final class EntityDetails
         return $this->metadata->identifier[0];
     }
 
-    public function getDisplayFields()
+    public function getDisplayFields(): array
     {
         return $this->metadata->fieldMappings;
     }
 
-    public function getFormFields()
+    public function getFormFields(): array
     {
         $fields = (array) $this->metadata->fieldNames;
         // Remove the primary key field if it's not managed manually

--- a/src/Doctrine/EntityRegenerator.php
+++ b/src/Doctrine/EntityRegenerator.php
@@ -40,7 +40,7 @@ final class EntityRegenerator
         $this->overwrite = $overwrite;
     }
 
-    public function regenerateEntities(string $classOrNamespace)
+    public function regenerateEntities(string $classOrNamespace): void
     {
         try {
             $metadata = $this->doctrineHelper->getMetadata($classOrNamespace);
@@ -215,7 +215,7 @@ final class EntityRegenerator
         return (new \ReflectionClass($class))->getFileName();
     }
 
-    private function generateRepository(ClassMetadata $metadata)
+    private function generateRepository(ClassMetadata $metadata): void
     {
         if (!$metadata->customRepositoryClassName) {
             return;
@@ -235,7 +235,7 @@ final class EntityRegenerator
         $this->generator->writeChanges();
     }
 
-    private function getMappedFieldsInEntity(ClassMetadata $classMetadata)
+    private function getMappedFieldsInEntity(ClassMetadata $classMetadata): array
     {
         /* @var $classReflection \ReflectionClass */
         $classReflection = $classMetadata->reflClass;

--- a/src/Doctrine/EntityRelation.php
+++ b/src/Doctrine/EntityRelation.php
@@ -55,12 +55,12 @@ final class EntityRelation
         $this->isSelfReferencing = $owningClass === $inverseClass;
     }
 
-    public function setOwningProperty(string $owningProperty)
+    public function setOwningProperty(string $owningProperty): void
     {
         $this->owningProperty = $owningProperty;
     }
 
-    public function setInverseProperty(string $inverseProperty)
+    public function setInverseProperty(string $inverseProperty): void
     {
         if (!$this->mapInverseRelation) {
             throw new \Exception('Cannot call setInverseProperty() when the inverse relation will not be mapped.');
@@ -69,12 +69,12 @@ final class EntityRelation
         $this->inverseProperty = $inverseProperty;
     }
 
-    public function setIsNullable(bool $isNullable)
+    public function setIsNullable(bool $isNullable): void
     {
         $this->isNullable = $isNullable;
     }
 
-    public function setOrphanRemoval(bool $orphanRemoval)
+    public function setOrphanRemoval(bool $orphanRemoval): void
     {
         $this->orphanRemoval = $orphanRemoval;
     }

--- a/src/Doctrine/ORMDependencyBuilder.php
+++ b/src/Doctrine/ORMDependencyBuilder.php
@@ -23,7 +23,7 @@ final class ORMDependencyBuilder
     /**
      * Central method to add dependencies needed for Doctrine ORM.
      */
-    public static function buildDependencies(DependencyBuilder $dependencies)
+    public static function buildDependencies(DependencyBuilder $dependencies): void
     {
         $classes = [
             // guarantee DoctrineBundle

--- a/src/Doctrine/RelationManyToMany.php
+++ b/src/Doctrine/RelationManyToMany.php
@@ -25,7 +25,7 @@ final class RelationManyToMany extends BaseCollectionRelation
         return $this->isOwning;
     }
 
-    public function setIsOwning($isOwning)
+    public function setIsOwning($isOwning): self
     {
         $this->isOwning = $isOwning;
 

--- a/src/Doctrine/RelationOneToMany.php
+++ b/src/Doctrine/RelationOneToMany.php
@@ -25,7 +25,7 @@ final class RelationOneToMany extends BaseCollectionRelation
         return $this->orphanRemoval;
     }
 
-    public function setOrphanRemoval($orphanRemoval)
+    public function setOrphanRemoval($orphanRemoval): self
     {
         $this->orphanRemoval = $orphanRemoval;
 

--- a/src/Doctrine/RelationOneToOne.php
+++ b/src/Doctrine/RelationOneToOne.php
@@ -25,19 +25,19 @@ final class RelationOneToOne extends BaseSingleRelation
         return $this->isOwning;
     }
 
-    public function setIsOwning($isOwning)
+    public function setIsOwning($isOwning): self
     {
         $this->isOwning = $isOwning;
 
         return $this;
     }
 
-    public function getTargetGetterMethodName()
+    public function getTargetGetterMethodName(): string
     {
         return 'get'.Str::asCamelCase($this->getTargetPropertyName());
     }
 
-    public function getTargetSetterMethodName()
+    public function getTargetSetterMethodName(): string
     {
         return 'set'.Str::asCamelCase($this->getTargetPropertyName());
     }

--- a/src/Event/ConsoleErrorSubscriber.php
+++ b/src/Event/ConsoleErrorSubscriber.php
@@ -27,7 +27,7 @@ final class ConsoleErrorSubscriber implements EventSubscriberInterface
 {
     private $setExitCode = false;
 
-    public function onConsoleError(ConsoleErrorEvent $event)
+    public function onConsoleError(ConsoleErrorEvent $event): void
     {
         if (!$event->getError() instanceof RuntimeCommandException) {
             return;
@@ -43,7 +43,7 @@ final class ConsoleErrorSubscriber implements EventSubscriberInterface
         $io->error($event->getError()->getMessage());
     }
 
-    public function onConsoleTerminate(ConsoleTerminateEvent $event)
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void
     {
         if (!$this->setExitCode) {
             return;
@@ -53,7 +53,7 @@ final class ConsoleErrorSubscriber implements EventSubscriberInterface
         $event->setExitCode(1);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ConsoleEvents::ERROR => 'onConsoleError',

--- a/src/EventRegistry.php
+++ b/src/EventRegistry.php
@@ -123,7 +123,7 @@ class EventRegistry
     /**
      * Attempts to get the event class for a given event.
      */
-    public function getEventClassName(string $event)
+    public function getEventClassName(string $event): ?string
     {
         // if the event is already a class name, use it
         if (class_exists($event)) {
@@ -169,7 +169,7 @@ class EventRegistry
         return null;
     }
 
-    public function listActiveEvents(array $events)
+    public function listActiveEvents(array $events): array
     {
         foreach ($events as $key => $event) {
             $events[$key] = sprintf('%s (<fg=yellow>%s</>)', $event, self::$eventsMap[$event]);

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -49,7 +49,7 @@ class FileManager
         $this->twigDefaultPath = $twigDefaultPath ? rtrim($this->relativizePath($twigDefaultPath), '/') : null;
     }
 
-    public function setIO(SymfonyStyle $io)
+    public function setIO(SymfonyStyle $io): void
     {
         $this->io = $io;
     }
@@ -63,7 +63,7 @@ class FileManager
         return ob_get_clean();
     }
 
-    public function dumpFile(string $filename, string $content)
+    public function dumpFile(string $filename, string $content): void
     {
         $absolutePath = $this->absolutizePath($filename);
         $newFile = !$this->fileExists($filename);
@@ -155,11 +155,9 @@ class FileManager
     }
 
     /**
-     * @return string|null
-     *
      * @throws \Exception
      */
-    public function getRelativePathForFutureClass(string $className)
+    public function getRelativePathForFutureClass(string $className): ?string
     {
         $path = $this->autoloaderUtil->getPathForFutureClass($className);
 

--- a/src/InputConfiguration.php
+++ b/src/InputConfiguration.php
@@ -19,7 +19,7 @@ final class InputConfiguration
      * Call in MakerInterface::configureCommand() to disable the automatic interactive
      * prompt for an argument.
      */
-    public function setArgumentAsNonInteractive(string $argumentName)
+    public function setArgumentAsNonInteractive(string $argumentName): void
     {
         $this->nonInteractiveArguments[] = $argumentName;
     }

--- a/src/Renderer/FormTypeRenderer.php
+++ b/src/Renderer/FormTypeRenderer.php
@@ -27,7 +27,7 @@ final class FormTypeRenderer
         $this->generator = $generator;
     }
 
-    public function render(ClassNameDetails $formClassDetails, array $formFields, ClassNameDetails $boundClassDetails = null, array $constraintClasses = [], array $extraUseClasses = [])
+    public function render(ClassNameDetails $formClassDetails, array $formFields, ClassNameDetails $boundClassDetails = null, array $constraintClasses = [], array $extraUseClasses = []): void
     {
         $fieldTypeUseStatements = [];
         $fields = [];

--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -145,7 +145,7 @@ final class SecurityConfigUpdater
         return $this->manipulator->getContents();
     }
 
-    private function normalizeSecurityYamlFile()
+    private function normalizeSecurityYamlFile(): void
     {
         if (!isset($this->manipulator->getData()['security'])) {
             $newData = $this->manipulator->getData();
@@ -154,7 +154,7 @@ final class SecurityConfigUpdater
         }
     }
 
-    private function updateProviders(UserClassConfiguration $userConfig, string $userClass)
+    private function updateProviders(UserClassConfiguration $userConfig, string $userClass): void
     {
         $this->removeMemoryProviderIfIsSingleConfigured();
 
@@ -185,7 +185,7 @@ final class SecurityConfigUpdater
         $this->manipulator->setData($newData);
     }
 
-    private function updatePasswordHashers(UserClassConfiguration $userConfig, string $userClass, string $keyName = 'password_hashers')
+    private function updatePasswordHashers(UserClassConfiguration $userConfig, string $userClass, string $keyName = 'password_hashers'): void
     {
         $newData = $this->manipulator->getData();
         if ('password_hashers' === $keyName && isset($newData['security']['encoders'])) {
@@ -217,7 +217,7 @@ final class SecurityConfigUpdater
         $this->manipulator->setData($newData);
     }
 
-    private function removeMemoryProviderIfIsSingleConfigured()
+    private function removeMemoryProviderIfIsSingleConfigured(): void
     {
         if (!$this->isSingleInMemoryProviderConfigured()) {
             return;

--- a/src/Security/SecurityControllerBuilder.php
+++ b/src/Security/SecurityControllerBuilder.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
  */
 final class SecurityControllerBuilder
 {
-    public function addLoginMethod(ClassSourceManipulator $manipulator)
+    public function addLoginMethod(ClassSourceManipulator $manipulator): void
     {
         $loginMethodBuilder = $manipulator->createMethodBuilder('login', 'Response', false, ['@Route("/login", name="app_login")']);
 
@@ -64,7 +64,7 @@ CODE
         $manipulator->addMethodBuilder($loginMethodBuilder);
     }
 
-    public function addLogoutMethod(ClassSourceManipulator $manipulator)
+    public function addLogoutMethod(ClassSourceManipulator $manipulator): void
     {
         $logoutMethodBuilder = $manipulator->createMethodBuilder('logout', null, false, ['@Route("/logout", name="app_logout")']);
 

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -129,7 +129,7 @@ final class UserClassBuilder
         }
     }
 
-    private function addGetRoles(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig)
+    private function addGetRoles(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
     {
         if ($userClassConfig->isEntity()) {
             // add entity property
@@ -206,7 +206,7 @@ final class UserClassBuilder
         $manipulator->addMethodBuilder($builder);
     }
 
-    private function addGetPassword(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig)
+    private function addGetPassword(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
     {
         $seeInterface = interface_exists(PasswordAuthenticatedUserInterface::class) ? '@see PasswordAuthenticatedUserInterface' : '@see UserInterface';
 
@@ -275,7 +275,7 @@ final class UserClassBuilder
         );
     }
 
-    private function addGetSalt(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig)
+    private function addGetSalt(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
     {
         if ($userClassConfig->hasPassword()) {
             $methodDescription = [
@@ -313,7 +313,7 @@ final class UserClassBuilder
         $manipulator->addMethodBuilder($builder);
     }
 
-    private function addEraseCredentials(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig)
+    private function addEraseCredentials(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
     {
         // add eraseCredentials: always empty
         $builder = $manipulator->createMethodBuilder(

--- a/src/Security/UserClassConfiguration.php
+++ b/src/Security/UserClassConfiguration.php
@@ -53,7 +53,7 @@ final class UserClassConfiguration
     /**
      * @deprecated since MakerBundle 1.12
      */
-    public function useArgon2(bool $shouldUse)
+    public function useArgon2(bool $shouldUse): void
     {
         $this->useArgon2 = $shouldUse;
     }
@@ -66,12 +66,12 @@ final class UserClassConfiguration
         return $this->useArgon2;
     }
 
-    public function getUserProviderClass()
+    public function getUserProviderClass(): string
     {
         return $this->userProviderClass;
     }
 
-    public function setUserProviderClass(string $userProviderClass)
+    public function setUserProviderClass(string $userProviderClass): void
     {
         if ($this->isEntity()) {
             throw new \LogicException('No custom user class allowed for entity user.');

--- a/src/Test/MakerTestProcess.php
+++ b/src/Test/MakerTestProcess.php
@@ -54,17 +54,17 @@ final class MakerTestProcess
         return $this;
     }
 
-    public function isSuccessful()
+    public function isSuccessful(): bool
     {
         return $this->process->isSuccessful();
     }
 
-    public function getOutput()
+    public function getOutput(): string
     {
         return $this->process->getOutput();
     }
 
-    public function getErrorOutput()
+    public function getErrorOutput(): string
     {
         return $this->process->getErrorOutput();
     }

--- a/src/Util/AutoloaderUtil.php
+++ b/src/Util/AutoloaderUtil.php
@@ -33,11 +33,9 @@ class AutoloaderUtil
     /**
      * Returns the relative path to where a new class should live.
      *
-     * @return string|null
-     *
      * @throws \Exception
      */
-    public function getPathForFutureClass(string $className)
+    public function getPathForFutureClass(string $className): ?string
     {
         $classLoader = $this->getClassLoader();
 

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -73,7 +73,7 @@ final class ClassSourceManipulator
         $this->setSourceCode($sourceCode);
     }
 
-    public function setIo(ConsoleStyle $io)
+    public function setIo(ConsoleStyle $io): void
     {
         $this->io = $io;
     }
@@ -83,7 +83,7 @@ final class ClassSourceManipulator
         return $this->sourceCode;
     }
 
-    public function addEntityField(string $propertyName, array $columnOptions, array $comments = [])
+    public function addEntityField(string $propertyName, array $columnOptions, array $comments = []): void
     {
         $typeHint = $this->getEntityTypeHint($columnOptions['type']);
         $nullable = $columnOptions['nullable'] ?? false;
@@ -110,7 +110,7 @@ final class ClassSourceManipulator
         }
     }
 
-    public function addEmbeddedEntity(string $propertyName, string $className)
+    public function addEmbeddedEntity(string $propertyName, string $className): void
     {
         $typeHint = $this->addUseStatementIfNecessary($className);
 
@@ -150,27 +150,27 @@ final class ClassSourceManipulator
         $this->addSetter($propertyName, $typeHint, false);
     }
 
-    public function addManyToOneRelation(RelationManyToOne $manyToOne)
+    public function addManyToOneRelation(RelationManyToOne $manyToOne): void
     {
         $this->addSingularRelation($manyToOne);
     }
 
-    public function addOneToOneRelation(RelationOneToOne $oneToOne)
+    public function addOneToOneRelation(RelationOneToOne $oneToOne): void
     {
         $this->addSingularRelation($oneToOne);
     }
 
-    public function addOneToManyRelation(RelationOneToMany $oneToMany)
+    public function addOneToManyRelation(RelationOneToMany $oneToMany): void
     {
         $this->addCollectionRelation($oneToMany);
     }
 
-    public function addManyToManyRelation(RelationManyToMany $manyToMany)
+    public function addManyToManyRelation(RelationManyToMany $manyToMany): void
     {
         $this->addCollectionRelation($manyToMany);
     }
 
-    public function addInterface(string $interfaceName)
+    public function addInterface(string $interfaceName): void
     {
         $this->addUseStatementIfNecessary($interfaceName);
 
@@ -181,7 +181,7 @@ final class ClassSourceManipulator
     /**
      * @param string $trait the fully-qualified trait name
      */
-    public function addTrait(string $trait)
+    public function addTrait(string $trait): void
     {
         $importedClassName = $this->addUseStatementIfNecessary($trait);
 
@@ -217,19 +217,19 @@ final class ClassSourceManipulator
         $this->updateSourceCodeFromNewStmts();
     }
 
-    public function addAccessorMethod(string $propertyName, string $methodName, $returnType, bool $isReturnTypeNullable, array $commentLines = [], $typeCast = null)
+    public function addAccessorMethod(string $propertyName, string $methodName, $returnType, bool $isReturnTypeNullable, array $commentLines = [], $typeCast = null): void
     {
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines, $typeCast);
     }
 
-    public function addGetter(string $propertyName, $returnType, bool $isReturnTypeNullable, array $commentLines = [])
+    public function addGetter(string $propertyName, $returnType, bool $isReturnTypeNullable, array $commentLines = []): void
     {
         $methodName = 'get'.Str::asCamelCase($propertyName);
 
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
     }
 
-    public function addSetter(string $propertyName, $type, bool $isNullable, array $commentLines = [])
+    public function addSetter(string $propertyName, $type, bool $isNullable, array $commentLines = []): void
     {
         $builder = $this->createSetterNodeBuilder($propertyName, $type, $isNullable, $commentLines);
         $builder->addStmt(
@@ -245,7 +245,7 @@ final class ClassSourceManipulator
     /**
      * @param Node[] $params
      */
-    public function addConstructor(array $params, string $methodBody)
+    public function addConstructor(array $params, string $methodBody): void
     {
         if (null !== $this->getConstructorNode()) {
             throw new \LogicException('Constructor already exists.');
@@ -264,7 +264,7 @@ final class ClassSourceManipulator
     /**
      * @param Node[] $params
      */
-    public function addMethodBuilder(Builder\Method $methodBuilder, array $params = [], string $methodBody = null)
+    public function addMethodBuilder(Builder\Method $methodBuilder, array $params = [], string $methodBody = null): void
     {
         $this->addMethodParams($methodBuilder, $params);
 
@@ -275,7 +275,7 @@ final class ClassSourceManipulator
         $this->addMethod($methodBuilder->getNode());
     }
 
-    public function addMethodBody(Builder\Method $methodBuilder, string $methodBody)
+    public function addMethodBody(Builder\Method $methodBuilder, string $methodBody): void
     {
         $nodes = $this->parser->parse($methodBody);
         $methodBuilder->addStmts($nodes);
@@ -311,7 +311,7 @@ final class ClassSourceManipulator
         return $this->createBlankLineNode(self::CONTEXT_CLASS_METHOD);
     }
 
-    public function addProperty(string $name, array $annotationLines = [], $defaultValue = null)
+    public function addProperty(string $name, array $annotationLines = [], $defaultValue = null): void
     {
         if ($this->propertyExists($name)) {
             // we never overwrite properties
@@ -331,7 +331,7 @@ final class ClassSourceManipulator
         $this->addNodeAfterProperties($newPropertyNode);
     }
 
-    public function addAnnotationToClass(string $annotationClass, array $options)
+    public function addAnnotationToClass(string $annotationClass, array $options): void
     {
         $annotationClassAlias = $this->addUseStatementIfNecessary($annotationClass);
         $docComment = $this->getClassNode()->getDocComment();
@@ -369,7 +369,7 @@ final class ClassSourceManipulator
         $this->updateSourceCodeFromNewStmts();
     }
 
-    private function addCustomGetter(string $propertyName, string $methodName, $returnType, bool $isReturnTypeNullable, array $commentLines = [], $typeCast = null)
+    private function addCustomGetter(string $propertyName, string $methodName, $returnType, bool $isReturnTypeNullable, array $commentLines = [], $typeCast = null): void
     {
         $propertyFetch = new Node\Expr\PropertyFetch(new Node\Expr\Variable('this'), $propertyName);
 
@@ -402,7 +402,7 @@ final class ClassSourceManipulator
         $this->addMethod($getterNodeBuilder->getNode());
     }
 
-    private function createSetterNodeBuilder(string $propertyName, $type, bool $isNullable, array $commentLines = [])
+    private function createSetterNodeBuilder(string $propertyName, $type, bool $isNullable, array $commentLines = []): Builder\Method
     {
         $methodName = 'set'.Str::asCamelCase($propertyName);
         $setterNodeBuilder = (new Builder\Method($methodName))->makePublic();
@@ -423,10 +423,8 @@ final class ClassSourceManipulator
     /**
      * @param string $annotationClass The annotation: e.g. "@ORM\Column"
      * @param array  $options         Key-value pair of options for the annotation
-     *
-     * @return string
      */
-    private function buildAnnotationLine(string $annotationClass, array $options)
+    private function buildAnnotationLine(string $annotationClass, array $options): string
     {
         $formattedOptions = array_map(function ($option, $value) {
             if (\is_array($value)) {
@@ -472,7 +470,7 @@ final class ClassSourceManipulator
         return sprintf('"%s"', $value);
     }
 
-    private function addSingularRelation(BaseRelation $relation)
+    private function addSingularRelation(BaseRelation $relation): void
     {
         $typeHint = $this->addUseStatementIfNecessary($relation->getTargetClassName());
         if ($relation->getTargetClassName() == $this->getThisFullClassName()) {
@@ -550,7 +548,7 @@ final class ClassSourceManipulator
         $this->addMethod($setterNodeBuilder->getNode());
     }
 
-    private function addCollectionRelation(BaseCollectionRelation $relation)
+    private function addCollectionRelation(BaseCollectionRelation $relation): void
     {
         $typeHint = $relation->isSelfReferencing() ? 'self' : $this->addUseStatementIfNecessary($relation->getTargetClassName());
 
@@ -730,7 +728,7 @@ final class ClassSourceManipulator
         $this->addMethod($removerNodeBuilder->getNode());
     }
 
-    private function addStatementToConstructor(Node\Stmt $stmt)
+    private function addStatementToConstructor(Node\Stmt $stmt): void
     {
         if (!$this->getConstructorNode()) {
             $constructorNode = (new Builder\Method('__construct'))->makePublic()->getNode();
@@ -756,11 +754,9 @@ final class ClassSourceManipulator
     }
 
     /**
-     * @return Node\Stmt\ClassMethod|null
-     *
      * @throws \Exception
      */
-    private function getConstructorNode()
+    private function getConstructorNode(): ?Node\Stmt\ClassMethod
     {
         foreach ($this->getClassNode()->stmts as $classNode) {
             if ($classNode instanceof Node\Stmt\ClassMethod && '__construct' == $classNode->name) {
@@ -849,7 +845,7 @@ final class ClassSourceManipulator
         return $shortClassName;
     }
 
-    private function updateSourceCodeFromNewStmts()
+    private function updateSourceCodeFromNewStmts(): void
     {
         $newCode = $this->printer->printFormatPreserving(
             $this->newStmts,
@@ -879,7 +875,7 @@ final class ClassSourceManipulator
         $this->setSourceCode($newCode);
     }
 
-    private function setSourceCode(string $sourceCode)
+    private function setSourceCode(string $sourceCode): void
     {
         $this->sourceCode = $sourceCode;
         $this->oldStmts = $this->parser->parse($sourceCode);
@@ -919,10 +915,7 @@ final class ClassSourceManipulator
         return $node;
     }
 
-    /**
-     * @return Node|null
-     */
-    private function findFirstNode(callable $filterCallback)
+    private function findFirstNode(callable $filterCallback): ?Node
     {
         $traverser = new NodeTraverser();
         $visitor = new NodeVisitor\FirstFindingVisitor($filterCallback);
@@ -932,10 +925,7 @@ final class ClassSourceManipulator
         return $visitor->getFoundNode();
     }
 
-    /**
-     * @return Node|null
-     */
-    private function findLastNode(callable $filterCallback, array $ast)
+    private function findLastNode(callable $filterCallback, array $ast): ?Node
     {
         $traverser = new NodeTraverser();
         $visitor = new NodeVisitor\FindingVisitor($filterCallback);
@@ -980,7 +970,7 @@ final class ClassSourceManipulator
         }
     }
 
-    private function createSingleLineCommentNode(string $comment, string $context)
+    private function createSingleLineCommentNode(string $comment, string $context): Node\Stmt
     {
         $this->pendingComments[] = $comment;
         switch ($context) {
@@ -997,7 +987,7 @@ final class ClassSourceManipulator
         }
     }
 
-    private function createDocBlock(array $commentLines)
+    private function createDocBlock(array $commentLines): string
     {
         $docBlock = "/**\n";
         foreach ($commentLines as $commentLine) {
@@ -1013,7 +1003,7 @@ final class ClassSourceManipulator
         return $docBlock;
     }
 
-    private function addMethod(Node\Stmt\ClassMethod $methodNode)
+    private function addMethod(Node\Stmt\ClassMethod $methodNode): void
     {
         $classNode = $this->getClassNode();
         $methodName = $methodNode->name;
@@ -1058,7 +1048,7 @@ final class ClassSourceManipulator
         $this->updateSourceCodeFromNewStmts();
     }
 
-    private function makeMethodFluent(Builder\Method $methodBuilder)
+    private function makeMethodFluent(Builder\Method $methodBuilder): void
     {
         if (!$this->fluentMutators) {
             return;
@@ -1071,7 +1061,7 @@ final class ClassSourceManipulator
         $methodBuilder->setReturnType('self');
     }
 
-    private function getEntityTypeHint($doctrineType)
+    private function getEntityTypeHint($doctrineType): ?string
     {
         switch ($doctrineType) {
             case 'string':
@@ -1120,7 +1110,7 @@ final class ClassSourceManipulator
         }
     }
 
-    private function isInSameNamespace($class)
+    private function isInSameNamespace($class): bool
     {
         $namespace = substr($class, 0, strrpos($class, '\\'));
 
@@ -1137,7 +1127,7 @@ final class ClassSourceManipulator
      *
      * Useful for adding properties, or adding a constructor.
      */
-    private function addNodeAfterProperties(Node $newNode)
+    private function addNodeAfterProperties(Node $newNode): void
     {
         $classNode = $this->getClassNode();
 
@@ -1185,12 +1175,12 @@ final class ClassSourceManipulator
         $this->updateSourceCodeFromNewStmts();
     }
 
-    private function createNullConstant()
+    private function createNullConstant(): Node\Expr\ConstFetch
     {
         return new Node\Expr\ConstFetch(new Node\Name('null'));
     }
 
-    private function addNodesToSetOtherSideOfOneToOne(RelationOneToOne $relation, Builder\Method $setterNodeBuilder)
+    private function addNodesToSetOtherSideOfOneToOne(RelationOneToOne $relation, Builder\Method $setterNodeBuilder): void
     {
         if (!$relation->isNullable()) {
             $setterNodeBuilder->addStmt($this->createSingleLineCommentNode(
@@ -1302,7 +1292,7 @@ final class ClassSourceManipulator
         return false;
     }
 
-    private function propertyExists(string $propertyName)
+    private function propertyExists(string $propertyName): bool
     {
         foreach ($this->getClassNode()->stmts as $i => $node) {
             if ($node instanceof Node\Stmt\Property && $node->props[0]->name->toString() === $propertyName) {
@@ -1313,14 +1303,14 @@ final class ClassSourceManipulator
         return false;
     }
 
-    private function writeNote(string $note)
+    private function writeNote(string $note): void
     {
         if (null !== $this->io) {
             $this->io->text($note);
         }
     }
 
-    private function addMethodParams(Builder\Method $methodBuilder, array $params)
+    private function addMethodParams(Builder\Method $methodBuilder, array $params): void
     {
         foreach ($params as $param) {
             $methodBuilder->addParam($param);

--- a/src/Util/ComposerAutoloaderFinder.php
+++ b/src/Util/ComposerAutoloaderFinder.php
@@ -48,10 +48,7 @@ class ComposerAutoloaderFinder
         return $this->classLoader;
     }
 
-    /**
-     * @return ClassLoader|null
-     */
-    private function findComposerClassLoader()
+    private function findComposerClassLoader(): ?ClassLoader
     {
         $autoloadFunctions = spl_autoload_functions();
 
@@ -74,10 +71,7 @@ class ComposerAutoloaderFinder
         return null;
     }
 
-    /**
-     * @return ClassLoader|null
-     */
-    private function extractComposerClassLoader(array $autoloader)
+    private function extractComposerClassLoader(array $autoloader): ?ClassLoader
     {
         if (isset($autoloader[0]) && \is_object($autoloader[0])) {
             if ($autoloader[0] instanceof ClassLoader) {
@@ -95,10 +89,7 @@ class ComposerAutoloaderFinder
         return null;
     }
 
-    /**
-     * @return ClassLoader|null
-     */
-    private function locateMatchingClassLoader(ClassLoader $classLoader)
+    private function locateMatchingClassLoader(ClassLoader $classLoader): ?ClassLoader
     {
         $makerClassLoader = null;
         foreach ($classLoader->getPrefixesPsr4() as $prefix => $paths) {

--- a/src/Util/PrettyPrinter.php
+++ b/src/Util/PrettyPrinter.php
@@ -34,7 +34,7 @@ final class PrettyPrinter extends Standard
      * also need to handle indent levels of 5, 9, etc: these
      * do not occur (at least in the code we generate);
      */
-    protected function setIndentLevel(int $level)
+    protected function setIndentLevel(int $level): void
     {
         if (1 === $level) {
             $level = 4;


### PR DESCRIPTION
- adds return types required to support Symfony 6

Also implements return types in other areas of the bundle as well.

Methodology:
- `internal` xor `final` classes return types added on all methods where possible
- All other classes, deprecation(s) to be added under a separate PR for methods that do not have a return type. return types to be added in the next major release.