### PR TITLE
Copy vendor/ from flex_project/ if it does not exist in maker_app_*/ to fix tests on Mac OS

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -403,6 +403,12 @@ $missingDependencies = array_merge(
 echo json_encode($missingDependencies);
         ');
 
+        // The "git clone" command do not copy vendor/ dir because it's in the .gitignore.
+        // Copy vendor/ dir manually if it does not exist before running "dep_runner.php"
+        // that requires vendor/autoload.php
+        if (!$this->fs->exists($this->path.'/vendor')) {
+            MakerTestProcess::create(sprintf('cp -R %s %s', $this->flexPath.'/vendor', $this->path.'/vendor'), $this->path)->run();
+        }
         $process = MakerTestProcess::create('php dep_runner.php', $this->path)->run();
         $data = json_decode($process->getOutput(), true);
         if (null === $data) {


### PR DESCRIPTION
Somehow, half of the tests still fail on my Mac OS locally, though I see green tests on CI. I was trying to track this down locally and figured out that the final `tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/` dir does not have `vendor/` dir after `git clone` of `tmp/cache/flex_project` which makes sense because `vendor/` is in `.gitignore`. I'm not sure how it works on CI with Linux platform, (probably `vendor/` dir also cloned with `git clone` even though it's gitignored?) but on Mac OS to get tests pass I had to add this `copy -R flex_project/vendor maker_app_*/vendor` to see green tests.

Some debugging below if we do not copy `vendor/`:
```
4) Symfony\Bundle\MakerBundle\Tests\Maker\MakeResetPasswordTest::testExecute with data set "it_generates_with_custom_user" (Symfony\Bundle\MakerBundle\Test\MakerTestDetails Object (...))
Exception: Error running command: "php dep_runner.php". Output: "
Warning: require(/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php): failed to open stream: No such file or directory in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3

Call Stack:
    0.0001     403280   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0


Fatal error: require(): Failed opening required '/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php' (include_path='.:/usr/local/Cellar/php@7.4/7.4.27/share/php@7.4/pear') in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3

Call Stack:
    0.0001     403280   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0

". Error: "PHP Warning:  require(/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php): failed to open stream: No such file or directory in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3
PHP Stack trace:
PHP   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0
PHP Fatal error:  require(): Failed opening required '/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php' (include_path='.:/usr/local/Cellar/php@7.4/7.4.27/share/php@7.4/pear') in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3
PHP Stack trace:
PHP   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0
"

/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestProcess.php:51
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestEnvironment.php:412
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestEnvironment.php:152
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestCase.php:58
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestCase.php:33
```

But with these changes, I have green tests locally on my Mac OS, though they are consuming a lot of time