### PR TITLE
[make:stimulus-controller] New Stimulus controller Maker command

### DIFF
--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -1,0 +1,240 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+/**
+ * @author Abdelilah Jabri <jbrabdelilah@gmail.com>
+ *
+ * @internal
+ */
+final class MakeStimulusController extends AbstractMaker
+{
+    public static function getCommandName(): string
+    {
+        return 'make:stimulus-controller';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new Stimulus controller';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->addArgument('name', InputArgument::REQUIRED, 'The name of the Stimulus controller (e.g. <fg=yellow>hello</>)')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeStimulusController.txt'));
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    {
+        $command->addArgument('extension', InputArgument::OPTIONAL);
+        $command->addArgument('targets', InputArgument::OPTIONAL, '', []);
+        $command->addArgument('values', InputArgument::OPTIONAL, '', []);
+
+        $chosenExtension = $io->choice(
+            'Language (<fg=yellow>JavaScript</> or <fg=yellow>TypeScript</>)',
+            [
+                'js' => 'JavaScript',
+                'ts' => 'TypeScript',
+            ]
+        );
+
+        $input->setArgument('extension', $chosenExtension);
+
+        $includeTargets = $io->confirm('Do you want to include targets?');
+        if ($includeTargets) {
+            $targets = [];
+            $isFirstTarget = true;
+            while (true) {
+                $newTarget = $this->askForNextTarget($io, $targets, $isFirstTarget);
+                $isFirstTarget = false;
+
+                if (null === $newTarget) {
+                    break;
+                }
+
+                $targets[] = $newTarget;
+            }
+
+            $input->setArgument('targets', $targets);
+        }
+
+        $includeValues = $io->confirm('Do you want to include values?');
+        if ($includeValues) {
+            $values = [];
+            $isFirstValue = true;
+            while (true) {
+                $newValue = $this->askForNextValue($io, $values, $isFirstValue);
+                $isFirstValue = false;
+
+                if (null === $newValue) {
+                    break;
+                }
+
+                $values[$newValue['name']] = $newValue;
+            }
+
+            $input->setArgument('values', $values);
+        }
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $controllerName = Str::asSnakeCase($input->getArgument('name'));
+        $chosenExtension = $input->getArgument('extension');
+        $targets = $input->getArgument('targets');
+        $values = $input->getArgument('values');
+
+        $targets = empty($targets) ? $targets : sprintf("['%s']", implode("', '", $targets));
+
+        $fileName = sprintf('%s_controller.%s', $controllerName, $chosenExtension);
+        $filePath = sprintf('assets/controllers/%s', $fileName);
+
+        $generator->generateFile(
+            $filePath,
+            'stimulus/Controller.tpl.php',
+            [
+                'targets' => $targets,
+                'values' => $values,
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next:',
+            sprintf('- Open <info>%s</info> and add the code you need', $filePath),
+            'Find the documentation at <fg=yellow>https://github.com/symfony/stimulus-bridge</>',
+        ]);
+    }
+
+    private function askForNextTarget(ConsoleStyle $io, array $targets, bool $isFirstTarget)
+    {
+        if ($isFirstTarget) {
+            $questionText = 'New target name (press <return> to stop adding targets)';
+        } else {
+            $questionText = 'Add another target? Enter the target name (or press <return> to stop adding targets)';
+        }
+
+        $targetName = $io->ask($questionText, null, function ($name) use ($targets) {
+            if (\in_array($name, $targets)) {
+                throw new \InvalidArgumentException(sprintf('The "%s" target already exists.', $name));
+            }
+
+            return $name;
+        });
+
+        if (!$targetName) {
+            return null;
+        }
+
+        return $targetName;
+    }
+
+    private function askForNextValue(ConsoleStyle $io, array $values, bool $isFirstValue)
+    {
+        if ($isFirstValue) {
+            $questionText = 'New value name (press <return> to stop adding values)';
+        } else {
+            $questionText = 'Add another value? Enter the value name (or press <return> to stop adding values)';
+        }
+
+        $valueName = $io->ask($questionText, null, function ($name) use ($values) {
+            if (\array_key_exists($name, $values)) {
+                throw new \InvalidArgumentException(sprintf('The "%s" value already exists.', $name));
+            }
+
+            return $name;
+        });
+
+        if (!$valueName) {
+            return null;
+        }
+
+        $defaultType = 'String';
+        // try to guess the type by the value name prefix/suffix
+        // convert to snake case for simplicity
+        $snakeCasedField = Str::asSnakeCase($valueName);
+
+        if ('_id' === $suffix = substr($snakeCasedField, -3)) {
+            $defaultType = 'Number';
+        } elseif (0 === strpos($snakeCasedField, 'is_')) {
+            $defaultType = 'Boolean';
+        } elseif (0 === strpos($snakeCasedField, 'has_')) {
+            $defaultType = 'Boolean';
+        }
+
+        $type = null;
+        $types = $this->getValuesTypes();
+        while (null === $type) {
+            $question = new Question('Value type (enter <comment>?</comment> to see all types)', $defaultType);
+            $question->setAutocompleterValues($types);
+            $type = $io->askQuestion($question);
+
+            if ('?' === $type) {
+                $this->printAvailableTypes($io);
+                $io->writeln('');
+
+                $type = null;
+            } elseif (!\in_array($type, $types)) {
+                $this->printAvailableTypes($io);
+                $io->error(sprintf('Invalid type "%s".', $type));
+                $io->writeln('');
+
+                $type = null;
+            }
+        }
+
+        return ['name' => $valueName, 'type' => $type];
+    }
+
+    private function printAvailableTypes(ConsoleStyle $io)
+    {
+        $allTypes = $this->getValuesTypes();
+        foreach ($allTypes as $type) {
+            $io->writeln(sprintf('<info>%s</info>', $type));
+        }
+    }
+
+    private function getValuesTypes(): array
+    {
+        return [
+            'Array',
+            'Boolean',
+            'Number',
+            'Object',
+            'String',
+        ];
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(
+            WebpackEncoreBundle::class,
+            'webpack-encore-bundle'
+        );
+    }
+}

