### PR TITLE
[make:controller] Return a JsonResponse instead of a Response with --no-template

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -25,6 +25,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Annotation\Route;
@@ -73,13 +74,14 @@ final class MakeController extends AbstractMaker
             'Controller'
         );
 
+        $withTemplate = $this->isTwigInstalled() && !$input->getOption('no-template');
+
         $useStatements = new UseStatementGenerator([
             AbstractController::class,
-            Response::class,
+            $withTemplate ? Response::class : JsonResponse::class,
             Route::class,
         ]);
 
-        $noTemplate = $input->getOption('no-template');
         $templateName = Str::asFilePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()).'/index.html.twig';
         $controllerPath = $generator->generateController(
             $controllerClassNameDetails->getFullName(),
@@ -88,12 +90,12 @@ final class MakeController extends AbstractMaker
                 'use_statements' => $useStatements,
                 'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
                 'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'with_template' => $this->isTwigInstalled() && !$noTemplate,
+                'with_template' => $withTemplate,
                 'template_name' => $templateName,
             ]
         );
 
-        if ($this->isTwigInstalled() && !$noTemplate) {
+        if ($withTemplate) {
             $generator->generateTemplate(
                 $templateName,
                 'controller/twig_template.tpl.php',

--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -7,7 +7,8 @@ namespace <?= $namespace; ?>;
 class <?= $class_name; ?> extends AbstractController
 {
 <?= $generator->generateRouteForControllerMethod($route_path, $route_name); ?>
-    public function index(): Response
+    public function index(): <?php if ($with_template) { ?>Response<?php } else { ?>JsonResponse<?php } ?>
+
     {
 <?php if ($with_template) { ?>
         return $this->render('<?= $template_name ?>', [

--- a/tests/fixtures/make-controller/tests/it_generates_a_controller.php
+++ b/tests/fixtures/make-controller/tests/it_generates_a_controller.php
@@ -12,5 +12,7 @@ class GeneratedControllerTest extends WebTestCase
         $client->request('GET', '/foo/bar');
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('{"message":"Welcome to your new controller!","path":"src\/Controller\/FooBarController.php"}', $client->getResponse()->getContent());
     }
 }


### PR DESCRIPTION
Return a JsonResponse instead of a Response when json method is used in controller.

Failing tests not related, see #1118 for a fix