### PR TITLE
[ci] fix symfony serializer deps in ci

### DIFF
--- a/tests/Maker/MakeSerializerEncoderTest.php
+++ b/tests/Maker/MakeSerializerEncoderTest.php
@@ -25,6 +25,11 @@ class MakeSerializerEncoderTest extends MakerTestCase
     public function getTestDetails()
     {
         yield 'it_makes_serializer_encoder' => [$this->createMakerTest()
+            // serializer-pack 1.1 requires symfony/property-info >= 5.4
+            // adding symfony/serializer-pack:* as an extra depends allows
+            // us to use serializer-pack < 1.1 which does not conflict with
+            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
+            ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeSerializerNormalizerTest.php
+++ b/tests/Maker/MakeSerializerNormalizerTest.php
@@ -25,6 +25,11 @@ class MakeSerializerNormalizerTest extends MakerTestCase
     public function getTestDetails()
     {
         yield 'it_makes_serializer_normalizer' => [$this->createMakerTest()
+            // serializer-pack 1.1 requires symfony/property-info >= 5.4
+            // adding symfony/serializer-pack:* as an extra depends allows
+            // us to use serializer-pack < 1.1 which does not conflict with
+            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
+            ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [


### PR DESCRIPTION
When running serializer tests in Symfony <= 5.3, composer attempts to use `symfony/serializer-pack@1.1` (The latest version at the time of this PR) which conflicts with `symfony/property-info` `<5.4`. This in turn causes our tests to fail due to an uninstallable set of packages. 

As a work around, until something better comes along, adding `symfony/serializer-pack:*` as an extra test dependency allows lesser version of `serializer-pack` to be used in the test without conflict with its underlying packages.