--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -39,14 +39,14 @@ final class MakeStimulusController extends AbstractMaker
         return 'Creates a new Stimulus controller';
     }
 
-    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
             ->addArgument('name', InputArgument::REQUIRED, 'The name of the Stimulus controller (e.g. <fg=yellow>hello</>)')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeStimulusController.txt'));
     }
 
-    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
         $command->addArgument('extension', InputArgument::OPTIONAL);
         $command->addArgument('targets', InputArgument::OPTIONAL, '', []);
@@ -62,10 +62,10 @@ final class MakeStimulusController extends AbstractMaker
 
         $input->setArgument('extension', $chosenExtension);
 
-        $includeTargets = $io->confirm('Do you want to include targets?');
-        if ($includeTargets) {
+        if ($io->confirm('Do you want to include targets?')) {
             $targets = [];
             $isFirstTarget = true;
+
             while (true) {
                 $newTarget = $this->askForNextTarget($io, $targets, $isFirstTarget);
                 $isFirstTarget = false;
@@ -80,8 +80,7 @@ final class MakeStimulusController extends AbstractMaker
             $input->setArgument('targets', $targets);
         }
 
-        $includeValues = $io->confirm('Do you want to include values?');
-        if ($includeValues) {
+        if ($io->confirm('Do you want to include values?')) {
             $values = [];
             $isFirstValue = true;
             while (true) {
@@ -99,7 +98,7 @@ final class MakeStimulusController extends AbstractMaker
         }
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $controllerName = Str::asSnakeCase($input->getArgument('name'));
         $chosenExtension = $input->getArgument('extension');
@@ -131,15 +130,15 @@ final class MakeStimulusController extends AbstractMaker
         ]);
     }
 
-    private function askForNextTarget(ConsoleStyle $io, array $targets, bool $isFirstTarget)
+    private function askForNextTarget(ConsoleStyle $io, array $targets, bool $isFirstTarget): ?string
     {
-        if ($isFirstTarget) {
-            $questionText = 'New target name (press <return> to stop adding targets)';
-        } else {
+        $questionText = 'New target name (press <return> to stop adding targets)';
+
+        if (!$isFirstTarget) {
             $questionText = 'Add another target? Enter the target name (or press <return> to stop adding targets)';
         }
 
-        $targetName = $io->ask($questionText, null, function ($name) use ($targets) {
+        $targetName = $io->ask($questionText, null, function (?string $name) use ($targets) {
             if (\in_array($name, $targets)) {
                 throw new \InvalidArgumentException(sprintf('The "%s" target already exists.', $name));
             }
@@ -147,18 +146,14 @@ final class MakeStimulusController extends AbstractMaker
             return $name;
         });
 
-        if (!$targetName) {
-            return null;
-        }
-
-        return $targetName;
+        return !$targetName ? null : $targetName;
     }
 
-    private function askForNextValue(ConsoleStyle $io, array $values, bool $isFirstValue)
+    private function askForNextValue(ConsoleStyle $io, array $values, bool $isFirstValue): ?array
     {
-        if ($isFirstValue) {
-            $questionText = 'New value name (press <return> to stop adding values)';
-        } else {
+        $questionText = 'New value name (press <return> to stop adding values)';
+
+        if (!$isFirstValue) {
             $questionText = 'Add another value? Enter the value name (or press <return> to stop adding values)';
         }
 
@@ -189,6 +184,7 @@ final class MakeStimulusController extends AbstractMaker
 
         $type = null;
         $types = $this->getValuesTypes();
+
         while (null === $type) {
             $question = new Question('Value type (enter <comment>?</comment> to see all types)', $defaultType);
             $question->setAutocompleterValues($types);
@@ -211,10 +207,9 @@ final class MakeStimulusController extends AbstractMaker
         return ['name' => $valueName, 'type' => $type];
     }
 
-    private function printAvailableTypes(ConsoleStyle $io)
+    private function printAvailableTypes(ConsoleStyle $io): void
     {
-        $allTypes = $this->getValuesTypes();
-        foreach ($allTypes as $type) {
+        foreach ($this->getValuesTypes() as $type) {
             $io->writeln(sprintf('<info>%s</info>', $type));
         }
     }
@@ -230,7 +225,7 @@ final class MakeStimulusController extends AbstractMaker
         ];
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public function configureDependencies(DependencyBuilder $dependencies): void
     {
         $dependencies->addClassDependency(
             WebpackEncoreBundle::class,

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -129,5 +129,9 @@
                 <argument>%kernel.project_dir%</argument>
                 <tag name="maker.command" />
             </service>
+
+            <service id="maker.maker.make_stimulus_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeStimulusController">
+                <tag name="maker.command" />
+            </service>
         </services>
 </container>

--- a/src/Resources/help/MakeStimulusController.txt
+++ b/src/Resources/help/MakeStimulusController.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates new Stimulus Controller.
+
+<info>php %command.full_name% hello</info>
+
+If the argument is missing, the command will ask for the controller name interactively.

--- a/src/Resources/skeleton/stimulus/Controller.tpl.php
+++ b/src/Resources/skeleton/stimulus/Controller.tpl.php
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+* The following line makes this controller "lazy": it won't be downloaded until needed
+* See https://github.com/symfony/stimulus-bridge#lazy-controllers
+*/
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+<?= $targets ? "    static targets = $targets\n" : "" ?>
+<?php if ($values) { ?>
+    static values = {
+<?php foreach ($values as $value): ?>
+        <?= $value['name'] ?>: <?= $value['type'] ?>,
+<?php endforeach; ?>
+    }
+<?php } ?>
+    // ...
+}

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -28,13 +28,13 @@ class MakeStimulusControllerTest extends MakerTestCase
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
-                        'with_targets', //controller name
-                        'js', //controller language
-                        'yes', //add targets
-                        'results', //first target
-                        'messages', //second target
-                        'errors', //third target
-                        '', //empty input to stop adding targets
+                        'with_targets', // controller name
+                        'js', // controller language
+                        'yes', // add targets
+                        'results', // first target
+                        'messages', // second target
+                        'errors', // third target
+                        '', // empty input to stop adding targets
                     ]);
 
                 $generatedFilePath = $runner->getPath('assets/controllers/with_targets_controller.js');
@@ -55,9 +55,9 @@ class MakeStimulusControllerTest extends MakerTestCase
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
-                        'without_targets', //controller name
-                        'js', //controller language
-                        'no', //do not add targets
+                        'without_targets', // controller name
+                        'js', // controller language
+                        'no', // do not add targets
                     ]);
 
                 $generatedFilePath = $runner->getPath('assets/controllers/without_targets_controller.js');
@@ -78,9 +78,9 @@ class MakeStimulusControllerTest extends MakerTestCase
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
-                        'typescript', //controller name
-                        'ts', //controller language
-                        'no', //do not add targets
+                        'typescript', // controller name
+                        'ts', // controller language
+                        'no', // do not add targets
                     ]);
 
                 $this->assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeStimulusController;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+
+class MakeStimulusControllerTest extends MakerTestCase
+{
+    protected function getMakerClass(): string
+    {
+        return MakeStimulusController::class;
+    }
+
+    public function getTestDetails()
+    {
+        yield 'it_generates_stimulus_controller_with_targets' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'with_targets', //controller name
+                        'js', //controller language
+                        'yes', //add targets
+                        'results', //first target
+                        'messages', //second target
+                        'errors', //third target
+                        '', //empty input to stop adding targets
+                    ]);
+
+                $generatedFilePath = $runner->getPath('assets/controllers/with_targets_controller.js');
+
+                $this->assertFileExists($generatedFilePath);
+
+                $generatedFileContents = file_get_contents($generatedFilePath);
+                $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_targets.js');
+
+                $this->assertSame(
+                    $expectedContents,
+                    $generatedFileContents
+                );
+            }),
+        ];
+
+        yield 'it_generates_stimulus_controller_without_targets' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'without_targets', //controller name
+                        'js', //controller language
+                        'no', //do not add targets
+                    ]);
+
+                $generatedFilePath = $runner->getPath('assets/controllers/without_targets_controller.js');
+
+                $this->assertFileExists($generatedFilePath);
+
+                $generatedFileContents = file_get_contents($generatedFilePath);
+                $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/without_targets.js');
+
+                $this->assertSame(
+                    $expectedContents,
+                    $generatedFileContents
+                );
+            }),
+        ];
+
+        yield 'it_generates_typescript_stimulus_controller' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'typescript', //controller name
+                        'ts', //controller language
+                        'no', //do not add targets
+                    ]);
+
+                $this->assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));
+            }),
+        ];
+    }
+}

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -22,7 +22,7 @@ class MakeStimulusControllerTest extends MakerTestCase
         return MakeStimulusController::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_generates_stimulus_controller_with_targets' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {

