### PR TITLE
Force adding vendor/ to bypass global .gitignore

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -299,7 +299,8 @@ final class MakerTestEnvironment
 
         file_put_contents($this->flexPath.'/.gitignore', "var/cache/\n");
 
-        MakerTestProcess::create('git init && git config user.name "symfony" && git config user.email "test@symfony.com" && git add . && git commit -a -m "first commit"',
+        // Force adding vendor/ dir to Git repo in case users exclude it in global .gitignore
+        MakerTestProcess::create('git init && git config user.name "symfony" && git config user.email "test@symfony.com" && git add . && git add vendor/ -f && git commit -a -m "first commit"',
             $this->flexPath
         )->run();
     }


### PR DESCRIPTION
If users excluded `vendor/` dir in their global `.gitignore` - it will cause problems with tests, something like this:

```
4) Symfony\Bundle\MakerBundle\Tests\Maker\MakeResetPasswordTest::testExecute with data set "it_generates_with_custom_user" (Symfony\Bundle\MakerBundle\Test\MakerTestDetails Object (...))
Exception: Error running command: "php dep_runner.php". Output: "
Warning: require(/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php): failed to open stream: No such file or directory in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3

Call Stack:
    0.0001     403280   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0


Fatal error: require(): Failed opening required '/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php' (include_path='.:/usr/local/Cellar/php@7.4/7.4.27/share/php@7.4/pear') in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3

Call Stack:
    0.0001     403280   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0

". Error: "PHP Warning:  require(/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php): failed to open stream: No such file or directory in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3
PHP Stack trace:
PHP   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0
PHP Fatal error:  require(): Failed opening required '/Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/vendor/autoload.php' (include_path='.:/usr/local/Cellar/php@7.4/7.4.27/share/php@7.4/pear') in /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php on line 3
PHP Stack trace:
PHP   1. {main}() /Users/victor/www/symfony/maker-bundle/tests/tmp/cache/maker_app_e9d3bad0858931812130f4a985c93519_current/dep_runner.php:0
"

/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestProcess.php:51
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestEnvironment.php:412
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestEnvironment.php:152
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestCase.php:58
/Users/victor/www/symfony/maker-bundle/src/Test/MakerTestCase.php:33
```

Force adding `vendor/` will help to overcome this problem