### PR TITLE
make PhpCompatUtil::getPhpVersion() public

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -173,6 +173,7 @@ class Generator
         $variables['relative_path'] = $this->fileManager->relativizePath($targetPath);
         $variables['use_attributes'] = $this->phpCompatUtil->canUseAttributes();
         $variables['use_typed_properties'] = $this->phpCompatUtil->canUseTypedProperties();
+        $variables['use_union_types'] = $this->phpCompatUtil->canUseUnionTypes();
 
         $templatePath = $templateName;
         if (!file_exists($templatePath)) {

--- a/src/Util/PhpCompatUtil.php
+++ b/src/Util/PhpCompatUtil.php
@@ -43,6 +43,13 @@ class PhpCompatUtil
         return version_compare($version, '7.4', '>=');
     }
 
+    public function canUseUnionTypes(): bool
+    {
+        $version = $this->getPhpVersion();
+
+        return version_compare($version, '8alpha', '>=');
+    }
+
     protected function getPhpVersion(): string
     {
         $rootDirectory = $this->fileManager->getRootDirectory();

--- a/tests/Util/PhpVersionTest.php
+++ b/tests/Util/PhpVersionTest.php
@@ -26,28 +26,7 @@ class PhpVersionTest extends TestCase
      */
     public function testUsesPhpPlatformFromComposerJsonFileForCanUseAttributes(string $version, bool $expectedResult): void
     {
-        $json = sprintf('{"platform-overrides": {"php": "%s"}}', $version);
-
-        $mockFileManager = $this->createMock(FileManager::class);
-        $mockFileManager
-            ->expects(self::once())
-            ->method('getRootDirectory')
-            ->willReturn('/test')
-        ;
-
-        $mockFileManager
-            ->expects(self::once())
-            ->method('fileExists')
-            ->with('/test/composer.lock')
-            ->willReturn(true)
-        ;
-
-        $mockFileManager
-            ->expects(self::once())
-            ->method('getFileContents')
-            ->with('/test/composer.lock')
-            ->willReturn($json)
-        ;
+        $mockFileManager = $this->mockFileManager(sprintf('{"platform-overrides": {"php": "%s"}}', $version));
 
         $version = new PhpCompatUtil($mockFileManager);
 
@@ -110,28 +89,7 @@ class PhpVersionTest extends TestCase
 
     public function testWithoutPlatformVersionSet(): void
     {
-        $json = '{"platform-overrides": {}}';
-
-        $mockFileManager = $this->createMock(FileManager::class);
-        $mockFileManager
-            ->expects(self::once())
-            ->method('getRootDirectory')
-            ->willReturn('/test')
-        ;
-
-        $mockFileManager
-            ->expects(self::once())
-            ->method('fileExists')
-            ->with('/test/composer.lock')
-            ->willReturn(true)
-        ;
-
-        $mockFileManager
-            ->expects(self::once())
-            ->method('getFileContents')
-            ->with('/test/composer.lock')
-            ->willReturn($json)
-        ;
+        $mockFileManager = $this->mockFileManager('{"platform-overrides": {}}');
 
         $util = new PhpCompatUtilTestFixture($mockFileManager);
 
@@ -145,28 +103,7 @@ class PhpVersionTest extends TestCase
      */
     public function testCanUseTypedProperties(string $version, bool $expectedResult): void
     {
-        $json = sprintf('{"platform-overrides": {"php": "%s"}}', $version);
-
-        $mockFileManager = $this->createMock(FileManager::class);
-        $mockFileManager
-            ->expects(self::once())
-            ->method('getRootDirectory')
-            ->willReturn('/test')
-        ;
-
-        $mockFileManager
-            ->expects(self::once())
-            ->method('fileExists')
-            ->with('/test/composer.lock')
-            ->willReturn(true)
-        ;
-
-        $mockFileManager
-            ->expects(self::once())
-            ->method('getFileContents')
-            ->with('/test/composer.lock')
-            ->willReturn($json)
-        ;
+        $mockFileManager = $this->mockFileManager(sprintf('{"platform-overrides": {"php": "%s"}}', $version));
 
         $version = new PhpCompatUtil($mockFileManager);
 
@@ -185,6 +122,61 @@ class PhpVersionTest extends TestCase
         yield ['7', false];
         yield ['7.0', false];
         yield ['5.7', false];
+    }
+
+    /**
+     * @dataProvider phpVersionForUnionTypesDataProvider
+     */
+    public function testCanUseUnionTypes(string $version, bool $expectedResult): void
+    {
+        $mockFileManager = $this->mockFileManager(sprintf('{"platform-overrides": {"php": "%s"}}', $version));
+
+        $version = new PhpCompatUtil($mockFileManager);
+
+        $result = $version->canUseUnionTypes();
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function phpVersionForUnionTypesDataProvider(): \Generator
+    {
+        yield ['8', true];
+        yield ['8.0.1', true];
+        yield ['8RC1', true];
+        yield ['7.4', false];
+        yield ['7.4.6', false];
+        yield ['7', false];
+        yield ['7.0', false];
+        yield ['5.7', false];
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|FileManager
+     */
+    private function mockFileManager(string $json)
+    {
+        $mockFileManager = $this->createMock(FileManager::class);
+        $mockFileManager
+            ->expects(self::once())
+            ->method('getRootDirectory')
+            ->willReturn('/test')
+        ;
+
+        $mockFileManager
+            ->expects(self::once())
+            ->method('fileExists')
+            ->with('/test/composer.lock')
+            ->willReturn(true)
+        ;
+
+        $mockFileManager
+            ->expects(self::once())
+            ->method('getFileContents')
+            ->with('/test/composer.lock')
+            ->willReturn($json)
+        ;
+
+        return $mockFileManager;
     }
 }
 


### PR DESCRIPTION
Hello,

what do you think if we make the method `PhpCompatUtil::getPhpVersion()` public?

This could be needed for some libs which leverage maker bundle

This would be helpful to resolve this problem: https://github.com/api-platform/core/pull/4423#pullrequestreview-747675271

Another solution for my problem would be to expose a global `is_php8` variable to all templates. but maybe that's not a good solution, because way _may_ need to differentiate minor versions