--- a/tests/fixtures/make-stimulus-controller/with_targets.js
+++ b/tests/fixtures/make-stimulus-controller/with_targets.js
@@ -1,0 +1,11 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+* The following line makes this controller "lazy": it won't be downloaded until needed
+* See https://github.com/symfony/stimulus-bridge#lazy-controllers
+*/
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    static targets = ['results', 'messages', 'errors']
+    // ...
+}

--- a/tests/fixtures/make-stimulus-controller/without_targets.js
+++ b/tests/fixtures/make-stimulus-controller/without_targets.js
@@ -1,0 +1,10 @@
+import { Controller } from '@hotwired/stimulus';
+
+/*
+* The following line makes this controller "lazy": it won't be downloaded until needed
+* See https://github.com/symfony/stimulus-bridge#lazy-controllers
+*/
+/* stimulusFetch: 'lazy' */
+export default class extends Controller {
+    // ...
+}


### PR DESCRIPTION
New Command to generate Stimulus Controller with targets and values.

![Stimulus controller Maker command](https://user-images.githubusercontent.com/42073961/155894537-002fdbaa-76e6-43fe-9016-d4459863f012.png)

**test_controller.js**
```
import { Controller } from '@hotwired/stimulus';

/*
* The following line makes this controller "lazy": it won't be downloaded until needed
* See https://github.com/symfony/stimulus-bridge#lazy-controllers
*/
/* stimulusFetch: 'lazy' */
export default class extends Controller {
    static targets = ['errors']
    static values = {
        maxItems: Number,
    }
    // ...
}
```
Tickets #809
