### PR TITLE
[POC] Refactor make:auth to also bootstrap built-in authenticators

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -18,28 +18,16 @@ use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
+use Symfony\Bundle\MakerBundle\Security\Authenticator\AuthenticatorMakerInterface;
 use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
-use Symfony\Bundle\MakerBundle\Security\SecurityControllerBuilder;
-use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
-use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
-use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Form\Form;
-use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator;
-use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
-use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
-use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -50,31 +38,19 @@ use Symfony\Component\Yaml\Yaml;
  */
 final class MakeAuthenticator extends AbstractMaker
 {
-    private const AUTH_TYPE_FORM_LOGIN = 'form-login';
-    private const AUTH_TYPE_JSON_LOGIN = 'json-login';
-    private const AUTH_TYPE_HTTP_BASIC = 'http-basic';
-    private const AUTH_TYPE_LOGIN_LINK = 'login-link';
-    private const AUTH_TYPE_X509 = 'x509';
-    private const AUTH_TYPE_REMOTE_USER = 'remote-user';
-    private const AUTH_TYPE_EMPTY_AUTHENTICATOR = 'empty-authenticator';
-    private const AUTH_TYPE_FORM_LOGIN_AUTHENTICATOR = 'form-login-authenticator';
+    private $authenticatorMakers;
 
     private $fileManager;
 
-    private $configUpdater;
-
     private $generator;
-
-    private $doctrineHelper;
 
     private $useSecurity52 = false;
 
-    public function __construct(FileManager $fileManager, SecurityConfigUpdater $configUpdater, Generator $generator, DoctrineHelper $doctrineHelper)
+    public function __construct(iterable $authenticatorMakers, FileManager $fileManager, Generator $generator)
     {
+        $this->authenticatorMakers = $authenticatorMakers instanceof \Traversable ? iterator_to_array($authenticatorMakers) : $authenticatorMakers;
         $this->fileManager = $fileManager;
-        $this->configUpdater = $configUpdater;
         $this->generator = $generator;
-        $this->doctrineHelper = $doctrineHelper;
     }
 
     public static function getCommandName(): string
@@ -108,101 +84,40 @@ final class MakeAuthenticator extends AbstractMaker
         }
 
         // authenticator type
