### PR TITLE
[reset-password] fix missing entity manager di

### DIFF
--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -16,10 +16,12 @@ class <?= $class_name ?> extends AbstractController
     use ResetPasswordControllerTrait;
 
     private $resetPasswordHelper;
+    private $entityManager;
 
-    public function __construct(ResetPasswordHelperInterface $resetPasswordHelper)
+    public function __construct(ResetPasswordHelperInterface $resetPasswordHelper, EntityManagerInterface $entityManager)
     {
         $this->resetPasswordHelper = $resetPasswordHelper;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -82,7 +84,7 @@ class <?= $class_name ?> extends AbstractController
      * @Route("/reset/{token}", name="app_reset_password")
      */
 <?php } ?>
-    public function reset(Request $request, <?= $password_hasher_class_details->getShortName() ?> <?= $password_hasher_variable_name ?>, EntityManagerInterface $entityManager, string $token = null): Response
+    public function reset(Request $request, <?= $password_hasher_class_details->getShortName() ?> <?= $password_hasher_variable_name ?>, string $token = null): Response
     {
         if ($token) {
             // We store the token in session and remove it from the URL, to avoid the URL being
@@ -123,7 +125,7 @@ class <?= $class_name ?> extends AbstractController
             );
 
             $user-><?= $password_setter ?>($encodedPassword);
-            $entityManager->flush();
+            $this->entityManager->flush();
 
             // The session is cleaned up after the password has been changed.
             $this->cleanSessionAfterReset();
@@ -136,9 +138,9 @@ class <?= $class_name ?> extends AbstractController
         ]);
     }
 
-    private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer, EntityManagerInterface $entityManager): RedirectResponse
+    private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer): RedirectResponse
     {
-        $user = $entityManager->getRepository(<?= $user_class_name ?>::class)->findOneBy([
+        $user = $this->entityManager->getRepository(<?= $user_class_name ?>::class)->findOneBy([
             '<?= $email_field ?>' => $emailFormData,
         ]);
 


### PR DESCRIPTION
DI the `EntityManagerInterface` into the constructor as the private method is ultimately called in https://github.com/symfony/maker-bundle/blob/63dc8ba1089f7ab7ae400b03dbee347f8b631275/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php#L41 as well as the public `reset` method as well.