### PR TITLE
[make:test] Removal of the condition requiring a php version < 8.1

### DIFF
--- a/src/Maker/MakeTest.php
+++ b/src/Maker/MakeTest.php
@@ -149,7 +149,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
             [
                 'web_assertions_are_available' => trait_exists(WebTestAssertionsTrait::class),
                 'use_legacy_container_property' => $this->useLegacyContainerProperty(),
-                'api_test_case_fqcn' => \PHP_VERSION_ID < 80100 && !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
+                'api_test_case_fqcn' => !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
             ]
         );
 
@@ -188,7 +188,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
 
             case 'ApiTestCase':
                 $dependencies->addClassDependency(
-                    \PHP_VERSION_ID < 80100 && !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
+                    !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
                     'api',
                     true,
                     false


### PR DESCRIPTION
Fixes #1092 

Here I do not see why we must have a version of php < 8.1 . This is what was causing the problem it seems to me, the condition passed in the else, so users with a version of php > 8.1 and API platform 2.6 had the wrong class path (`ApiPlatform\Symfony\Bundle\Test\ApiTestCase`).

I think here we just need to know whether the class exists or not. Future versions of API platform will warn about deprecation of this wrong class path `ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase` from version 2.7 and become invalid in 3.0, as shown [here ](https://github.com/symfony/maker-bundle/pull/1015).