-        $authenticatorTypeValues = [
-            'Login form' => self::AUTH_TYPE_FORM_LOGIN,
-            'JSON API login' => self::AUTH_TYPE_JSON_LOGIN,
-            'HTTP basic' => self::AUTH_TYPE_HTTP_BASIC,
-        ];
-        if (class_exists(LoginLinkAuthenticator::class)) {
-            $authenticatorTypeValues['Login link'] = self::AUTH_TYPE_LOGIN_LINK;
+        $authenticatorTypeValues = [];
+        /** @var AuthenticatorMakerInterface $authenticatorMaker */
+        foreach ($this->authenticatorMakers as $authenticatorType => $authenticatorMaker) {
+            if (!$authenticatorMaker->isAvailable($this->useSecurity52)) {
+                continue;
+            }
+
+            $authenticatorTypeValues[$authenticatorMaker->getDescription()] = $authenticatorType;
         }
-        $authenticatorTypeValues += [
-            'Pre authenticated' => 'pre-authenticated',
-            'Custom authenticator' => self::AUTH_TYPE_EMPTY_AUTHENTICATOR,
-        ];
+
         $command->addArgument('authenticator-type', InputArgument::REQUIRED);
-        $authenticatorType = $io->choice(
-            'What style of authentication do you want?',
-            array_keys($authenticatorTypeValues),
-            key($authenticatorTypeValues)
-        );
-        $input->setArgument('authenticator-type', $authenticatorTypeValues[$authenticatorType]);
 
-        if ('pre-authenticated' === $input->getArgument('authenticator-type')) {
-            $preAuthenticatedTypes = [
-                'Remote user (e.g. Kerebos)' => self::AUTH_TYPE_REMOTE_USER,
-                'Client certificates (X.509)' => self::AUTH_TYPE_X509,
-            ];
-            $authenticatorType = $io->choice('Which pre-authenticated method do you want?', array_keys($preAuthenticatedTypes));
-            $input->setArgument('authenticator-type', $preAuthenticatedTypes[$authenticatorType]);
+        $finalMaker = null;
+        while (!$finalMaker) {
+            if (null === $finalMaker) {
+                $authenticatorType = $io->choice(
+                    'What style of authentication do you want?',
+                    array_keys($authenticatorTypeValues),
+                    key($authenticatorTypeValues)
+                );
+                $input->setArgument('authenticator-type', $authenticatorTypeValues[$authenticatorType]);
+            }
+
+            $authenticatorMaker = $this->authenticatorMakers[$input->getArgument('authenticator-type')];
+            $finalMaker = $authenticatorMaker->interact($input, $io, $command);
         }
 
-        $formLoginAuthenticatorQuestion = null;
-        if (self::AUTH_TYPE_FORM_LOGIN === $input->getArgument('authenticator-type')) {
-            $formLoginAuthenticatorQuestion = 'Do you require other fields than user identifier (e.g. email) and password?';
-        } elseif (self::AUTH_TYPE_EMPTY_AUTHENTICATOR === $input->getArgument('authenticator-type')) {
-            $formLoginAuthenticatorQuestion = 'Do you want to use a login form?';
-        }
-        if (null !== $formLoginAuthenticatorQuestion && $io->confirm($formLoginAuthenticatorQuestion, false)) {
-            $input->setArgument('authenticator-type', self::AUTH_TYPE_FORM_LOGIN_AUTHENTICATOR);
-        }
-
-        $isFormAuthenticator = \in_array($input->getArgument('authenticator-type'), [self::AUTH_TYPE_FORM_LOGIN, self::AUTH_TYPE_FORM_LOGIN_AUTHENTICATOR], true);
+        // todo move
+        $isFormAuthenticator = \in_array($input->getArgument('authenticator-type'), ['login-form', 'form-login-authenticator'], true);
         if ($isFormAuthenticator) {
             $this->checkFormAuthenticatorRequirements($securityData);
         }
 
-        // authenticator class
-        $isCustomAuthenticator = \in_array($input->getArgument('authenticator-type'), [self::AUTH_TYPE_EMPTY_AUTHENTICATOR, self::AUTH_TYPE_FORM_LOGIN_AUTHENTICATOR], true);
-        if ($isCustomAuthenticator) {
-            $command->addArgument('authenticator-class', InputArgument::REQUIRED);
-            $questionAuthenticatorClass = new Question('The class name of the authenticator to create (e.g. <fg=yellow>AppCustomAuthenticator</>)');
-            $questionAuthenticatorClass->setValidator(function ($answer) {
-                Validator::notBlank($answer);
-
-                return Validator::classDoesNotExist($this->generator->createClassNameDetails($answer, 'Security\\', 'Authenticator')->getFullName());
-            });
-            $input->setArgument('authenticator-class', $io->askQuestion($questionAuthenticatorClass));
-        }
-
-        $interactiveSecurityHelper = new InteractiveSecurityHelper();
-        $command->addOption('firewall-name', null, InputOption::VALUE_OPTIONAL);
-        $input->setOption('firewall-name', $firewallName = $interactiveSecurityHelper->guessFirewallName($io, $securityData));
-
-        $command->addOption('entry-point', null, InputOption::VALUE_OPTIONAL);
-
-        if (!$this->useSecurity52) {
-            $input->setOption(
-                'entry-point',
-                $interactiveSecurityHelper->guessEntryPoint($io, $securityData, $input->getArgument('authenticator-class'), $firewallName)
-            );
-        }
-
-        $command->addArgument('user-class', InputArgument::REQUIRED);
-        $input->setArgument(
-            'user-class',
-            $userClass = $interactiveSecurityHelper->guessUserClass($io, $securityData['security']['providers'])
-        );
-
-        if ($isFormAuthenticator || self::AUTH_TYPE_JSON_LOGIN === $input->getArgument('authenticator-type')) {
-            $command->addArgument('controller-class', InputArgument::REQUIRED);
-            $input->setArgument(
-                'controller-class',
-                $io->ask(
-                    'Choose a name for the controller class (e.g. <fg=yellow>SecurityController</>)',
-                    'SecurityController',
-                    [Validator::class, 'validateClassName']
-                )
-            );
-
-            $command->addArgument('username-field', InputArgument::REQUIRED);
-            $input->setArgument(
-                'username-field',
-                $interactiveSecurityHelper->guessUserNameField($io, $userClass, $securityData['security']['providers'])
-            );
-        }
-
-        if (self::AUTH_TYPE_HTTP_BASIC !== $input->getArgument('authenticator-type')) {
+        if ('http-basic' !== $input->getArgument('authenticator-type')) {
             $command->addOption('logout-setup', null, InputOption::VALUE_NEGATABLE, '', true);
             $input->setOption('logout-setup', $io->confirm('Do you want to generate a \'/logout\' URL?', true));
         }
@@ -222,229 +137,16 @@ final class MakeAuthenticator extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
-        $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents('config/packages/security.yaml'));
-        $securityData = $manipulator->getData();
         $authenticatorType = $input->getArgument('authenticator-type');
+        $authenticatorMaker = $this->authenticatorMakers[$authenticatorType];
 
-        $isCustomAuthenticator = \in_array($authenticatorType, [self::AUTH_TYPE_EMPTY_AUTHENTICATOR, self::AUTH_TYPE_FORM_LOGIN_AUTHENTICATOR], true);
-        if ($isCustomAuthenticator) {
-            $this->generateAuthenticatorClass(
-                $securityData,
-                $input->getArgument('authenticator-type'),
-                $input->getArgument('authenticator-class'),
-                $input->hasArgument('user-class') ? $input->getArgument('user-class') : null,
-                $input->hasArgument('username-field') ? $input->getArgument('username-field') : null
-            );
-        }
+        $nextMessage = $authenticatorMaker->generate($input, $io, $generator, $this->useSecurity52);
 
-        // update security.yaml with guard config
-        $securityYamlUpdated = false;
-
-        $entryPoint = $input->getOption('entry-point');
-
-        if ($this->useSecurity52 && self::AUTH_TYPE_FORM_LOGIN !== $authenticatorType) {
-            $entryPoint = false;
-        }
-
-        $securityYamlSource = $this->fileManager->getFileContents($path = 'config/packages/security.yaml');
-        if ($isCustomAuthenticator) {
-            try {
-                $newYaml = $this->configUpdater->updateForCustomAuthenticator(
-                    $securityYamlSource,
-                    $input->getOption('firewall-name'),
-                    $entryPoint,
-                    $input->getArgument('authenticator-class'),
-                    $input->hasOption('logout-setup') ? $input->getOption('logout-setup') : false,
-                    $this->useSecurity52
-                );
-                $generator->dumpFile($path, $newYaml);
-                $securityYamlUpdated = true;
-            } catch (YamlManipulationFailedException $e) {
-            }
-        } else {
-            $newYaml = null;
-            switch ($authenticatorType) {
-                case self::AUTH_TYPE_HTTP_BASIC:
-                    $newYaml = $this->configUpdater->updateForAuthenticator(
-                        $securityYamlSource,
-                        $input->getOption('firewall-name'),
-                        'http_basic',
-                        true,
-                        $input->hasOption('logout-setup') ? $input->getOption('logout-setup') : false,
-                        $this->useSecurity52
-                    );
-
-                    break;
-
-                default:
-                    throw new \Exception('TODO: '.$authenticatorType);
-            }
-
-            if ($newYaml) {
-                $generator->dumpFile($path, $newYaml);
-                $securityYamlUpdated = true;
-            }
-        }
-
-        if (self::AUTH_TYPE_FORM_LOGIN === $input->getArgument('authenticator-type')) {
-            $this->generateFormLoginFiles(
-                $input->getArgument('controller-class'),
-                $input->getArgument('username-field'),
-                $input->getOption('logout-setup')
-            );
-        }
-
-        $generator->writeChanges();
+        $this->generator->writeChanges();
 
         $this->writeSuccessMessage($io);
 
-        if ($isCustomAuthenticator) {
-            // TODO there is enough to say when we're not building a custom authenticator :)
-            $io->text(
-                $this->generateNextMessage(
-                    $securityYamlUpdated,
-                    $input->getArgument('authenticator-type'),
-                    $input->getArgument('authenticator-class'),
-                    $securityData,
-                    $input->hasArgument('user-class') ? $input->getArgument('user-class') : null,
-                    $input->hasOption('logout-setup') ? $input->getOption('logout-setup') : false
-                )
-            );
-        }
-    }
-
-    private function generateAuthenticatorClass(array $securityData, string $authenticatorType, string $authenticatorClass, $userClass, $userNameField)
-    {
-        // generate authenticator class
-        if (self::AUTH_TYPE_EMPTY_AUTHENTICATOR === $authenticatorType) {
-            $this->generator->generateClass(
-                $authenticatorClass,
-                sprintf('authenticator/%sEmptyAuthenticator.tpl.php', $this->useSecurity52 ? 'Security52' : ''),
-                [
-                    'provider_key_type_hint' => $this->getGuardProviderKeyTypeHint(),
-                    'use_legacy_passport_interface' => $this->shouldUseLegacyPassportInterface(),
-                ]
-            );
-
-            return;
-        }
-
-        $userClassNameDetails = $this->generator->createClassNameDetails(
-            '\\'.$userClass,
-            'Entity\\'
-        );
-
-        $this->generator->generateClass(
-            $authenticatorClass,
-            sprintf('authenticator/%sLoginFormAuthenticator.tpl.php', $this->useSecurity52 ? 'Security52' : ''),
-            [
-                'user_fully_qualified_class_name' => trim($userClassNameDetails->getFullName(), '\\'),
-                'user_class_name' => $userClassNameDetails->getShortName(),
-                'username_field' => $userNameField,
-                'username_field_label' => Str::asHumanWords($userNameField),
-                'username_field_var' => Str::asLowerCamelCase($userNameField),
-                'user_needs_encoder' => $this->userClassHasEncoder($securityData, $userClass),
-                'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
-                'provider_key_type_hint' => $this->getGuardProviderKeyTypeHint(),
-                'use_legacy_passport_interface' => $this->shouldUseLegacyPassportInterface(),
-            ]
-        );
-    }
-
-    private function generateFormLoginFiles(string $controllerClass, string $userNameField, bool $logoutSetup)
-    {
-        $controllerClassNameDetails = $this->generator->createClassNameDetails(
-            $controllerClass,
-            'Controller\\',
-            'Controller'
-        );
-
-        if (!class_exists($controllerClassNameDetails->getFullName())) {
-            $controllerPath = $this->generator->generateController(
-                $controllerClassNameDetails->getFullName(),
-                'authenticator/EmptySecurityController.tpl.php'
-            );
-
-            $controllerSourceCode = $this->generator->getFileContentsForPendingOperation($controllerPath);
-        } else {
-            $controllerPath = $this->fileManager->getRelativePathForFutureClass($controllerClassNameDetails->getFullName());
-            $controllerSourceCode = $this->fileManager->getFileContents($controllerPath);
-        }
-
-        if (method_exists($controllerClassNameDetails->getFullName(), 'login')) {
-            throw new RuntimeCommandException(sprintf('Method "login" already exists on class %s', $controllerClassNameDetails->getFullName()));
-        }
-
-        $manipulator = new ClassSourceManipulator($controllerSourceCode, true);
-
-        $securityControllerBuilder = new SecurityControllerBuilder();
-        $securityControllerBuilder->addLoginMethod($manipulator);
-        if ($logoutSetup) {
-            $securityControllerBuilder->addLogoutMethod($manipulator);
-        }
-
-        $this->generator->dumpFile($controllerPath, $manipulator->getSourceCode());
-
-        // create login form template
-        $this->generator->generateTemplate(
-            'security/login.html.twig',
-            'authenticator/login_form.tpl.php',
-            [
-                'username_field' => $userNameField,
-                'username_is_email' => false !== stripos($userNameField, 'email'),
-                'username_label' => ucfirst(Str::asHumanWords($userNameField)),
-                'logout_setup' => $logoutSetup,
-            ]
-        );
-    }
-
-    private function generateNextMessage(bool $securityYamlUpdated, string $authenticatorType, string $authenticatorClass, array $securityData, $userClass, bool $logoutSetup): array
-    {
-        $nextTexts = ['Next:'];
-        $nextTexts[] = '- Customize your new authenticator.';
-
-        if (!$securityYamlUpdated) {
-            $yamlExample = $this->configUpdater->updateForCustomAuthenticator(
-                'security: {}',
-                'main',
-                null,
-                $authenticatorClass,
-                $logoutSetup,
-                $this->useSecurity52
-            );
-            $nextTexts[] = "- Your <info>security.yaml</info> could not be updated automatically. You'll need to add the following config manually:\n\n".$yamlExample;
-        }
-
-        if (self::AUTH_TYPE_FORM_LOGIN === $authenticatorType) {
-            $nextTexts[] = sprintf('- Finish the redirect "TODO" in the <info>%s::onAuthenticationSuccess()</info> method.', $authenticatorClass);
-
-            if (!$this->doctrineHelper->isClassAMappedEntity($userClass)) {
-                $nextTexts[] = sprintf('- Review <info>%s::getUser()</info> to make sure it matches your needs.', $authenticatorClass);
-            }
-
-            // this only applies to Guard authentication AND if the user does not have a hasher configured
-            if (!$this->useSecurity52 && !$this->userClassHasEncoder($securityData, $userClass)) {
-                $nextTexts[] = sprintf('- Check the user\'s password in <info>%s::checkCredentials()</info>.', $authenticatorClass);
-            }
-
-            $nextTexts[] = '- Review & adapt the login template: <info>'.$this->fileManager->getPathForTemplate('security/login.html.twig').'</info>.';
-        }
-
-        return $nextTexts;
-    }
-
-    private function userClassHasEncoder(array $securityData, string $userClass): bool
-    {
-        $userNeedsEncoder = false;
-        $hashersData = $securityData['security']['encoders'] ?? $securityData['security']['encoders'] ?? [];
-
-        foreach ($hashersData as $userClassWithEncoder => $encoder) {
-            if ($userClass === $userClassWithEncoder || is_subclass_of($userClass, $userClassWithEncoder) || class_implements($userClass, $userClassWithEncoder)) {
-                $userNeedsEncoder = true;
-            }
-        }
-
-        return $userNeedsEncoder;
+        $io->text($nextMessage);
     }
 
     public function configureDependencies(DependencyBuilder $dependencies, InputInterface $input = null)
@@ -459,44 +161,5 @@ final class MakeAuthenticator extends AbstractMaker
             Yaml::class,
             'yaml'
         );
