### PR TITLE
[CSM] fix: Handle enum as values

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -514,7 +514,7 @@ final class ClassSourceManipulator
 
         if (\function_exists('enum_exists')) {
             // do we have an enum ?
-            if (is_object($value) && enum_exists(get_class($value))) {
+            if (\is_object($value) && enum_exists(\get_class($value))) {
                 $value = $value->value;
             }
         }

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -512,7 +512,7 @@ final class ClassSourceManipulator
             throw new \Exception('Invalid value: loop before quoting.');
         }
 
-        if (\PHP_VERSION_ID >= 80000) {
+        if (\function_exists('enum_exists')) {
             // do we have an enum ?
             if (is_object($value) && enum_exists(get_class($value))) {
                 $value = $value->value;

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -512,6 +512,13 @@ final class ClassSourceManipulator
             throw new \Exception('Invalid value: loop before quoting.');
         }
 
+        if (\PHP_VERSION_ID >= 80000) {
+            // do we have an enum ?
+            if (is_object($value) && enum_exists(get_class($value))) {
+                $value = $value->value;
+            }
+        }
+
         return sprintf('"%s"', $value);
     }
 


### PR DESCRIPTION
This PR aims to handle enums as value.
It's purpose is to prevent the make;entity command to fail because of manual use of Enum in entity attributes.
It may help when Doctrine will support Enums natively.