### PR TITLE
[make:reset-password] Translate exception reasons provided by ResetPasswordBundle

### DIFF
--- a/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
-<?= $use_legacy_passport_interface ? 'use Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\PassportInterface;'."\n" : '' ?>
+use <?= $use_legacy_passport_interface ? 'Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\PassportInterface' : 'Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\Passport' ?>;
 
 class <?php echo $class_name ?> extends AbstractAuthenticator
 {

--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -34,7 +34,7 @@ class <?= $class_name ?> extends AbstractController
      * @Route("", name="app_forgot_password_request")
      */
 <?php } ?>
-    public function request(Request $request, MailerInterface $mailer): Response
+    public function request(Request $request, MailerInterface $mailer<?php if ($translator_available): ?>, TranslatorInterface $translator<?php endif ?>): Response
     {
         $form = $this->createForm(<?= $request_form_type_class_name ?>::class);
         $form->handleRequest($request);
@@ -42,7 +42,8 @@ class <?= $class_name ?> extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             return $this->processSendingPasswordResetEmail(
                 $form->get('<?= $email_field ?>')->getData(),
-                $mailer
+                $mailer<?php if ($translator_available): ?>,
+                $translator<?php endif ?><?= "\n" ?>
             );
         }
 
@@ -84,7 +85,7 @@ class <?= $class_name ?> extends AbstractController
      * @Route("/reset/{token}", name="app_reset_password")
      */
 <?php } ?>
-    public function reset(Request $request, <?= $password_hasher_class_details->getShortName() ?> <?= $password_hasher_variable_name ?>, string $token = null): Response
+    public function reset(Request $request, <?= $password_hasher_class_details->getShortName() ?> <?= $password_hasher_variable_name ?><?php if ($translator_available): ?>, TranslatorInterface $translator<?php endif ?>, string $token = null): Response
     {
         if ($token) {
             // We store the token in session and remove it from the URL, to avoid the URL being
@@ -103,8 +104,9 @@ class <?= $class_name ?> extends AbstractController
             $user = $this->resetPasswordHelper->validateTokenAndFetchUser($token);
         } catch (ResetPasswordExceptionInterface $e) {
             $this->addFlash('reset_password_error', sprintf(
-                'There was a problem validating your reset request - %s',
-                $e->getReason()
+                '%s - %s',
+                <?php if ($translator_available): ?>$translator->trans(<?= $problem_validate_message_or_constant ?>, [], 'ResetPasswordBundle')<?php else: ?><?= $problem_validate_message_or_constant ?><?php endif ?>,
+                <?php if ($translator_available): ?>$translator->trans($e->getReason(), [], 'ResetPasswordBundle')<?php else: ?>$e->getReason()<?php endif ?><?= "\n" ?>
             ));
 
             return $this->redirectToRoute('app_forgot_password_request');
@@ -138,7 +140,7 @@ class <?= $class_name ?> extends AbstractController
         ]);
     }
 
