### PR TITLE
[make:auth] Add `RememberMeBadge`

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -49,6 +49,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
@@ -65,6 +66,9 @@ final class MakeAuthenticator extends AbstractMaker
 {
     private const AUTH_TYPE_EMPTY_AUTHENTICATOR = 'empty-authenticator';
     private const AUTH_TYPE_FORM_LOGIN = 'form-login';
+
+    private const REMEMBER_ME_TYPE_ALWAYS = 'always';
+    private const REMEMBER_ME_TYPE_CHECKBOX = 'checkbox';
 
     public function __construct(
         private FileManager $fileManager,
@@ -184,6 +188,34 @@ final class MakeAuthenticator extends AbstractMaker
                     true
                 )
             );
+
+            $command->addArgument('support-remember-me', InputArgument::REQUIRED);
+            $input->setArgument(
+                'support-remember-me',
+                $io->confirm(
+                    'Do you want to support remember me?',
+                    true
+                )
+            );
+
+            if ($input->getArgument('support-remember-me')) {
+                $supportRememberMeValues = [
+                    'Activate when the user checks a box' => self::REMEMBER_ME_TYPE_CHECKBOX,
+                    'Always activate remember me' => self::REMEMBER_ME_TYPE_ALWAYS,
+                ];
+                $command->addArgument('always-remember-me', InputArgument::REQUIRED);
+
+                $supportRememberMeType = $io->choice(
+                    'When activate the remember me?',
+                    array_keys($supportRememberMeValues),
+                    key($supportRememberMeValues)
+                );
+
+                $input->setArgument(
+                    'always-remember-me',
+                    $supportRememberMeValues[$supportRememberMeType]
+                );
+            }
         }
     }
 
@@ -192,12 +224,16 @@ final class MakeAuthenticator extends AbstractMaker
         $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents('config/packages/security.yaml'));
         $securityData = $manipulator->getData();
 
+        $supportRememberMe = $input->hasArgument('support-remember-me') ? $input->getArgument('support-remember-me') : false;
+        $alwaysRememberMe = $input->hasArgument('always-remember-me') ? $input->getArgument('always-remember-me') : false;
+
         $this->generateAuthenticatorClass(
             $securityData,
             $input->getArgument('authenticator-type'),
             $input->getArgument('authenticator-class'),
             $input->hasArgument('user-class') ? $input->getArgument('user-class') : null,
-            $input->hasArgument('username-field') ? $input->getArgument('username-field') : null
+            $input->hasArgument('username-field') ? $input->getArgument('username-field') : null,
+            $supportRememberMe,
         );
 
         // update security.yaml with guard config
@@ -215,7 +251,9 @@ final class MakeAuthenticator extends AbstractMaker
                 $input->getOption('firewall-name'),
                 $entryPoint,
                 $input->getArgument('authenticator-class'),
-                $input->hasArgument('logout-setup') ? $input->getArgument('logout-setup') : false
+                $input->hasArgument('logout-setup') ? $input->getArgument('logout-setup') : false,
+                $supportRememberMe,
+                $alwaysRememberMe
             );
             $generator->dumpFile($path, $newYaml);
             $securityYamlUpdated = true;
@@ -226,7 +264,9 @@ final class MakeAuthenticator extends AbstractMaker
             $this->generateFormLoginFiles(
                 $input->getArgument('controller-class'),
                 $input->getArgument('username-field'),
-                $input->getArgument('logout-setup')
+                $input->getArgument('logout-setup'),
+                $supportRememberMe,
+                $alwaysRememberMe,
             );
         }
 
@@ -241,12 +281,14 @@ final class MakeAuthenticator extends AbstractMaker
                 $input->getArgument('authenticator-class'),
                 $securityData,
                 $input->hasArgument('user-class') ? $input->getArgument('user-class') : null,
-                $input->hasArgument('logout-setup') ? $input->getArgument('logout-setup') : false
+                $input->hasArgument('logout-setup') ? $input->getArgument('logout-setup') : false,
+                $supportRememberMe,
+                $alwaysRememberMe
             )
         );
     }
 
