### PR TITLE
[ci] use composer 2.2 for Symfony 4.4 compat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,11 +132,11 @@ jobs:
                   mysql --host 127.0.0.1 --port 3306 -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test_maker;"
 
             - name: "Install PHP with extensions"
-              uses: shivammathur/setup-php@2.7.0
+              uses: shivammathur/setup-php@v2
               with:
                   coverage: "none"
                   php-version: ${{ matrix.php-version }}
-                  tools: composer:v2
+                  tools: composer:2.2
 
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
use the latest version of `setup-php` && force composer `v2.2` for Symfony 4.4 / PHP 7.1 support. The latter to be reverted in the future.