-    }
-
-    /**
-     * Calculates the type-hint used for the $provider argument (string or nothing) for Guard.
-     */
-    private function getGuardProviderKeyTypeHint(): string
-    {
-        // doesn't matter: this only applies to non-Guard authenticators
-        if (!class_exists(AbstractFormLoginAuthenticator::class)) {
-            return '';
-        }
-
-        $reflectionMethod = new \ReflectionMethod(AbstractFormLoginAuthenticator::class, 'onAuthenticationSuccess');
-        $type = $reflectionMethod->getParameters()[2]->getType();
-
-        if (!$type instanceof \ReflectionNamedType) {
-            return '';
-        }
-
-        return sprintf('%s ', $type->getName());
-    }
-
-    private function shouldUseLegacyPassportInterface(): bool
-    {
-        // only applies to new authenticator security
-        if (!$this->useSecurity52) {
-            return false;
-        }
-
-        // legacy: checking for Symfony 5.2 & 5.3 before PassportInterface deprecation
-        $class = new \ReflectionClass(AuthenticatorInterface::class);
-        $method = $class->getMethod('authenticate');
-
-        // 5.4 where return type is temporarily removed
-        if (!$method->getReturnType()) {
-            return false;
-        }
-
-        return PassportInterface::class === $method->getReturnType()->getName();
     }
 }

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -8,11 +8,45 @@
             <defaults public="false" />
 
             <service id="maker.maker.make_authenticator" class="Symfony\Bundle\MakerBundle\Maker\MakeAuthenticator">
