### PR TITLE
[MakeRegistration] add support for verify email attributes

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -13,6 +13,13 @@ namespace Symfony\Bundle\MakerBundle\Util;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Embedded;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use PhpParser\Builder;
 use PhpParser\BuilderHelpers;
 use PhpParser\Comment\Doc;
@@ -93,7 +100,7 @@ final class ClassSourceManipulator
         $attributes = [];
 
         if ($this->useAttributesForDoctrineMapping) {
-            $attributes[] = $this->buildAttributeNode('ORM\Column', $columnOptions);
+            $attributes[] = $this->buildAttributeNode(Column::class, $columnOptions, 'ORM');
         } else {
             $comments[] = $this->buildAnnotationLine('@ORM\Column', $columnOptions);
         }
@@ -138,10 +145,9 @@ final class ClassSourceManipulator
         } else {
             $attributes = [
                 $this->buildAttributeNode(
-                    'ORM\\Embedded',
-                    [
-                        'class' => new ClassNameValue($className, $typeHint),
-                    ]
+                    Embedded::class,
+                    ['class' => new ClassNameValue($className, $typeHint)],
+                    'ORM'
                 ),
             ];
         }
@@ -333,6 +339,9 @@ final class ClassSourceManipulator
         return $this->createBlankLineNode(self::CONTEXT_CLASS_METHOD);
     }
 
+    /**
+     * @param array<Node\Attribute|Node\AttributeGroup> $attributes
+     */
     public function addProperty(string $name, array $annotationLines = [], $defaultValue = null, array $attributes = []): void
     {
         if ($this->propertyExists($name)) {
@@ -342,12 +351,12 @@ final class ClassSourceManipulator
 
         $newPropertyBuilder = (new Builder\Property($name))->makePrivate();
 
-        if ($annotationLines && $this->useAnnotations) {
+        if ($this->useAttributesForDoctrineMapping) {
+            foreach ($attributes as $attribute) {
+                $newPropertyBuilder->addAttribute($attribute);
+            }
+        } elseif ($annotationLines && $this->useAnnotations) {
             $newPropertyBuilder->setDocComment($this->createDocBlock($annotationLines));
-        }
-
-        foreach ($attributes as $attribute) {
-            $newPropertyBuilder->addAttribute($attribute);
         }
 
         if (null !== $defaultValue) {
@@ -356,6 +365,17 @@ final class ClassSourceManipulator
         $newPropertyNode = $newPropertyBuilder->getNode();
 
         $this->addNodeAfterProperties($newPropertyNode);
+    }
+
+    public function addAttributeToClass(string $attributeClass, array $options): void
+    {
+        $this->addUseStatementIfNecessary($attributeClass);
+
+        $classNode = $this->getClassNode();
+
+        $classNode->attrGroups[] = new Node\AttributeGroup([$this->buildAttributeNode($attributeClass, $options)]);
+
+        $this->updateSourceCodeFromNewStmts();
     }
 
     public function addAnnotationToClass(string $annotationClass, array $options): void
@@ -532,8 +552,9 @@ final class ClassSourceManipulator
         } else {
             $attributes = [
                 $this->buildAttributeNode(
-                    $relation instanceof RelationManyToOne ? 'ORM\\ManyToOne' : 'ORM\\OneToOne',
-                    $annotationOptions
+                    $relation instanceof RelationManyToOne ? ManyToOne::class : OneToOne::class,
+                    $annotationOptions,
+                    'ORM'
                 ),
             ];
         }
@@ -544,9 +565,7 @@ final class ClassSourceManipulator
                     'nullable' => false,
                 ]);
             } else {
-                $attributes[] = $this->buildAttributeNode('ORM\\JoinColumn', [
-                    'nullable' => false,
-                ]);
+                $attributes[] = $this->buildAttributeNode(JoinColumn::class, ['nullable' => false], 'ORM');
             }
         }
 
@@ -628,8 +647,9 @@ final class ClassSourceManipulator
         } else {
             $attributes = [
                 $this->buildAttributeNode(
-                    $relation instanceof RelationManyToMany ? 'ORM\\ManyToMany' : 'ORM\\OneToMany',
-                    $annotationOptions
+                    $relation instanceof RelationManyToMany ? ManyToMany::class : OneToMany::class,
+                    $annotationOptions,
+                    'ORM'
                 ),
             ];
         }
@@ -898,6 +918,30 @@ final class ClassSourceManipulator
         $this->updateSourceCodeFromNewStmts();
 
         return $shortClassName;
