### PR TITLE
Lower symfony/finder & symfony/yaml requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/dependency-injection": "^5.4.7|^6.0",
         "symfony/deprecation-contracts": "^2.2|^3",
         "symfony/filesystem": "^5.4.7|^6.0",
-        "symfony/finder": "^5.4.7|^6.0",
+        "symfony/finder": "^5.4.3|^6.0",
         "symfony/framework-bundle": "^5.4.7|^6.0",
         "symfony/http-kernel": "^5.4.7|^6.0"
     },
@@ -34,7 +34,7 @@
         "symfony/polyfill-php80": "^1.16.0",
         "symfony/process": "^5.4.7|^6.0",
         "symfony/security-core": "^5.4.7|^6.0",
-        "symfony/yaml": "^5.4.7|^6.0",
+        "symfony/yaml": "^5.4.3|^6.0",
         "twig/twig": "^2.0|^3.0"
     },
     "config": {


### PR DESCRIPTION
Because 5.4.7 simply doesn't exist for those packages, as Symfony no longer tags the packages when no changes have occured.