+                <argument type="tagged_iterator" tag="maker.authenticator_maker" index-by="type" />
                 <argument type="service" id="maker.file_manager" />
-                <argument type="service" id="maker.security_config_updater" />
                 <argument type="service" id="maker.generator" />
-                <argument type="service" id="maker.doctrine_helper" />
                 <tag name="maker.command" />
+            </service>
+
+            <service id="maker.abstract_authenticator" abstract="true">
+                <argument type="service" id="maker.file_manager" />
+                <argument type="service" id="maker.generator" />
+                <argument type="service" id="maker.security_config_updater" />
+            </service>
+
+            <service id="maker.authenticator_login_form_maker" class="Symfony\Bundle\MakerBundle\Security\Authenticator\LoginFormAuthenticatorMaker" parent="maker.abstract_authenticator">
+                <tag name="maker.authenticator_maker" type="login-form" />
+            </service>
+
+            <service id="maker.authenticator_json_login_form_maker" class="Symfony\Bundle\MakerBundle\Security\Authenticator\JsonLoginAuthenticatorMaker" parent="maker.abstract_authenticator">
+                <tag name="maker.authenticator_maker" type="json-login" />
+            </service>
+
+            <service id="maker.authenticator_login_link_maker" class="Symfony\Bundle\MakerBundle\Security\Authenticator\LoginLinkAuthenticatorMaker" parent="maker.abstract_authenticator">
+                <tag name="maker.authenticator_maker" type="login-link" />
+            </service>
+
+            <service id="maker.authenticator_pre_authenticated_maker" class="Symfony\Bundle\MakerBundle\Security\Authenticator\PreAuthenticatedAuthenticatorMaker" parent="maker.abstract_authenticator">
+                <tag name="maker.authenticator_maker" type="pre-authenticated" />
+            </service>
+
+            <service id="maker.authenticator_http_baic_maker" class="Symfony\Bundle\MakerBundle\Security\Authenticator\HttpBasicAuthenticatorMaker" parent="maker.abstract_authenticator">
+                <tag name="maker.authenticator_maker" type="http-basic" />
+            </service>
+
+            <service id="maker.authenticator_custom_authenticator_maker" class="Symfony\Bundle\MakerBundle\Security\Authenticator\CustomAuthenticatorMaker" parent="maker.abstract_authenticator">
+                <tag name="maker.authenticator_maker" type="custom-authenticator" />
+            </service>
+
+            <service id="maker.authenticator_custom_form_login_authenticator_maker" class="Symfony\Bundle\MakerBundle\Security\Authenticator\CustomLoginFormAuthenticatorMaker" parent="maker.abstract_authenticator">
+                <argument type="service" id="maker.doctrine_helper" />
+                <tag name="maker.authenticator_maker" type="form-login-authenticator" />
             </service>
 
             <service id="maker.maker.make_command" class="Symfony\Bundle\MakerBundle\Maker\MakeCommand">

