### PR TITLE
Avoid iterating on null for DoctrineBundle 2.2 and lower

### DIFF
--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -311,7 +311,7 @@ final class DoctrineHelper
         $lowestCharacterDiff = null;
         $foundDriver = null;
 
-        foreach ($this->mappingDriversByPrefix as $key => $mappings) {
+        foreach ($this->mappingDriversByPrefix ?? [] as $mappings) {
             foreach ($mappings as [$prefix, $driver]) {
                 $diff = substr_compare($namespace, $prefix, 0);
 


### PR DESCRIPTION
Fixes #989 