### PR TITLE
[make:controller][make:crud] Make route names start with 'app_'

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -102,7 +102,9 @@ final class Str
 
     public static function asRouteName(string $value): string
     {
-        return self::asTwigVariable($value);
+        $routeName = self::asTwigVariable($value);
+
+        return str_starts_with($routeName, 'app_') ? $routeName : 'app_'.$routeName;
     }
 
     public static function asSnakeCase(string $value): string

--- a/src/Test/MakerTestCase.php
+++ b/src/Test/MakerTestCase.php
@@ -106,7 +106,7 @@ abstract class MakerTestCase extends TestCase
         }
 
         // a cheap way to guess the service id
-        $serviceId = $serviceId ?? sprintf('maker.maker.%s', Str::asRouteName((new \ReflectionClass($makerClass))->getShortName()));
+        $serviceId = $serviceId ?? sprintf('maker.maker.%s', Str::asSnakeCase((new \ReflectionClass($makerClass))->getShortName()));
 
         return $this->kernel->getContainer()->get($serviceId);
     }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -200,4 +200,19 @@ class StrTest extends TestCase
         yield [' FooBar', 'Foo Bar'];
         yield [' Foo Bar ', 'Foo Bar'];
     }
+
+    /**
+     * @dataProvider provideAsRouteName
+     */
+    public function testAsRouteName(string $value, string $expectedRouteName)
+    {
+        $this->assertSame($expectedRouteName, Str::asRouteName($value));
+    }
+
+    public function provideAsRouteName()
+    {
+        yield ['Example', 'app_example'];
+        yield ['AppExample', 'app_example'];
+        yield ['Apple', 'app_apple'];
+    }
 }


### PR DESCRIPTION
This PR amends the route names generated by `make:controller` and `make:crud` by prepending them with `app_`.

This matches the route names generated by `make:auth` and `make:registration-form`.