--- a/src/Security/Authenticator/AbstractAuthenticatorMaker.php
+++ b/src/Security/Authenticator/AbstractAuthenticatorMaker.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Security\InteractiveSecurityHelper;
+use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
+use Symfony\Bundle\MakerBundle\Security\SecurityControllerBuilder;
+use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class AbstractAuthenticatorMaker implements AuthenticatorMakerInterface
+{
+    protected const SECURITY_YAML_PATH = 'config/packages/security.yaml';
+
+    protected $fileManager;
+    protected $generator;
+    protected $configUpdater;
+    private $interactiveSecurityHelper;
+
+    public function __construct(FileManager $fileManager, Generator $generator, SecurityConfigUpdater $configUpdater)
+    {
+        $this->fileManager = $fileManager;
+        $this->generator = $generator;
+        $this->configUpdater = $configUpdater;
+        $this->interactiveSecurityHelper = new InteractiveSecurityHelper();
+    }
+
+    public function isAvailable(bool $security52): bool
+    {
+        return true;
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): bool
+    {
+        $securityData = $this->getSecurityData();
+        $command->addOption('firewall-name', null, InputOption::VALUE_OPTIONAL);
+        $input->setOption('firewall-name', $firewallName = $this->interactiveSecurityHelper->guessFirewallName($io, $securityData));
+
+        $command->addOption('entry-point', null, InputOption::VALUE_OPTIONAL);
+
+        if (!$securityData['security']['enable_authenticator_manager'] ?? false) {
+            $input->setOption(
+                'entry-point',
+                $this->interactiveSecurityHelper->guessEntryPoint($io, $securityData, $input->getArgument('authenticator-class'), $firewallName)
+            );
+        }
+
+        $command->addArgument('user-class', InputArgument::REQUIRED);
+        $input->setArgument(
+            'user-class',
+            $userClass = $this->interactiveSecurityHelper->guessUserClass($io, $securityData['security']['providers'])
+        );
+
+        return true;
+    }
+
+    protected function askControllerClass(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        $command->addArgument('controller-class', InputArgument::REQUIRED);
+        $input->setArgument(
+            'controller-class',
+            $io->ask(
+                'Choose a name for the controller class (e.g. <fg=yellow>SecurityController</>)',
+                'SecurityController',
+                [Validator::class, 'validateClassName']
+            )
+        );
+    }
+
+    protected function askUsernameField(InputInterface $input, ConsoleStyle $io, Command $command, string $userClass): void
+    {
+        $securityData = $this->getSecurityData();
+
+        $command->addArgument('username-field', InputArgument::REQUIRED);
+        $input->setArgument(
+            'username-field',
+            $this->interactiveSecurityHelper->guessUserNameField($io, $userClass, $securityData['security']['providers'])
+        );
+    }
+
+    /**
+     * @param callable(SecurityControllerBuilder, ClassSourceManipulator, ClassNameDetails): void $configureControllerBuilder
+     */
+    protected function generateController(string $controllerClass, string $templateName, callable $configureControllerBuilder = null): void
+    {
+        $controllerClassNameDetails = $this->generator->createClassNameDetails(
+            $controllerClass,
+            'Controller\\',
+            'Controller'
+        );
+
+        if (!class_exists($controllerClassNameDetails->getFullName())) {
+            $controllerPath = $this->generator->generateController($controllerClassNameDetails->getFullName(), $templateName);
+            $controllerSourceCode = $this->generator->getFileContentsForPendingOperation($controllerPath);
+        } else {
+            $controllerPath = $this->fileManager->getRelativePathForFutureClass($controllerClassNameDetails->getFullName());
+            $controllerSourceCode = $this->fileManager->getFileContents($controllerPath);
+        }
+
+        $manipulator = new ClassSourceManipulator($controllerSourceCode, true);
+
+        if ($configureControllerBuilder) {
+            $securityControllerBuilder = new SecurityControllerBuilder();
+
+            $configureControllerBuilder($securityControllerBuilder, $manipulator, $controllerClassNameDetails);
+        }
+
+        $this->generator->dumpFile($controllerPath, $manipulator->getSourceCode());
+    }
+
+    protected function getSecurityData(): array
+    {
+        $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents(self::SECURITY_YAML_PATH));
+
+        return $manipulator->getData();
+    }
+
+    protected function getSecurityYamlSource(): string
+    {
+        return $this->fileManager->getFileContents(self::SECURITY_YAML_PATH);
+    }
+}

--- a/src/Security/Authenticator/AuthenticatorMakerInterface.php
+++ b/src/Security/Authenticator/AuthenticatorMakerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+interface AuthenticatorMakerInterface
+{
+    public function getDescription(): string;
+    public function isAvailable(bool $security52): bool;
+    /** @return bool false if the authenticator type changed, true if this authenticator maker should be used in the rest of the maker */
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): bool;
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array;
+}