+    }
+
+    /**
+     * Builds a PHPParser attribute node.
+     *
+     * @param string  $attributeClass  The attribute class which should be used for the attribute E.g. #[Column()]
+     * @param array   $options         The named arguments for the attribute ($key = argument name, $value = argument value)
+     * @param ?string $attributePrefix If a prefix is provided, the node is built using the prefix. E.g. #[ORM\Column()]
+     */
+    public function buildAttributeNode(string $attributeClass, array $options, ?string $attributePrefix = null): Node\Attribute
+    {
+        $options = $this->sortOptionsByClassConstructorParameters($options, $attributeClass);
+
+        $context = $this;
+        $nodeArguments = array_map(static function ($option, $value) use ($context) {
+            return new Node\Arg($context->buildNodeExprByValue($value), false, false, [], new Node\Identifier($option));
+        }, array_keys($options), array_values($options));
+
+        $class = $attributePrefix ? sprintf('%s\\%s', $attributePrefix, Str::getShortClassName($attributeClass)) : Str::getShortClassName($attributeClass);
+
+        return new Node\Attribute(
+            new Node\Name($class),
+            $nodeArguments
+        );
     }
 
     private function updateSourceCodeFromNewStmts(): void
@@ -1419,27 +1463,6 @@ final class ClassSourceManipulator
         }
 
         return $nodeValue;
-    }
-
-    /**
-     * builds an PHPParser attribute node.
-     *
-     * @param string $attributeClass the attribute class which should be used for the attribute
-     * @param array  $options        the named arguments for the attribute ($key = argument name, $value = argument value)
-     */
-    private function buildAttributeNode(string $attributeClass, array $options): Node\Attribute
-    {
-        $options = $this->sortOptionsByClassConstructorParameters($options, $attributeClass);
-
-        $context = $this;
-        $nodeArguments = array_map(static function ($option, $value) use ($context) {
-            return new Node\Arg($context->buildNodeExprByValue($value), false, false, [], new Node\Identifier($option));
-        }, array_keys($options), array_values($options));
-
-        return new Node\Attribute(
-            new Node\Name($attributeClass),
-            $nodeArguments
-        );
     }
 
     /**

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
 use PhpParser\Builder\Param;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToMany;
@@ -164,6 +166,41 @@ class ClassSourceManipulatorTest extends TestCase
             false,
             [],
             'User_empty.php',
+        ];
+    }
+
+    /**
+     * @dataProvider getAttributeClassTests
+     */
+    public function testAddAttributeToClass(string $sourceFilename, string $expectedSourceFilename, string $attributeClass, array $attributeOptions, string $attributePrefix = null): void
+    {
+        // @legacy Remove conditional when PHP < 8.0 support is dropped.
+        if ((\PHP_VERSION_ID < 80000)) {
+            $this->markTestSkipped('Requires PHP >= PHP 8.0');
+        }
+
+        $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
+        $expectedSource = file_get_contents(__DIR__.'/fixtures/add_class_attribute/'.$expectedSourceFilename);
+        $manipulator = new ClassSourceManipulator($source);
+        $manipulator->addAttributeToClass($attributeClass, $attributeOptions, $attributePrefix);
+
+        self::assertSame($expectedSource, $manipulator->getSourceCode());
+    }
+
+    public function getAttributeClassTests(): \Generator
+    {
+        yield 'Empty class' => [
+            'User_empty.php',
+            'User_empty.php',
+            Entity::class,
+            [],
+        ];
+
+        yield 'Class already has attributes' => [
+            'User_simple.php',
+            'User_simple.php',
+            Column::class,
+            ['message' => 'We use this attribute for class level tests so we dont have to add additional test dependencies.'],
         ];
     }
 

--- a/tests/Util/fixtures/add_class_attribute/User_empty.php
+++ b/tests/Util/fixtures/add_class_attribute/User_empty.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping\Entity;
+
+#[Entity]
+class User
+{
+}

--- a/tests/Util/fixtures/add_class_attribute/User_simple.php
+++ b/tests/Util/fixtures/add_class_attribute/User_simple.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+
+#[ORM\Entity]
+#[Column(message: 'We use this attribute for class level tests so we dont have to add additional test dependencies.')]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
- fixes CI related MakeRegistrationFailures
- Adds support for class level attributes, specifically `UniqueEntity` attributes on the `User` entity.
- Adds support for VerifyEmail property attributes

Known Issues:
Adding a class level attribute that utilizes an aliased use statement, e.g. `use CLASS as PREFIX` type alias is not supported in this PR.  