-    private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer): RedirectResponse
+    private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer<?php if ($translator_available): ?>, TranslatorInterface $translator<?php endif ?>): RedirectResponse
     {
         $user = $this->entityManager->getRepository(<?= $user_class_name ?>::class)->findOneBy([
             '<?= $email_field ?>' => $emailFormData,
@@ -157,8 +159,9 @@ class <?= $class_name ?> extends AbstractController
             // Caution: This may reveal if a user is registered or not.
             //
             // $this->addFlash('reset_password_error', sprintf(
-            //     'There was a problem handling your password reset request - %s',
-            //     $e->getReason()
+            //     '%s - %s',
+            //     <?php if ($translator_available): ?>$translator->trans(<?= $problem_handle_message_or_constant ?>, [], 'ResetPasswordBundle')<?php else: ?><?= $problem_handle_message_or_constant ?><?php endif ?>,
+            //     <?php if ($translator_available): ?>$translator->trans($e->getReason(), [], 'ResetPasswordBundle')<?php else: ?>$e->getReason()<?php endif ?><?= "\n" ?>
             // ));
 
             return $this->redirectToRoute('app_check_email');

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -13,6 +13,13 @@ namespace Symfony\Bundle\MakerBundle\Util;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use PhpParser\Builder;
 use PhpParser\BuilderHelpers;
 use PhpParser\Comment\Doc;
@@ -93,7 +100,7 @@ final class ClassSourceManipulator
         $attributes = [];
 
         if ($this->useAttributesForDoctrineMapping) {
-            $attributes[] = $this->buildAttributeNode('ORM\Column', $columnOptions);
+            $attributes[] = $this->buildAttributeNode(Column::class, $columnOptions, 'ORM');
         } else {
             $comments[] = $this->buildAnnotationLine('@ORM\Column', $columnOptions);
         }
@@ -138,10 +145,9 @@ final class ClassSourceManipulator
         } else {
             $attributes = [
                 $this->buildAttributeNode(
-                    'ORM\\Embedded',
-                    [
-                        'class' => new ClassNameValue($className, $typeHint),
-                    ]
+                    Embedded::class,
+                    ['class' => new ClassNameValue($className, $typeHint)],
+                    'ORM'
                 ),
             ];
         }
@@ -333,6 +339,9 @@ final class ClassSourceManipulator
         return $this->createBlankLineNode(self::CONTEXT_CLASS_METHOD);
     }
 
+    /**
+     * @param array<Node\Attribute|Node\AttributeGroup> $attributes
+     */
     public function addProperty(string $name, array $annotationLines = [], $defaultValue = null, array $attributes = []): void
     {
         if ($this->propertyExists($name)) {
@@ -342,12 +351,12 @@ final class ClassSourceManipulator
 
         $newPropertyBuilder = (new Builder\Property($name))->makePrivate();
 
-        if ($annotationLines && $this->useAnnotations) {
+        if ($this->useAttributesForDoctrineMapping) {
+            foreach ($attributes as $attribute) {
+                $newPropertyBuilder->addAttribute($attribute);
+            }
+        } elseif ($annotationLines && $this->useAnnotations) {
             $newPropertyBuilder->setDocComment($this->createDocBlock($annotationLines));
-        }
-
-        foreach ($attributes as $attribute) {
-            $newPropertyBuilder->addAttribute($attribute);
         }
 
         if (null !== $defaultValue) {
@@ -356,6 +365,17 @@ final class ClassSourceManipulator
         $newPropertyNode = $newPropertyBuilder->getNode();
 
         $this->addNodeAfterProperties($newPropertyNode);
+    }
+
+    public function addAttributeToClass(string $attributeClass, array $options): void
+    {
+        $this->addUseStatementIfNecessary($attributeClass);
+
+        $classNode = $this->getClassNode();
+
+        $classNode->attrGroups[] = new Node\AttributeGroup([$this->buildAttributeNode($attributeClass, $options)]);
+
+        $this->updateSourceCodeFromNewStmts();
     }
 
     public function addAnnotationToClass(string $annotationClass, array $options): void
@@ -532,8 +552,9 @@ final class ClassSourceManipulator
         } else {
             $attributes = [
                 $this->buildAttributeNode(
-                    $relation instanceof RelationManyToOne ? 'ORM\\ManyToOne' : 'ORM\\OneToOne',
-                    $annotationOptions
+                    $relation instanceof RelationManyToOne ? ManyToOne::class : OneToOne::class,
+                    $annotationOptions,
+                    'ORM'
                 ),
             ];
         }
@@ -544,9 +565,7 @@ final class ClassSourceManipulator
                     'nullable' => false,
                 ]);
             } else {
-                $attributes[] = $this->buildAttributeNode('ORM\\JoinColumn', [
-                    'nullable' => false,
-                ]);
+                $attributes[] = $this->buildAttributeNode(JoinColumn::class, ['nullable' => false], 'ORM');
             }
         }
 
@@ -628,8 +647,9 @@ final class ClassSourceManipulator
         } else {
             $attributes = [
                 $this->buildAttributeNode(
-                    $relation instanceof RelationManyToMany ? 'ORM\\ManyToMany' : 'ORM\\OneToMany',
-                    $annotationOptions
+                    $relation instanceof RelationManyToMany ? ManyToMany::class : OneToMany::class,
+                    $annotationOptions,
+                    'ORM'
                 ),
             ];
         }
