### PR TITLE
[make:registration-form] Translate reasons for VerifyEmailBundle if translator available

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -50,7 +50,9 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 use Symfony\Component\Security\Http\Authentication\UserAuthenticatorInterface;
+use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents;
 use SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle;
@@ -324,6 +326,10 @@ final class MakeRegistrationForm extends AbstractMaker
             }
         }
 
+        if ($isTranslatorAvailable = class_exists(Translator::class)) {
+            $useStatements[] = TranslatorInterface::class;
+        }
+
         $generator->generateController(
             $controllerClassNameDetails->getFullName(),
             'registration/RegistrationController.tpl.php',
@@ -348,6 +354,7 @@ final class MakeRegistrationForm extends AbstractMaker
                     'password_hasher_class_details' => ($passwordClassDetails = $generator->createClassNameDetails($passwordHasher, '\\')),
                     'password_hasher_variable_name' => str_replace('Interface', '', sprintf('$%s', lcfirst($passwordClassDetails->getShortName()))), // @legacy see passwordHasher conditional above
                     'use_password_hasher' => UserPasswordHasherInterface::class === $passwordHasher, // @legacy see passwordHasher conditional above
+                    'translator_available' => $isTranslatorAvailable,
                 ],
                 $userRepoVars
             )

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -73,7 +73,7 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
 <?php if ($will_verify_email): ?>
 
 <?= $generator->generateRouteForControllerMethod('/verify/email', 'app_verify_email') ?>
-    public function verifyUserEmail(Request $request<?= $verify_email_anonymously ? sprintf(', %s %s', $repository_class_name, $repository_var) : null ?>): Response
+    public function verifyUserEmail(Request $request<?php if ($translator_available): ?>, TranslatorInterface $translator<?php endif ?><?= $verify_email_anonymously ? sprintf(', %s %s', $repository_class_name, $repository_var) : null ?>): Response
     {
 <?php if (!$verify_email_anonymously): ?>
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
@@ -101,7 +101,7 @@ class <?= $class_name; ?> extends <?= $parent_class_name; ?><?= "\n" ?>
         try {
             $this->emailVerifier->handleEmailConfirmation($request, <?= $verify_email_anonymously ? '$user' : '$this->getUser()' ?>);
         } catch (VerifyEmailExceptionInterface $exception) {
-            $this->addFlash('verify_email_error', $exception->getReason());
+            $this->addFlash('verify_email_error', <?php if ($translator_available): ?>$translator->trans($exception->getReason(), [], 'VerifyEmailBundle')<?php else: ?>$exception->getReason()<?php endif ?>);
 
             return $this->redirectToRoute('<?= $route_name ?>');
         }

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -165,6 +165,37 @@ class MakeRegistrationFormTest extends MakerTestCase
                 $this->runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
             }),
         ];
+
+        yield 'it_generates_registration_form_with_verification_and_translator' => [$this->createRegistrationFormTest()
+            ->setRequiredPhpVersion(70200)
+            ->addExtraDependencies('symfonycasts/verify-email-bundle')
+            // needed for internal functional test
+            ->addExtraDependencies('symfony/web-profiler-bundle', 'mailer', 'symfony/translation')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->writeFile(
+                    'config/packages/mailer.yaml',
+                    Yaml::dump(['framework' => [
+                        'mailer' => ['dsn' => 'null://null'],
+                    ]])
+                );
+
+                $this->makeUser($runner);
+
+                $output = $runner->runMaker([
+                    'n', // add UniqueEntity
+                    'y', // verify user
+                    'y', // require authentication to verify user email
+                    'victor@symfonycasts.com', // from email address
+                    'SymfonyCasts', // From Name
+                    'n', // no authenticate after
+                    0, // route number to redirect to
+                ]);
+
+                $this->assertStringContainsString('Success', $output);
+
+                $this->runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
+            }),
+        ];
     }
 
     private function makeUser(MakerTestRunner $runner, string $identifier = 'email')


### PR DESCRIPTION
Exception reasons were translated in https://github.com/SymfonyCasts/verify-email-bundle/pull/103 that allows us to translate them with Maker bundle out of the box if Translator is available.

This PR is similar to #1059 but for VerifyEmailBundle