-    private function generateAuthenticatorClass(array $securityData, string $authenticatorType, string $authenticatorClass, $userClass, $userNameField): void
+    private function generateAuthenticatorClass(array $securityData, string $authenticatorType, string $authenticatorClass, $userClass, $userNameField, bool $supportRememberMe): void
     {
         $useStatements = new UseStatementGenerator([
             Request::class,
@@ -288,6 +330,10 @@ final class MakeAuthenticator extends AbstractMaker
             $useStatements->addUseStatement(LegacySecurity::class);
         }
 
+        if ($supportRememberMe) {
+            $useStatements->addUseStatement(RememberMeBadge::class);
+        }
+
         $userClassNameDetails = $this->generator->createClassNameDetails(
             '\\'.$userClass,
             'Entity\\'
@@ -305,11 +351,12 @@ final class MakeAuthenticator extends AbstractMaker
                 'username_field_var' => Str::asLowerCamelCase($userNameField),
                 'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
                 'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
+                'remember_me_badge' => $supportRememberMe,
             ]
         );
     }
 
-    private function generateFormLoginFiles(string $controllerClass, string $userNameField, bool $logoutSetup): void
+    private function generateFormLoginFiles(string $controllerClass, string $userNameField, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe): void
     {
         $controllerClassNameDetails = $this->generator->createClassNameDetails(
             $controllerClass,
@@ -362,11 +409,13 @@ final class MakeAuthenticator extends AbstractMaker
                 'username_is_email' => false !== stripos($userNameField, 'email'),
                 'username_label' => ucfirst(Str::asHumanWords($userNameField)),
                 'logout_setup' => $logoutSetup,
+                'support_remember_me' => $supportRememberMe,
+                'always_remember_me' => $alwaysRememberMe,
             ]
         );
     }
 
-    private function generateNextMessage(bool $securityYamlUpdated, string $authenticatorType, string $authenticatorClass, array $securityData, $userClass, bool $logoutSetup): array
+    private function generateNextMessage(bool $securityYamlUpdated, string $authenticatorType, string $authenticatorClass, array $securityData, $userClass, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe): array
     {
         $nextTexts = ['Next:'];
         $nextTexts[] = '- Customize your new authenticator.';
@@ -377,7 +426,9 @@ final class MakeAuthenticator extends AbstractMaker
                 'main',
                 null,
                 $authenticatorClass,
-                $logoutSetup
+                $logoutSetup,
+                $supportRememberMe,
+                $alwaysRememberMe
             );
             $nextTexts[] = "- Your <info>security.yaml</info> could not be updated automatically. You'll need to add the following config manually:\n\n".$yamlExample;
         }

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -24,7 +24,8 @@ class <?= $class_name; ?> extends AbstractLoginFormAuthenticator
             new UserBadge($<?= $username_field_var ?>),
             new PasswordCredentials($request->request->get('password', '')),
             [
-                new CsrfTokenBadge('authenticate', $request->request->get('_csrf_token')),
+                new CsrfTokenBadge('authenticate', $request->request->get('_csrf_token')),<?= $remember_me_badge ? "
+                new RememberMeBadge(),\n" : "" ?>
             ]
         );
     }

--- a/src/Resources/skeleton/authenticator/login_form.tpl.php
+++ b/src/Resources/skeleton/authenticator/login_form.tpl.php
@@ -25,17 +25,16 @@
     <input type="hidden" name="_csrf_token"
            value="{{ csrf_token('authenticate') }}"
     >
+<?php if($support_remember_me): ?>
+<?php if(!$always_remember_me): ?>
 
-    {#
-        Uncomment this section and add a remember_me option below your firewall to activate remember me functionality.
-        See https://symfony.com/doc/current/security/remember_me.html
-
-        <div class="checkbox mb-3">
-            <label>
-                <input type="checkbox" name="_remember_me"> Remember me
-            </label>
-        </div>
-    #}
+    <div class="checkbox mb-3">
+        <label>
+            <input type="checkbox" name="_remember_me"> Remember me
+        </label>
+    </div>
+<?php endif; ?>
+<?php endif; ?>
 
     <button class="btn btn-lg btn-primary" type="submit">
         Sign in

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -104,14 +104,14 @@ class SecurityConfigUpdaterTest extends TestCase
     /**
      * @dataProvider getAuthenticatorTests
      */
-    public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename, bool $logoutSetup): void
+    public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe): void
     {
         $this->createLogger();
 
         $updater = new SecurityConfigUpdater($this->ysmLogger);
-        $source = $this->getYamlSource($startingSourceFilename);
-        $actualSource = $updater->updateForAuthenticator($source, $firewallName, $entryPoint, 'App\\Security\\AppCustomAuthenticator', $logoutSetup);
-        $expectedSource = $this->getExpectedYaml('expected_authenticator', $expectedSourceFilename);
+        $source = file_get_contents(__DIR__.'/yaml_fixtures/source/'.$startingSourceFilename);
+        $actualSource = $updater->updateForAuthenticator($source, $firewallName, $entryPoint, 'App\\Security\\AppCustomAuthenticator', $logoutSetup, $supportRememberMe, $alwaysRememberMe);
+        $expectedSource = file_get_contents(__DIR__.'/yaml_fixtures/expected_authenticator/'.$expectedSourceFilename);
 
         $this->assertSame($expectedSource, $actualSource);
     }