@@ -898,6 +918,30 @@ final class ClassSourceManipulator
         $this->updateSourceCodeFromNewStmts();
 
         return $shortClassName;
+    }
+
+    /**
+     * Builds a PHPParser attribute node.
+     *
+     * @param string  $attributeClass  The attribute class which should be used for the attribute E.g. #[Column()]
+     * @param array   $options         The named arguments for the attribute ($key = argument name, $value = argument value)
+     * @param ?string $attributePrefix If a prefix is provided, the node is built using the prefix. E.g. #[ORM\Column()]
+     */
+    public function buildAttributeNode(string $attributeClass, array $options, ?string $attributePrefix = null): Node\Attribute
+    {
+        $options = $this->sortOptionsByClassConstructorParameters($options, $attributeClass);
+
+        $context = $this;
+        $nodeArguments = array_map(static function ($option, $value) use ($context) {
+            return new Node\Arg($context->buildNodeExprByValue($value), false, false, [], new Node\Identifier($option));
+        }, array_keys($options), array_values($options));
+
+        $class = $attributePrefix ? sprintf('%s\\%s', $attributePrefix, Str::getShortClassName($attributeClass)) : Str::getShortClassName($attributeClass);
+
+        return new Node\Attribute(
+            new Node\Name($class),
+            $nodeArguments
+        );
     }
 
     private function updateSourceCodeFromNewStmts(): void
@@ -1419,27 +1463,6 @@ final class ClassSourceManipulator
         }
 
         return $nodeValue;
