### PR TITLE
adding repository counts for crud testRemove 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /tools/*/composer.lock
 /tools/*/vendor
 /vendor/
+/.idea/

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -100,6 +100,9 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
     public function testRemove(): void
     {
         $this->markTestIncomplete();
+
+        $originalNumObjectsInRepository = count($this->repository->findAll());
+
         $fixture = new <?= $entity_class_name; ?>();
 <?php foreach ($form_fields as $form_field => $typeOptions): ?>
         $fixture->set<?= ucfirst($form_field); ?>('My Title');
@@ -107,10 +110,13 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 
         $this->repository->add($fixture, true);
 
+        $this->assertSame($originalNumObjectsInRepository + 1, count($this->repository->findAll()));
+
         $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
         $this->client->submitForm('Delete');
 
+        self::assertSame($originalNumObjectsInRepository, count($this->repository->findAll()));
+
         self::assertResponseRedirects('<?= $route_path; ?>/');
-        self::assertSame(0, $this->repository->count([]));
     }
 }


### PR DESCRIPTION
suggested asserts for the testRemove() method of the crud generated tests

- count repository objects
- add a new object
- assert repository objects count is 1 more than originally
- remove via CRUD form Delete
- assert repository count has returned to original number