@@ -124,6 +124,8 @@ class SecurityConfigUpdaterTest extends TestCase
             'empty_source.yaml',
             'empty_security.yaml',
             false,
+            false,
+            false,
         ];
 
         yield 'simple_security' => [
@@ -131,6 +133,8 @@ class SecurityConfigUpdaterTest extends TestCase
             null,
             'simple_security_source.yaml',
             'simple_security.yaml',
+            false,
+            false,
             false,
         ];
 
@@ -140,6 +144,8 @@ class SecurityConfigUpdaterTest extends TestCase
             'simple_security_with_firewalls.yaml',
             'simple_security_with_firewalls.yaml',
             false,
+            false,
+            false,
         ];
 
         yield 'simple_security_with_firewalls_and_authenticator' => [
@@ -147,6 +153,8 @@ class SecurityConfigUpdaterTest extends TestCase
             'App\\Security\\AppCustomAuthenticator',
             'simple_security_with_firewalls_and_authenticator.yaml',
             'simple_security_with_firewalls_and_authenticator.yaml',
+            false,
+            false,
             false,
         ];
 
@@ -156,6 +164,8 @@ class SecurityConfigUpdaterTest extends TestCase
             'simple_security_with_firewalls_and_logout.yaml',
             'simple_security_with_firewalls_and_logout.yaml',
             true,
+            false,
+            false,
         ];
 
         yield 'security_52_with_multiple_authenticators' => [
@@ -164,6 +174,28 @@ class SecurityConfigUpdaterTest extends TestCase
             'multiple_authenticators.yaml',
             'multiple_authenticators.yaml',
             false,
+            false,
+            false,
+        ];
+
+        yield 'simple_security_with_firewalls_and_remember_me_checkbox' => [
+            'main',
+            null,
+            'simple_security_with_firewalls_and_remember_me_checkbox.yaml',
+            'simple_security.yaml',
+            false,
+            true,
+            false,
+        ];
+
+        yield 'simple_security_with_firewalls_and_always_remember_me' => [
+            'main',
+            null,
+            'simple_security_with_firewalls_and_always_remember_me.yaml',
+            'simple_security.yaml',
+            false,
+            true,
+            true,
         ];
     }
 

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_always_remember_me.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_always_remember_me.yaml
@@ -1,0 +1,18 @@
+security:
+    enable_authenticator_manager: true
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main:
+            lazy: true
+            custom_authenticator: App\Security\AppCustomAuthenticator
+
+            remember_me:
+                secret: '%kernel.secret%'
+                lifetime: 604800
+                path: /
+                always_remember_me: true

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_remember_me_checkbox.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_and_remember_me_checkbox.yaml
@@ -1,0 +1,20 @@
+security:
+    enable_authenticator_manager: true
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main:
+            lazy: true
+            custom_authenticator: App\Security\AppCustomAuthenticator
+
+            remember_me:
+                secret: '%kernel.secret%'
+                lifetime: 604800
+                path: /
+                # by default, the feature is enabled by checking a checkbox in the
+                # login form, uncomment the following line to always enable it.
+                #always_remember_me: true


### PR DESCRIPTION
Fix #848 

@weaverryan in #848:
> EDIT: And I wonder if we should even ask "Do you want to support remember me?" during this process? We could then ask "Do you want remember me to be activated via a checkbox or always activated"? We could use this to determine how the template is generated AND to automatically add the correct remember_me config to security.yaml.


- [x] Ask "Do you want to support remember me?" and "Do you want remember me to be activated via a checkbox or always activated"?
- [x] Add RememberMeBadge in `LoginFormAuthenticator` when remember me is supported
- [x] Update generated `security.yaml`
- [x] Update `security/login.html.twig`