### PR TITLE
Updating test dsn for DATABASE_URL

### DIFF
--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -139,7 +139,7 @@ final class MakerTestDetails
         $this
             ->addReplacement(
                 '.env',
-                'postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8',
+                'postgresql://symfony:ChangeMe@127.0.0.1:5432/app?serverVersion=13&charset=utf8',
                 getenv('TEST_DATABASE_DSN')
             )
         ;


### PR DESCRIPTION
Ref: https://github.com/symfony/recipes/commit/b1b582b7326d4049e361b96d27b6fc28bb4f644a

tl;dr Our tests fail, because we are not manipulating the `.env` file correctly.