### PR TITLE
Fixed typo in src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php

### DIFF
--- a/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
@@ -36,7 +36,7 @@ class <?php echo $class_name ?> extends AbstractAuthenticator
 //        /*
 //         * If you would like this class to control what happens when an anonymous user accesses a
 //         * protected page (e.g. redirect to /login), uncomment this method and make this class
-//         * implement Symfony\Component\Security\Http\EntryPoint\AuthenticationEntrypointInterface.
+//         * implement Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface.
 //         *
 //         * For more details, see https://symfony.com/doc/current/security/experimental_authenticators.html#configuring-the-authentication-entry-point
 //         */


### PR DESCRIPTION
refs: https://github.com/symfony/symfony/blob/1c1e2d96816166fdbe726ecc09716d07da90c06d/src/Symfony/Component/Security/Http/EntryPoint/AuthenticationEntryPointInterface.php#L24