### PR TITLE
Update ApiTestCase to be compliant with ApiPlatform v3.0

### DIFF
--- a/src/Maker/MakeTest.php
+++ b/src/Maker/MakeTest.php
@@ -11,7 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
-use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase as LegacyApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestAssertionsTrait;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
@@ -103,7 +104,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
             );
         }
 
-        if ('ApiTestCase' === $input->getArgument('type') && !class_exists(ApiTestCase::class)) {
+        if ('ApiTestCase' === $input->getArgument('type') && !class_exists(ApiTestCase::class) && !class_exists(LegacyApiTestCase::class)) {
             $io->warning([
                 'API Platform is required for this test type. Install it with',
                 'composer require api',
@@ -148,6 +149,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
             [
                 'web_assertions_are_available' => trait_exists(WebTestAssertionsTrait::class),
                 'use_legacy_container_property' => $this->useLegacyContainerProperty(),
+                'api_test_case_fqcn' => \PHP_VERSION_ID < 80100 && !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
             ]
         );
 
@@ -186,7 +188,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
 
             case 'ApiTestCase':
                 $dependencies->addClassDependency(
-                    ApiTestCase::class,
+                    \PHP_VERSION_ID < 80100 && !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
                     'api',
                     true,
                     false

--- a/src/Resources/skeleton/test/ApiTestCase.tpl.php
+++ b/src/Resources/skeleton/test/ApiTestCase.tpl.php
@@ -2,7 +2,7 @@
 
 namespace <?= $namespace; ?>;
 
-use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
+use <?= $api_test_case_fqcn; ?>;
 
 class <?= $class_name ?> extends ApiTestCase
 {


### PR DESCRIPTION
Following the work in progress in https://github.com/api-platform/core/pull/4556, ApiTestCase will be moved from ApiPlatform\Core\Bridge\Symfony\Bundle\Test to ApiPlatform\Symfony\Bundle\Test. The current file location will be deprecated in 2.7 and become invalid in 3.0 .

As recommended by @dunglas, this implementation is compatible with all versions of API Platform.
