### PR TITLE
[make:entity] APIP: use new attribute if exists

### DIFF
--- a/src/Doctrine/EntityRegenerator.php
+++ b/src/Doctrine/EntityRegenerator.php
@@ -44,7 +44,7 @@ final class EntityRegenerator
     {
         try {
             $metadata = $this->doctrineHelper->getMetadata($classOrNamespace);
-        } catch (MappingException | LegacyCommonMappingException | PersistenceMappingException $mappingException) {
+        } catch (MappingException|LegacyCommonMappingException|PersistenceMappingException $mappingException) {
             $metadata = $this->doctrineHelper->getMetadata($classOrNamespace, true);
         }
 

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -2,7 +2,8 @@
 
 namespace <?= $namespace ?>;
 
-<?php if ($api_resource): ?>use ApiPlatform\Core\Annotation\ApiResource;
+<?php if ($api_resource && class_exists(\ApiPlatform\Metadata\ApiResource::class)): ?>use ApiPlatform\Metadata\ApiResource;
+<?php elseif ($api_resource): ?>use ApiPlatform\Core\Annotation\ApiResource;
 <?php endif ?>
 use <?= $repository_full_class_name ?>;
 use Doctrine\ORM\Mapping as ORM;


### PR DESCRIPTION
Hi,

here is an update to use new `ApiResource` attribute from api platofrm v3 when providing `--api-resource` flag in `make:entity` command.

This cannot be tested yet since v3 is not released