### PR TITLE
[ci] fix overriding entire route config

### DIFF
--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -33,6 +33,24 @@ class MakeRegistrationFormTest extends MakerTestCase
                     ''
                 );
                 $runner->adjustAuthenticatorForLegacyPassportInterface('src/Security/StubAuthenticator.php');
+
+                if (60000 > $runner->getSymfonyVersion()) {
+                    /*
+                     * @Legacy - Drop when Symfony 6.0 is LTS
+                     *
+                     * This is a round about way to handle empty yaml files and YamlSourceManipulator.
+                     * Prior to Symfony 6.0, the routes.yaml was empty w/ a comment line. YSM
+                     * requires a top level array structure to manipulate them.
+                     */
+                    $runner->writeFile('config/routes.yaml', 'app_homepage:');
+                }
+
+                $runner->modifyYamlFile('config/routes.yaml', function (array $yaml) {
+                    $yaml['app_homepage'] = ['path' => '/', 'controller' => 'App\Controller\TestingController::homepage'];
+                    $yaml['app_anonymous'] = ['path' => '/anonymous', 'controller' => 'App\Controller\TestingController::anonymous'];
+
+                    return $yaml;
+                });
             })
         ;
     }

--- a/tests/fixtures/make-registration-form/standard_setup/config/routes.yaml
+++ b/tests/fixtures/make-registration-form/standard_setup/config/routes.yaml
@@ -1,7 +1,0 @@
-app_homepage:
-    path: /
-    controller: App\Controller\TestingController::homepage
-
-app_anonymous:
-    path: /anonymous
-    controller: App\Controller\TestingController::anonymous


### PR DESCRIPTION
Previously we were replacing the `config/routes.yaml` file generated by recipes with our own. This broke several tests when https://github.com/symfony/recipes/issues/1030 was resolved in Symfony 6. 

To better test against a "real" environment, we use the generated `routes.yaml` file and then append our static routes to it.