-    }
-
-    /**
-     * builds an PHPParser attribute node.
-     *
-     * @param string $attributeClass the attribute class which should be used for the attribute
-     * @param array  $options        the named arguments for the attribute ($key = argument name, $value = argument value)
-     */
-    private function buildAttributeNode(string $attributeClass, array $options): Node\Attribute
-    {
-        $options = $this->sortOptionsByClassConstructorParameters($options, $attributeClass);
-
-        $context = $this;
-        $nodeArguments = array_map(static function ($option, $value) use ($context) {
-            return new Node\Arg($context->buildNodeExprByValue($value), false, false, [], new Node\Identifier($option));
-        }, array_keys($options), array_values($options));
-
-        return new Node\Attribute(
-            new Node\Name($attributeClass),
-            $nodeArguments
-        );
     }
 
     /**

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -32,13 +32,15 @@ class MakeEntityTest extends MakerTestCase
             ->preRun(function (MakerTestRunner $runner) use ($withDatabase) {
                 $config = $runner->readYaml('config/packages/doctrine.yaml');
 
-                if (isset($config['doctrine']['orm']['mappings']['App']['type']) && $this->useAttributes($runner)) {
-                    // use attributes
-                    $runner->replaceInFile(
-                        'config/packages/doctrine.yaml',
-                        'type: annotation',
-                        'type: attribute'
-                    );
+                /* @legacy Refactor when annotations are no longer supported. */
+                if (isset($config['doctrine']['orm']['mappings']['App']) && !$this->useAttributes($runner)) {
+                    // Attributes are only supported w/ PHP 8, FrameworkBundle >=5.2,
+                    // ORM >=2.9, & DoctrineBundle >=2.4
+                    $runner->modifyYamlFile('config/packages/doctrine.yaml', function (array $data) {
+                        $data['doctrine']['orm']['mappings']['App']['type'] = 'annotation';
+
+                        return $data;
+                    });
                 }
 
                 if ($withDatabase) {

--- a/tests/Maker/MakeFunctionalTestTest.php
+++ b/tests/Maker/MakeFunctionalTestTest.php
@@ -28,7 +28,8 @@ class MakeFunctionalTestTest extends MakerTestCase
     public function getTestDetails()
     {
         yield 'it_generates_test_with_panther' => [$this->createMakerTest()
-            ->addExtraDependencies('panther')
+            /* @legacy Allows Panther >= 1.x to be installed. (PHP <8.0 support) */
+            ->addExtraDependencies('panther:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-functional/MainController.php',

--- a/tests/Maker/MakeSerializerEncoderTest.php
+++ b/tests/Maker/MakeSerializerEncoderTest.php
@@ -25,6 +25,11 @@ class MakeSerializerEncoderTest extends MakerTestCase
     public function getTestDetails()
     {
         yield 'it_makes_serializer_encoder' => [$this->createMakerTest()
+            // serializer-pack 1.1 requires symfony/property-info >= 5.4
+            // adding symfony/serializer-pack:* as an extra depends allows
+            // us to use serializer-pack < 1.1 which does not conflict with
+            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
+            ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeSerializerNormalizerTest.php
+++ b/tests/Maker/MakeSerializerNormalizerTest.php
@@ -25,6 +25,11 @@ class MakeSerializerNormalizerTest extends MakerTestCase
     public function getTestDetails()
     {
         yield 'it_makes_serializer_normalizer' => [$this->createMakerTest()
+            // serializer-pack 1.1 requires symfony/property-info >= 5.4
+            // adding symfony/serializer-pack:* as an extra depends allows
+            // us to use serializer-pack < 1.1 which does not conflict with
+            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
+            ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeTestTest.php
+++ b/tests/Maker/MakeTestTest.php
@@ -80,7 +80,8 @@ class MakeTestTest extends MakerTestCase
         ];
 
         yield 'it_makes_PantherTestCase_type' => [$this->createMakerTest()
-            ->addExtraDependencies('panther')
+            /* @legacy Allows Panther >= 1.x to be installed. (PHP <8.0 support) */
+            ->addExtraDependencies('panther:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-test/basic_setup',

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
 use PhpParser\Builder\Param;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToMany;
@@ -164,6 +166,41 @@ class ClassSourceManipulatorTest extends TestCase
             false,
             [],
             'User_empty.php',
+        ];
+    }
+
+    /**
+     * @dataProvider getAttributeClassTests
+     */
+    public function testAddAttributeToClass(string $sourceFilename, string $expectedSourceFilename, string $attributeClass, array $attributeOptions, string $attributePrefix = null): void
+    {
+        // @legacy Remove conditional when PHP < 8.0 support is dropped.
+        if ((\PHP_VERSION_ID < 80000)) {
+            $this->markTestSkipped('Requires PHP >= PHP 8.0');
+        }
+
+        $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
+        $expectedSource = file_get_contents(__DIR__.'/fixtures/add_class_attribute/'.$expectedSourceFilename);
+        $manipulator = new ClassSourceManipulator($source);
+        $manipulator->addAttributeToClass($attributeClass, $attributeOptions, $attributePrefix);
+
+        self::assertSame($expectedSource, $manipulator->getSourceCode());
+    }
+
+    public function getAttributeClassTests(): \Generator
+    {
+        yield 'Empty class' => [
+            'User_empty.php',
+            'User_empty.php',
+            Entity::class,
+            [],
+        ];
+
+        yield 'Class already has attributes' => [
+            'User_simple.php',
+            'User_simple.php',
+            Column::class,
+            ['message' => 'We use this attribute for class level tests so we dont have to add additional test dependencies.'],
         ];
     }
 

--- a/tests/Util/fixtures/add_class_attribute/User_empty.php
+++ b/tests/Util/fixtures/add_class_attribute/User_empty.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping\Entity;
+
+#[Entity]
+class User
+{
+}

--- a/tests/Util/fixtures/add_class_attribute/User_simple.php
+++ b/tests/Util/fixtures/add_class_attribute/User_simple.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+
+#[ORM\Entity]
+#[Column(message: 'We use this attribute for class level tests so we dont have to add additional test dependencies.')]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
If there's `Symfony\Contracts\Translation\TranslatorInterface` service available in the project - Maker will generate a slightly different controller's code to inject translator service and translate exception reasons out of the box.

Available after: https://github.com/SymfonyCasts/reset-password-bundle/pull/206
