### PR TITLE
[ci] handle when@test for doctrine

### DIFF
--- a/src/Test/MakerTestRunner.php
+++ b/src/Test/MakerTestRunner.php
@@ -178,10 +178,21 @@ class MakerTestRunner
 
         // Flex includes a recipe to suffix the dbname w/ "_test" - lets keep
         // things simple for these tests and not do that.
-        $this->removeFromFile(
-            'config/packages/test/doctrine.yaml',
-            "dbname_suffix: '_test%env(default::TEST_TOKEN)%'"
-        );
+        $this->modifyYamlFile('config/packages/doctrine.yaml', function (array $config) {
+            if (isset($config['when@test']['doctrine']['dbal']['dbname_suffix'])) {
+                unset($config['when@test']['doctrine']['dbal']['dbname_suffix']);
+            }
+
+            return $config;
+        });
+
+        // @legacy DoctrineBundle 2.4 recipe uses when@test instead of a test/doctrine.yaml config
+        if ($this->filesystem->exists('config/packages/test/doctrine.yaml')) {
+            $this->removeFromFile(
+                'config/packages/test/doctrine.yaml',
+                "dbname_suffix: '_test%env(default::TEST_TOKEN)%'"
+            );
+        }
 
         // this looks silly, but it's the only way to drop the database *for sure*,
         // as doctrine:database:drop will error if there is no database


### PR DESCRIPTION
DoctrineBundle >= 2.4 Flex Recipe uses `when@test` in the `config/packages/doctrine.yaml` file instead of a separate `config/packages/test/doctrine.yaml` file. 

Prior to this PR we were removing the `test/doctrine.yaml` file because we did not want to use the `_test` database suffix in our tests. Now we remove the `dbname_suffix` property if it isset in the test environment. For BC, we still remove the `test/doctrine.yaml` file. 

We could remove then entire `when@test` property from `doctrine.yaml`, but it would probably be best to do this if something changes to the recipe in the future that warrants the removal. (Something may be added that we don't want to remove in the future as well.)