--- a/src/Security/Authenticator/CustomAuthenticatorMaker.php
+++ b/src/Security/Authenticator/CustomAuthenticatorMaker.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+
+class CustomAuthenticatorMaker extends AbstractAuthenticatorMaker
+{
+    public function getDescription(): string
+    {
+        return 'Custom authenticator';
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): bool
+    {
+        if (!$io->confirm('A custom authenticator is only required in advanced use-cases, are you sure your use-case isn\'t covered by one of the built-in authenticators?', true)) {
+            $input->setArgument('authenticator-type', null);
+
+            return false;
+        }
+
+        if ($io->confirm('Do you want to use a login form?', false)) {
+            $input->setArgument('authenticator-type', 'form-login-authenticator');
+
+            return false;
+        }
+
+        return $this->baseInteract($input, $io, $command);
+    }
+
+    protected function baseInteract(InputInterface $input, ConsoleStyle $io, Command $command): bool
+    {
+        // authenticator class
+        $command->addArgument('authenticator-class', InputArgument::REQUIRED);
+        $questionAuthenticatorClass = new Question('The class name of the authenticator to create (e.g. <fg=yellow>AppCustomAuthenticator</>)');
+        $questionAuthenticatorClass->setValidator(function ($answer) {
+            Validator::notBlank($answer);
+
+            return Validator::classDoesNotExist($this->generator->createClassNameDetails($answer, 'Security\\', 'Authenticator')->getFullName());
+        });
+        $input->setArgument('authenticator-class', $io->askQuestion($questionAuthenticatorClass));
+
+        parent::interact($input, $io, $command);
+
+        return true;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array
+    {
+        $this->generator->generateClass(
+            $authenticatorClass = $input->getArgument('authenticator-class'),
+            sprintf('authenticator/%sEmptyAuthenticator.tpl.php', $useSecurity52 ? 'Security52' : ''),
+            [
+                'provider_key_type_hint' => $this->getGuardProviderKeyTypeHint(),
+                'use_legacy_passport_interface' => $this->shouldUseLegacyPassportInterface($useSecurity52),
+            ]
+        );
+
+        $securityYamlUpdated = $this->updateSecurityYamlForAuthenticator(
+            $input->getOption('firewall-name'),
+            $useSecurity52 ? false : $input->getOption('entry-point'),
+            $authenticatorClass,
+            $input->hasOption('logout-setup') ? $input->getOption('logout-setup') : false,
+            $useSecurity52
+        );
+
+        $nextTexts = ['Next:'];
+        $nextTexts[] = '- Customize your new authenticator.';
+        if (!$securityYamlUpdated) {
+            $yamlExample = $this->configUpdater->updateForCustomAuthenticator(
+                'security: {}',
+                'main',
+                null,
+                $authenticatorClass,
+                $logoutSetup,
+                $useSecurity52
+            );
+            $nextTexts[] = "- Your <info>security.yaml</info> could not be updated automatically. You'll need to add the following config manually:\n\n".$yamlExample;
+        }
+        $nextTexts[] = sprintf('- Finish the redirect "TODO" in the <info>%s::onAuthenticationSuccess()</info> method.', $authenticatorClass);
+    }
+
+    /**
+     * Calculates the type-hint used for the $provider argument (string or nothing) for Guard.
+     */
+    protected function getGuardProviderKeyTypeHint(): string
+    {
+        // doesn't matter: this only applies to non-Guard authenticators
+        if (!class_exists(AbstractFormLoginAuthenticator::class)) {
+            return '';
+        }
+
+        $reflectionMethod = new \ReflectionMethod(AbstractFormLoginAuthenticator::class, 'onAuthenticationSuccess');
+        $type = $reflectionMethod->getParameters()[2]->getType();
+
+        if (!$type instanceof \ReflectionNamedType) {
+            return '';
+        }
+
+        return sprintf('%s ', $type->getName());
+    }
+
+    protected function shouldUseLegacyPassportInterface(bool $useSecurity52): bool
+    {
+        // only applies to new authenticator security
+        if (!$useSecurity52) {
+            return false;
+        }
+
+        // legacy: checking for Symfony 5.2 & 5.3 before PassportInterface deprecation
+        $class = new \ReflectionClass(AuthenticatorInterface::class);
+        $method = $class->getMethod('authenticate');
+
+        // 5.4 where return type is temporarily removed
+        if (!$method->getReturnType()) {
+            return false;
+        }
+
+        return PassportInterface::class === $method->getReturnType()->getName();
+    }
+
+    protected function updateSecurityYamlForAuthenticator(string $firewallName, ?string $entryPoint, string $authenticatorClass, bool $logoutSetup, bool $security52): bool
+    {
+        $securityYamlSource = $this->getSecurityYamlSource();
+        try {
+            $newYaml = $this->configUpdater->updateForCustomAuthenticator(
+                $securityYamlSource,
+                $firewallName,
+                $entryPoint,
+                $authenticatorClass,
+                $logoutSetup,
+                $security52
+            );
+            $this->generator->dumpFile(self::SECURITY_YAML_PATH, $newYaml);
+
+            return true;
+        } catch (YamlManipulationFailedException $e) {
+        }
+
+        return false;
+    }
+}

--- a/src/Security/Authenticator/CustomLoginFormAuthenticatorMaker.php
+++ b/src/Security/Authenticator/CustomLoginFormAuthenticatorMaker.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
+use Symfony\Bundle\MakerBundle\Security\SecurityControllerBuilder;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
+use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class CustomLoginFormAuthenticatorMaker extends CustomAuthenticatorMaker
+{
+    private $doctrineHelper;
+
+    public function __construct(FileManager $fileManager, Generator $generator, SecurityConfigUpdater $configUpdater, DoctrineHelper $doctrineHelper)
+    {
+        parent::__construct($fileManager, $generator, $configUpdater);
+
+        $this->doctrineHelper = $doctrineHelper;
+    }
+
+    public function isAvailable(bool $security52): bool
+    {
+        return false;
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): bool
+    {
+        if (!$this->baseInteract($input, $io, $command)) {
+            return false;
+        }
+
+        $this->askControllerClass($input, $io, $command);
+        $this->askUsernameField($input, $io, $command, $input->getArgument('user-class'));
+
+        return true;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array
+    {
+        $userClass = $input->getArgument('user-class');
+        $userClassNameDetails = $this->generator->createClassNameDetails('\\'.$userClass, 'Entity\\');
+        $userNameField = $input->hasArgument('username-field') ? $input->getArgument('username-field') : null;
+        $authenticatorClass = $input->getArgument('authenticator-class');
+
+        $this->generator->generateClass(
+            $authenticatorClass,
+            sprintf('authenticator/%sLoginFormAuthenticator.tpl.php', $useSecurity52 ? 'Security52' : ''),
+            [
+                'user_fully_qualified_class_name' => trim($userClassNameDetails->getFullName(), '\\'),
+                'user_class_name' => $userClassNameDetails->getShortName(),
+                'username_field' => $userNameField,
+                'username_field_label' => Str::asHumanWords($userNameField),
+                'username_field_var' => Str::asLowerCamelCase($userNameField),
+                'user_needs_encoder' => $this->userClassHasEncoder($this->getSecurityData(), $userClass),
+                'user_is_entity' => $this->doctrineHelper->isClassAMappedEntity($userClass),
+                'provider_key_type_hint' => $this->getGuardProviderKeyTypeHint(),
+                'use_legacy_passport_interface' => $this->shouldUseLegacyPassportInterface($useSecurity52),
+            ]
+        );
+
+        $securityYamlUpdated = $this->updateSecurityYamlForAuthenticator(
+            $input->getOption('firewall-name'),
+            $input->getOption('entry-point'),
+            $authenticatorClass,
+            $input->hasOption('logout-setup') ? $input->getOption('logout-setup') : false,
+            $useSecurity52
+        );
+
+        $logoutSetup = $input->getOption('logout-setup');
+        $this->generateController(
+            $input->getArgument('controller-class'),
+            'authenticator/EmptySecurityController.tpl.php',
+            function (SecurityControllerBuilder $securityControllerBuilder, ClassSourceManipulator $manipulator, ClassNameDetails $controllerClassNameDetails) use ($logoutSetup) {
+                if (method_exists($controllerClassNameDetails->getFullName(), 'login')) {
+                    throw new RuntimeCommandException(sprintf('Method "login" already exists on class %s', $controllerClassNameDetails->getFullName()));
+                }
+
+                $securityControllerBuilder->addLoginMethod($manipulator);
+                if ($logoutSetup) {
+                    $securityControllerBuilder->addLogoutMethod($manipulator);
+                }
+            }
+        );
+
+        $this->generator->generateTemplate(
+            'security/login.html.twig',
+            'authenticator/login_form.tpl.php',
+            [
+                'username_field' => $userNameField,
+                'username_is_email' => false !== stripos($userNameField, 'email'),
+                'username_label' => ucfirst(Str::asHumanWords($userNameField)),
+                'logout_setup' => $logoutSetup,
+            ]
+        );
+
+        $nextTexts = ['Next:'];
+        $nextTexts[] = '- Customize your new authenticator.';
+        if (!$securityYamlUpdated) {
+            $yamlExample = $this->configUpdater->updateForCustomAuthenticator(
+                'security: {}',
+                $input->getOption('firewall-name'),
+                null,
+                $authenticatorClass,
+                $logoutSetup,
+                $useSecurity52
+            );
+            $nextTexts[] = "- Your <info>security.yaml</info> could not be updated automatically. You'll need to add the following config manually:\n\n".$yamlExample;
+        }
+        $nextTexts[] = sprintf('- Finish the redirect "TODO" in the <info>%s::onAuthenticationSuccess()</info> method.', $authenticatorClass);
+        if (!$this->doctrineHelper->isClassAMappedEntity($userClass)) {
+            $nextTexts[] = sprintf('- Review <info>%s::getUser()</info> to make sure it matches your needs.', $authenticatorClass);
+        }
+
+        // this only applies to Guard authentication AND if the user does not have a hasher configured
+        if (!$useSecurity52 && !$this->userClassHasEncoder($this->getSecurityData(), $userClass)) {
+            $nextTexts[] = sprintf('- Check the user\'s password in <info>%s::checkCredentials()</info>.', $authenticatorClass);
+        }
+
+        $nextTexts[] = '- Review & adapt the login template: <info>'.$this->fileManager->getPathForTemplate('security/login.html.twig').'</info>.';
+
+        return $nextTexts;
+    }
+
+    private function userClassHasEncoder(array $securityData, string $userClass): bool
+    {
+        $userNeedsEncoder = false;
+        $hashersData = $securityData['security']['encoders'] ?? $securityData['security']['encoders'] ?? [];
+
+        foreach ($hashersData as $userClassWithEncoder => $encoder) {
+            if ($userClass === $userClassWithEncoder || is_subclass_of($userClass, $userClassWithEncoder) || class_implements($userClass, $userClassWithEncoder)) {
+                $userNeedsEncoder = true;
+            }
+        }
+
+        return $userNeedsEncoder;
+    }
+}

--- a/src/Security/Authenticator/HttpBasicAuthenticatorMaker.php
+++ b/src/Security/Authenticator/HttpBasicAuthenticatorMaker.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
+use Symfony\Component\Console\Input\InputInterface;
+
+class HttpBasicAuthenticatorMaker extends AbstractAuthenticatorMaker
+{
+    public function getDescription(): string
+    {
+        return 'HTTP basic';
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array
+    {
+        $securityYamlSource = $this->getSecurityYamlSource();
+        $nextTexts = [];
+        try {
+            $newYaml = $this->configUpdater->updateForAuthenticator(
+                $securityYamlSource,
+                $input->getOption('firewall-name'),
+                'http_basic',
+                true,
+                $input->hasOption('logout-setup') ? $input->getOption('logout-setup') : false,
+                $useSecurity52
+            );
+
+            $this->generator->dumpFile(self::SECURITY_YAML_PATH, $newYaml);
+        } catch (YamlManipulationFailedException $e) {
+            $yamlExample = $this->configUpdater->updateForAuthenticator(
+                'security: {}',
+                $input->getOption('firewall-name'),
+                'http_basic',
+                true,
+                $input->hasOption('logout-setup') ? $input->getOption('logout-setup') : false,
+                $useSecurity52
+            );
+
+            $nextTexts[] = 'Next:';
+            $nextTexts[] = "- Your <info>security.yaml</info> could not be updated automatically. You'll need to add the following config manually:\n\n".$yamlExample;
+        }
+
+        return $nextTexts;
+    }
+}

--- a/src/Security/Authenticator/JsonLoginAuthenticatorMaker.php
+++ b/src/Security/Authenticator/JsonLoginAuthenticatorMaker.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class JsonLoginAuthenticatorMaker extends AbstractAuthenticatorMaker
+{
+    public function getDescription(): string
+    {
+        return 'JSON API login';
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): bool
+    {
+        parent::interact($input, $io, $command);
+
+        $this->askControllerClass($input, $io, $command);
+        $this->askUsernameField($input, $io, $command);
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array
+    {
+    }
+}

--- a/src/Security/Authenticator/LoginFormAuthenticatorMaker.php
+++ b/src/Security/Authenticator/LoginFormAuthenticatorMaker.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class LoginFormAuthenticatorMaker extends AbstractAuthenticatorMaker
+{
+    public function getDescription(): string
+    {
+        return 'Login form';
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): bool
+    {
+        if ($io->confirm('Do you require other fields than user identifier (e.g. email) and password?', false)) {
+            $input->setArgument('authenticator-type', self::AUTH_TYPE_FORM_LOGIN_AUTHENTICATOR);
+
+            return false;
+        }
+
+        parent::interact($input, $io, $command);
+
+        $this->askControllerClass($input, $io, $command);
+        $this->askUsernameField($input, $io, $command);
+
+        return true;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array
+    {
+    }
+}

--- a/src/Security/Authenticator/LoginLinkAuthenticatorMaker.php
+++ b/src/Security/Authenticator/LoginLinkAuthenticatorMaker.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
+
+class LoginLinkAuthenticatorMaker extends AbstractAuthenticatorMaker
+{
+    public function getDescription(): string
+    {
+        return 'Login link';
+    }
+
+    public function isAvailable(bool $security52): bool
+    {
+        return $security52 && class_exists(LoginLinkAuthenticator::class);
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array
+    {
+    }
+}

--- a/src/Security/Authenticator/PreAuthenticatedAuthenticatorMaker.php
+++ b/src/Security/Authenticator/PreAuthenticatedAuthenticatorMaker.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Security\Authenticator;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+class PreAuthenticatedAuthenticatorMaker extends AbstractAuthenticatorMaker
+{
+    private const AUTH_TYPE_X509 = 'x509';
+    private const AUTH_TYPE_REMOTE_USER = 'remote-user';
+
+    public function getDescription(): string
+    {
+        return 'Pre authenticated (e.g. Kerebos or certificates)';
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): bool
+    {
+        $preAuthenticatedTypes = [
+            'Remote user (e.g. Kerebos)' => self::AUTH_TYPE_REMOTE_USER,
+            'Client certificates (X.509)' => self::AUTH_TYPE_X509,
+        ];
+        $authenticatorType = $io->choice('Which pre-authenticated method do you want?', array_keys($preAuthenticatedTypes));
+        // argument type is changed, but it should still be managed by this maker
+        $input->setArgument('authenticator-type', $preAuthenticatedTypes[$authenticatorType]);
+
+        parent::interact($input, $io, $command);
+
+        return true;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator, bool $useSecurity52): array
+    {
+    }
+}


### PR DESCRIPTION
Fixes #1049

This is a very early proof of concept. Please focus on this description, rather than on the code and CI failures :)

Goal
---

1. If you look at https://symfony.com/doc/current/security/#authenticating-users , you can see that almost all built-in authenticator require bootstrapping code: controllers, templates, etc. I would like to replace that whole section with: **"Run `make:auth`, choose the authentication method you want and follow the steps."**
2. The maker bundle currently "forces" you to write a custom authenticator. For most common use-cases, this is not needed and **we should instead encourage people to use the built-in authenticators**.

How do we get there?
---

We should start by asking a few simple questions in order to determine whether a custom authenticator, or built-in authenticators should be generated (solves (2)). After those questions, we can bootstrap the code required to get all authenticators working (solves (1)).

The state of this PR at the moment is that it more or less fixed the 2nd goal, by listing all available built-in authenticators and asking an extra question for form login/custom authenticator:

```
$ symfony console make:auth

 What style of authentication do you want? [Login form]:
  [0] Login form
  [1] JSON API login
  [2] HTTP basic
  [3] Login link
  [4] Pre authenticated
  [5] Custom authenticator
 > 0

 Do you require other fields than user identifier (e.g. email) and password? (yes/no) [no]:
 > no

 # ... configure and bootstrap the built-in authenticator
 # a custom form login authenticator would be bootstrapped when the last answer was "yes"
```

Finally, I implemented the HTTP basic authenticator bootstrapping (for the simple reason that this one doesn't require anything else than a `security.yaml` update).

Please let me know what you think :)