### PR TITLE
Changed behaviour of Str::addSuffix so it doesn't care about duplicate suffixes

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -32,13 +32,11 @@ final class Str
     }
 
     /**
-     * Ensures that the given string ends with the given suffix. If the string
-     * already contains the suffix, it's not added twice. It's case-insensitive
-     * (e.g. value: 'Foocommand' suffix: 'Command' -> result: 'FooCommand').
+     * Ensures that the given string ends with the given suffix.
      */
     public static function addSuffix(string $value, string $suffix): string
     {
-        return self::removeSuffix($value, $suffix).$suffix;
+        return $value.$suffix;
     }
 
     /**

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -100,5 +100,13 @@ class GeneratorTest extends TestCase
             'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
             'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
         ];
+
+        yield 'repository_fqcn' => [
+            'Repository',
+            'Repository\\',
+            'Repository',
+            'App\\Repository\\RepositoryRepository',
+            'RepositoryRepository',
+        ];
     }
 }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -62,12 +62,12 @@ class StrTest extends TestCase
     {
         yield ['', '', ''];
         yield ['GenerateCommand', '', 'GenerateCommand'];
-        yield ['GenerateCommand', 'Command', 'GenerateCommand'];
-        yield ['GenerateCommand', 'command', 'Generatecommand'];
-        yield ['Generatecommand', 'Command', 'GenerateCommand'];
-        yield ['Generatecommand', 'command', 'Generatecommand'];
-        yield ['GenerateCommandCommand', 'Command', 'GenerateCommandCommand'];
-        yield ['GenerateCommandcommand', 'Command', 'GenerateCommandCommand'];
+        yield ['GenerateCommand', 'Command', 'GenerateCommandCommand'];
+        yield ['GenerateCommand', 'command', 'GenerateCommandcommand'];
+        yield ['Generatecommand', 'Command', 'GeneratecommandCommand'];
+        yield ['Generatecommand', 'command', 'Generatecommandcommand'];
+        yield ['GenerateCommandCommand', 'Command', 'GenerateCommandCommandCommand'];
+        yield ['GenerateCommandcommand', 'Command', 'GenerateCommandcommandCommand'];
         yield ['Generate', 'command', 'Generatecommand'];
         yield ['Generate', 'Command', 'GenerateCommand'];
     }
@@ -95,7 +95,7 @@ class StrTest extends TestCase
         yield ['gen-erate:Co-mman-d', '', 'GenErateCoMmanD'];
         yield ['generate', 'Command', 'GenerateCommand'];
         yield ['app:generate', 'Command', 'AppGenerateCommand'];
-        yield ['app:generate:command', 'Command', 'AppGenerateCommand'];
+        yield ['app:generate:command', 'Command', 'AppGenerateCommandCommand'];
     }
 
     public function provideAsTwigVariable()


### PR DESCRIPTION
This PR tries to resolve the issue: https://github.com/symfony/maker-bundle/issues/964

I'm still not sure why `Str::addSuffix` wanted to be sure that suffix is not added twice. So, let someone with bigger knowledge of the bundle and class name generation review the PR :)

Thanks!