### PR TITLE
[ci] allow panther <2.0 in tests

### DIFF
--- a/tests/Maker/MakeFunctionalTestTest.php
+++ b/tests/Maker/MakeFunctionalTestTest.php
@@ -28,7 +28,8 @@ class MakeFunctionalTestTest extends MakerTestCase
     public function getTestDetails()
     {
         yield 'it_generates_test_with_panther' => [$this->createMakerTest()
-            ->addExtraDependencies('panther')
+            /* @legacy Allows Panther >= 1.x to be installed. (PHP <8.0 support) */
+            ->addExtraDependencies('panther:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-functional/MainController.php',

--- a/tests/Maker/MakeTestTest.php
+++ b/tests/Maker/MakeTestTest.php
@@ -80,7 +80,8 @@ class MakeTestTest extends MakerTestCase
         ];
 
         yield 'it_makes_PantherTestCase_type' => [$this->createMakerTest()
-            ->addExtraDependencies('panther')
+            /* @legacy Allows Panther >= 1.x to be installed. (PHP <8.0 support) */
+            ->addExtraDependencies('panther:*')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-test/basic_setup',


### PR DESCRIPTION
Panther `>= 2.x` only supports PHP >= `8.0`. We still need to use Panther `1.x` for PHP `7.x` tests until PHP 7 support is dropped in MakerBundle 