### PR TITLE
Add missing Passport use statement

### DIFF
--- a/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/Security52EmptyAuthenticator.tpl.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
-<?= $use_legacy_passport_interface ? 'use Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\PassportInterface;'."\n" : '' ?>
+use <?= $use_legacy_passport_interface ? 'Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\PassportInterface' : 'Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\Passport' ?>;
 
 class <?php echo $class_name ?> extends AbstractAuthenticator
 {


### PR DESCRIPTION
We either use `PassportInterface` or `Passport` below, but only add `PassportInterface` use statement