### PR TITLE
Fix replacing default MERCURE_URL in tests

### DIFF
--- a/tests/Maker/MakeEntityLegacyTest.php
+++ b/tests/Maker/MakeEntityLegacyTest.php
@@ -513,7 +513,7 @@ class MakeEntityLegacyTest extends MakerTestCase
             ->configureDatabase()
             ->addReplacement(
                 '.env',
-                'https://127.0.0.1:8000/.well-known/mercure',
+                'https://example.com/.well-known/mercure',
                 'http://127.0.0.1:1337/.well-known/mercure'
             )
             ->updateSchemaAfterCommand()

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -623,7 +623,7 @@ class MakeEntityTest extends MakerTestCase
             ->configureDatabase()
             ->addReplacement(
                 '.env',
-                'https://127.0.0.1:8000/.well-known/mercure',
+                'https://example.com/.well-known/mercure',
                 'http://127.0.0.1:1337/.well-known/mercure'
             )
             ->updateSchemaAfterCommand()


### PR DESCRIPTION
The test failing seems to be caused by https://github.com/symfony/recipes/pull/1007