### PR TITLE
Ignore fake file created after running tests and reorder .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /composer.lock
+/fake
 /phpunit.xml
 /vendor/
 /tests/tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
+/.php-cs-fixer.cache
+/.phpunit.result.cache
 /composer.lock
 /fake
 /phpunit.xml
-/vendor/
 /tests/tmp/*
-/.php-cs-fixer.cache
-/tools/*/vendor
 /tools/*/composer.lock
-/.phpunit.result.cache
+/tools/*/vendor
+/vendor/


### PR DESCRIPTION
After running tests the repo is in a dirty state - the `/fake` file is created in the root dir.

Also, I reordered `.gitignore` file here
