### PR TITLE
update php-cs-fixer ruleset for php8

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,8 @@ $finder = (new PhpCsFixer\Finder())
 
 return (new PhpCsFixer\Config())
     ->setRules(array(
-        '@PHPUnit75Migration:risky' => true,
+        '@PHP80Migration' => true,
+        '@PHPUnit84Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'header_comment' => [
@@ -30,6 +31,12 @@ EOF
         ],
         'protected_to_private' => false,
         'semicolon_after_instruction' => false,
+        'trailing_comma_in_multiline' => [
+            'elements' => [
+                'arrays',
+                'parameters'
+            ],
+        ]
     ))
     ->setRiskyAllowed(true)
     ->setFinder($finder)

--- a/src/Doctrine/EntityDetails.php
+++ b/src/Doctrine/EntityDetails.php
@@ -22,7 +22,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 final class EntityDetails
 {
     public function __construct(
-        private ClassMetadata|LegacyClassMetadata $metadata
+        private ClassMetadata|LegacyClassMetadata $metadata,
     ) {
     }
 

--- a/src/Doctrine/EntityRegenerator.php
+++ b/src/Doctrine/EntityRegenerator.php
@@ -30,7 +30,7 @@ final class EntityRegenerator
         private FileManager $fileManager,
         private Generator $generator,
         private EntityClassGenerator $entityClassGenerator,
-        private bool $overwrite
+        private bool $overwrite,
     ) {
     }
 
@@ -92,7 +92,7 @@ final class EntityRegenerator
             foreach ($classMetadata->fieldMappings as $fieldName => $mapping) {
                 // skip embedded fields
                 if (false !== strpos($fieldName, '.')) {
-                    list($fieldName, $embeddedFiledName) = explode('.', $fieldName);
+                    [$fieldName, $embeddedFiledName] = explode('.', $fieldName);
 
                     $operations[$embeddedClasses[$fieldName]]->addEntityField($embeddedFiledName, $mapping);
 

--- a/src/Doctrine/EntityRelation.php
+++ b/src/Doctrine/EntityRelation.php
@@ -31,7 +31,7 @@ final class EntityRelation
     public function __construct(
         private string $type,
         private string $owningClass,
-        private string $inverseClass
+        private string $inverseClass,
     ) {
         if (!\in_array($type, self::getValidRelationTypes())) {
             throw new \Exception(sprintf('Invalid relation type "%s"', $type));

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -38,7 +38,7 @@ class FileManager
         AutoloaderUtil $autoloaderUtil,
         MakerFileLinkFormatter $makerFileLinkFormatter,
         string $rootDirectory,
-        string $twigDefaultPath = null
+        string $twigDefaultPath = null,
     ) {
         // move FileManagerTest stuff
         // update EntityRegeneratorTest to mock the autoloader

--- a/src/GeneratorTwigHelper.php
+++ b/src/GeneratorTwigHelper.php
@@ -68,19 +68,19 @@ final class GeneratorTwigHelper
     {
         if ($this->fileManager->fileExists($this->fileManager->getPathForTemplate('base.html.twig'))) {
             return <<<TWIG
-{% extends 'base.html.twig' %}
+                {% extends 'base.html.twig' %}
 
-{% block title %}$title{% endblock %}
+                {% block title %}$title{% endblock %}
 
-TWIG;
+                TWIG;
         }
 
         return <<<HTML
-<!DOCTYPE html>
+            <!DOCTYPE html>
 
-<title>$title</title>
+            <title>$title</title>
 
-HTML;
+            HTML;
     }
 
     public function getFileLink($path, $text = null, $line = 0): string

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -70,7 +70,7 @@ final class MakeAuthenticator extends AbstractMaker
         private SecurityConfigUpdater $configUpdater,
         private Generator $generator,
         private DoctrineHelper $doctrineHelper,
-        private SecurityControllerBuilder $securityControllerBuilder
+        private SecurityControllerBuilder $securityControllerBuilder,
     ) {
     }
 

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -55,7 +55,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         string $projectDirectory = null,
         Generator $generator = null,
         EntityClassGenerator $entityClassGenerator = null,
-        PhpCompatUtil $phpCompatUtil = null
+        PhpCompatUtil $phpCompatUtil = null,
     ) {
         if (null !== $projectDirectory) {
             @trigger_error('The $projectDirectory constructor argument is no longer used since 1.41.0', \E_USER_DEPRECATED);

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -86,7 +86,7 @@ final class MakeRegistrationForm extends AbstractMaker
         private FileManager $fileManager,
         private FormTypeRenderer $formTypeRenderer,
         private RouterInterface $router,
-        private DoctrineHelper $doctrineHelper
+        private DoctrineHelper $doctrineHelper,
     ) {
     }
 
@@ -537,33 +537,33 @@ final class MakeRegistrationForm extends AbstractMaker
             'agreeTerms' => [
                 'type' => CheckboxType::class,
                 'options_code' => <<<EOF
-                'mapped' => false,
-                'constraints' => [
-                    new IsTrue([
-                        'message' => 'You should agree to our terms.',
-                    ]),
-                ],
-EOF
+                                    'mapped' => false,
+                                    'constraints' => [
+                                        new IsTrue([
+                                            'message' => 'You should agree to our terms.',
+                                        ]),
+                                    ],
+                    EOF
             ],
             'plainPassword' => [
                 'type' => PasswordType::class,
                 'options_code' => <<<EOF
-                // instead of being set onto the object directly,
-                // this is read and encoded in the controller
-                'mapped' => false,
-                'attr' => ['autocomplete' => 'new-password'],
-                'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter a password',
-                    ]),
-                    new Length([
-                        'min' => 6,
-                        'minMessage' => 'Your password should be at least {{ limit }} characters',
-                        // max length allowed by Symfony for security reasons
-                        'max' => 4096,
-                    ]),
-                ],
-EOF
+                                    // instead of being set onto the object directly,
+                                    // this is read and encoded in the controller
+                                    'mapped' => false,
+                                    'attr' => ['autocomplete' => 'new-password'],
+                                    'constraints' => [
+                                        new NotBlank([
+                                            'message' => 'Please enter a password',
+                                        ]),
+                                        new Length([
+                                            'min' => 6,
+                                            'minMessage' => 'Your password should be at least {{ limit }} characters',
+                                            // max length allowed by Symfony for security reasons
+                                            'max' => 4096,
+                                        ]),
+                                    ],
+                    EOF
             ],
         ];
 

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -88,7 +88,7 @@ class MakeResetPassword extends AbstractMaker
     public function __construct(
         private FileManager $fileManager,
         private DoctrineHelper $doctrineHelper,
-        private EntityClassGenerator $entityClassGenerator
+        private EntityClassGenerator $entityClassGenerator,
     ) {
     }
 
@@ -421,10 +421,10 @@ class MakeResetPassword extends AbstractMaker
             (new Param('selector'))->setType('string')->getNode(),
             (new Param('hashedToken'))->setType('string')->getNode(),
         ], <<<'CODE'
-<?php
-$this->user = $user;
-$this->initialize($expiresAt, $selector, $hashedToken);
-CODE
+            <?php
+            $this->user = $user;
+            $this->initialize($expiresAt, $selector, $hashedToken);
+            CODE
         );
 
         $manipulator->addManyToOneRelation((new RelationManyToOne())
@@ -466,9 +466,9 @@ CODE
             (new Param('selector'))->setType('string')->getNode(),
             (new Param('hashedToken'))->setType('string')->getNode(),
         ], <<<'CODE'
-<?php
-return new ResetPasswordRequest($user, $expiresAt, $selector, $hashedToken);
-CODE
+            <?php
+            return new ResetPasswordRequest($user, $expiresAt, $selector, $hashedToken);
+            CODE
         );
 
         $this->fileManager->dumpFile($pathRequestRepository, $manipulator->getSourceCode());

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -53,7 +53,7 @@ final class MakeUser extends AbstractMaker
         private UserClassBuilder $userClassBuilder,
         private SecurityConfigUpdater $configUpdater,
         private EntityClassGenerator $entityClassGenerator,
-        private DoctrineHelper $doctrineHelper
+        private DoctrineHelper $doctrineHelper,
     ) {
     }
 

--- a/src/Renderer/FormTypeRenderer.php
+++ b/src/Renderer/FormTypeRenderer.php
@@ -36,7 +36,7 @@ final class FormTypeRenderer
         $fieldTypeUseStatements = [];
         $fields = [];
         foreach ($formFields as $name => $fieldTypeOptions) {
-            $fieldTypeOptions = $fieldTypeOptions ?? ['type' => null, 'options_code' => null];
+            $fieldTypeOptions ??= ['type' => null, 'options_code' => null];
 
             if (isset($fieldTypeOptions['type'])) {
                 $fieldTypeUseStatements[] = $fieldTypeOptions['type'];

--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -26,7 +26,7 @@ final class SecurityConfigUpdater
     private ?YamlSourceManipulator $manipulator;
 
     public function __construct(
-        private ?Logger $ysmLogger = null
+        private ?Logger $ysmLogger = null,
     ) {
     }
 

--- a/src/Security/SecurityControllerBuilder.php
+++ b/src/Security/SecurityControllerBuilder.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 final class SecurityControllerBuilder
 {
     public function __construct(
-        private PhpCompatUtil $phpCompatUtil
+        private PhpCompatUtil $phpCompatUtil,
     ) {
     }
 
@@ -42,32 +42,32 @@ final class SecurityControllerBuilder
         );
 
         $manipulator->addMethodBody($loginMethodBuilder, <<<'CODE'
-<?php
-// if ($this->getUser()) {
-//     return $this->redirectToRoute('target_path');
-// }
-CODE
+            <?php
+            // if ($this->getUser()) {
+            //     return $this->redirectToRoute('target_path');
+            // }
+            CODE
         );
         $loginMethodBuilder->addStmt($manipulator->createMethodLevelBlankLine());
         $manipulator->addMethodBody($loginMethodBuilder, <<<'CODE'
-<?php
-// get the login error if there is one
-$error = $authenticationUtils->getLastAuthenticationError();
-// last username entered by the user
-$lastUsername = $authenticationUtils->getLastUsername();
-CODE
+            <?php
+            // get the login error if there is one
+            $error = $authenticationUtils->getLastAuthenticationError();
+            // last username entered by the user
+            $lastUsername = $authenticationUtils->getLastUsername();
+            CODE
         );
         $loginMethodBuilder->addStmt($manipulator->createMethodLevelBlankLine());
         $manipulator->addMethodBody($loginMethodBuilder, <<<'CODE'
-<?php
-return $this->render(
-    'security/login.html.twig',
-    [
-        'last_username' => $lastUsername,
-        'error' => $error,
-    ]
-);
-CODE
+            <?php
+            return $this->render(
+                'security/login.html.twig',
+                [
+                    'last_username' => $lastUsername,
+                    'error' => $error,
+                ]
+            );
+            CODE
         );
         $manipulator->addMethodBuilder($loginMethodBuilder);
     }
@@ -80,9 +80,9 @@ CODE
 
         $manipulator->addUseStatementIfNecessary(Route::class);
         $manipulator->addMethodBody($logoutMethodBuilder, <<<'CODE'
-<?php
-throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
-CODE
+            <?php
+            throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
+            CODE
         );
         $manipulator->addMethodBuilder($logoutMethodBuilder);
     }

--- a/src/Test/MakerTestCase.php
+++ b/src/Test/MakerTestCase.php
@@ -106,7 +106,7 @@ abstract class MakerTestCase extends TestCase
         }
 
         // a cheap way to guess the service id
-        $serviceId = $serviceId ?? sprintf('maker.maker.%s', Str::asSnakeCase((new \ReflectionClass($makerClass))->getShortName()));
+        $serviceId ??= sprintf('maker.maker.%s', Str::asSnakeCase((new \ReflectionClass($makerClass))->getShortName()));
 
         return $this->kernel->getContainer()->get($serviceId);
     }

--- a/src/Util/AutoloaderUtil.php
+++ b/src/Util/AutoloaderUtil.php
@@ -21,7 +21,7 @@ use Composer\Autoload\ClassLoader;
 class AutoloaderUtil
 {
     public function __construct(
-        private ComposerAutoloaderFinder $autoloaderFinder
+        private ComposerAutoloaderFinder $autoloaderFinder,
     ) {
     }
 

--- a/src/Util/ClassDetails.php
+++ b/src/Util/ClassDetails.php
@@ -17,7 +17,7 @@ namespace Symfony\Bundle\MakerBundle\Util;
 final class ClassDetails
 {
     public function __construct(
-        private string $fullClassName
+        private string $fullClassName,
     ) {
     }
 

--- a/src/Util/ClassNameDetails.php
+++ b/src/Util/ClassNameDetails.php
@@ -18,7 +18,7 @@ final class ClassNameDetails
     public function __construct(
         private string $fullClassName,
         private string $namespacePrefix,
-        private ?string $suffix = null
+        private ?string $suffix = null,
     ) {
         $this->namespacePrefix = trim($namespacePrefix, '\\');
     }

--- a/src/Util/ClassNameValue.php
+++ b/src/Util/ClassNameValue.php
@@ -20,7 +20,7 @@ final class ClassNameValue
 {
     public function __construct(
         private string $typeHint,
-        private string $fullClassName
+        private string $fullClassName,
     ) {
     }
 

--- a/src/Util/UseStatementGenerator.php
+++ b/src/Util/UseStatementGenerator.php
@@ -29,7 +29,7 @@ final class UseStatementGenerator implements \Stringable
      * @param string[]|array<string, string> $classesToBeImported
      */
     public function __construct(
-        private array $classesToBeImported
+        private array $classesToBeImported,
     ) {
     }
 

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -49,7 +49,7 @@ class YamlSourceManipulator
     private $arrayTypeForDepths = [];
 
     public function __construct(
-        private string $contents
+        private string $contents,
     ) {
         $this->currentData = Yaml::parse($contents);
 
@@ -966,7 +966,7 @@ class YamlSourceManipulator
         }
 
         $context = [
-            'key' => isset($this->currentPath[$this->depth]) ? $this->currentPath[$this->depth] : 'n/a',
+            'key' => $this->currentPath[$this->depth] ?? 'n/a',
             'depth' => $this->depth,
             'position' => $this->currentPosition,
             'indentation' => $this->indentationForDepths[$this->depth],

--- a/tests/DependencyBuilderTest.php
+++ b/tests/DependencyBuilderTest.php
@@ -98,30 +98,30 @@ class DependencyBuilderTest extends TestCase
             ['bar-package'],
             [],
             <<<EOF
-Missing package: to use the make:something command, run:
+                Missing package: to use the make:something command, run:
 
-composer require bar-package
-EOF
+                composer require bar-package
+                EOF
         ];
 
         yield 'missing_multiple_packages' => [
             ['bar-package', 'other-package'],
             [],
             <<<EOF
-Missing packages: to use the make:something command, run:
+                Missing packages: to use the make:something command, run:
 
-composer require bar-package other-package
-EOF
+                composer require bar-package other-package
+                EOF
         ];
 
         yield 'missing_dev_packages' => [
             [],
             ['bar-package', 'other-package'],
             <<<EOF
-Missing packages: to use the make:something command, run:
+                Missing packages: to use the make:something command, run:
 
-composer require bar-package other-package --dev
-EOF
+                composer require bar-package other-package --dev
+                EOF
         ];
     }
 }

--- a/tests/Maker/MakeMessageTest.php
+++ b/tests/Maker/MakeMessageTest.php
@@ -109,12 +109,12 @@ class MakeMessageTest extends MakerTestCase
         $runner->writeFile(
             'config/packages/messenger.yaml',
             <<<EOF
-framework:
-    messenger:
-        transports:
-            async: 'sync://'
-            async_high_priority: 'sync://'
-EOF
+                framework:
+                    messenger:
+                        transports:
+                            async: 'sync://'
+                            async_high_priority: 'sync://'
+                EOF
         );
     }
 }

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -758,9 +758,9 @@ class ClassSourceManipulatorTest extends TestCase
             [
                 (new Param('someParam'))->setType('string')->getNode(),
             ], <<<'CODE'
-<?php
-$this->someParam = $someParam;
-CODE
+                <?php
+                $this->someParam = $someParam;
+                CODE
 );
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -779,9 +779,9 @@ CODE
         );
         $manipulator->addMethodBody($methodBuilder,
 <<<'CODE'
-<?php
-return new JsonResponse(['param' => $param]);
-CODE
+    <?php
+    return new JsonResponse(['param' => $param]);
+    CODE
         );
         $manipulator->addMethodBuilder($methodBuilder);
         $manipulator->addUseStatementIfNecessary('Symfony\\Component\\HttpFoundation\\JsonResponse');
@@ -807,118 +807,118 @@ CODE
     {
         yield 'no_doc_block' => [
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-class Foo
-{
-}
-EOF
+    class Foo
+    {
+    }
+    EOF
 ,
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-use Bar\SomeAnnotation;
+    use Bar\SomeAnnotation;
 
-/**
- * @SomeAnnotation(message="Foo")
- */
-class Foo
-{
-}
-EOF
+    /**
+     * @SomeAnnotation(message="Foo")
+     */
+    class Foo
+    {
+    }
+    EOF
 ];
 
         yield 'normal_doc_block' => [
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-/**
- * I'm a class!
- */
-class Foo
-{
-}
-EOF
+    /**
+     * I'm a class!
+     */
+    class Foo
+    {
+    }
+    EOF
 ,
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-use Bar\SomeAnnotation;
+    use Bar\SomeAnnotation;
 
-/**
- * I'm a class!
- * @SomeAnnotation(message="Foo")
- */
-class Foo
-{
-}
-EOF
+    /**
+     * I'm a class!
+     * @SomeAnnotation(message="Foo")
+     */
+    class Foo
+    {
+    }
+    EOF
 ];
 
         yield 'simple_inline_doc_block' => [
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-/** I'm a class! */
-class Foo
-{
-}
-EOF
+    /** I'm a class! */
+    class Foo
+    {
+    }
+    EOF
 ,
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-use Bar\SomeAnnotation;
+    use Bar\SomeAnnotation;
 
-/**
- * I'm a class!
- * @SomeAnnotation(message="Foo")
- */
-class Foo
-{
-}
-EOF
+    /**
+     * I'm a class!
+     * @SomeAnnotation(message="Foo")
+     */
+    class Foo
+    {
+    }
+    EOF
         ];
 
         yield 'weird_inline_doc_block' => [
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-/** **I'm a class!** ***/
-class Foo
-{
-}
-EOF
+    /** **I'm a class!** ***/
+    class Foo
+    {
+    }
+    EOF
 ,
 <<<EOF
-<?php
+    <?php
 
-namespace Acme;
+    namespace Acme;
 
-use Bar\SomeAnnotation;
+    use Bar\SomeAnnotation;
 
-/**
- * **I'm a class!**
- * @SomeAnnotation(message="Foo")
- ***/
-class Foo
-{
-}
-EOF
+    /**
+     * **I'm a class!**
+     * @SomeAnnotation(message="Foo")
+     ***/
+    class Foo
+    {
+    }
+    EOF
 ];
     }
 
@@ -993,10 +993,10 @@ EOF
                 (new Param('someObjectParam'))->setType('object')->getNode(),
                 (new Param('someStringParam'))->setType('string')->getNode(),
                 ], <<<'CODE'
-<?php
-$this->someObjectParam = $someObjectParam;
-$this->someMethod($someStringParam);
-CODE
+                    <?php
+                    $this->someObjectParam = $someObjectParam;
+                    $this->someMethod($someStringParam);
+                    CODE
         );
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -1013,10 +1013,10 @@ CODE
             (new Param('someObjectParam'))->setType('object')->getNode(),
             (new Param('someStringParam'))->setType('string')->getNode(),
         ], <<<'CODE'
-<?php
-$this->someObjectParam = $someObjectParam;
-$this->someMethod($someStringParam);
-CODE
+            <?php
+            $this->someObjectParam = $someObjectParam;
+            $this->someMethod($someStringParam);
+            CODE
         );
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -1033,10 +1033,10 @@ CODE
             (new Param('someObjectParam'))->setType('object')->getNode(),
             (new Param('someStringParam'))->setType('string')->getNode(),
         ], <<<'CODE'
-<?php
-$this->someObjectParam = $someObjectParam;
-$this->someMethod($someStringParam);
-CODE
+            <?php
+            $this->someObjectParam = $someObjectParam;
+            $this->someMethod($someStringParam);
+            CODE
         );
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
@@ -1055,10 +1055,10 @@ CODE
             (new Param('someObjectParam'))->setType('object')->getNode(),
             (new Param('someStringParam'))->setType('string')->getNode(),
         ], <<<'CODE'
-<?php
-$this->someObjectParam = $someObjectParam;
-$this->someMethod($someStringParam);
-CODE
+            <?php
+            $this->someObjectParam = $someObjectParam;
+            $this->someMethod($someStringParam);
+            CODE
         );
     }
 }

--- a/tests/Util/ComposeFileManipulatorTest.php
+++ b/tests/Util/ComposeFileManipulatorTest.php
@@ -40,10 +40,10 @@ class ComposeFileManipulatorTest extends TestCase
     public function testServiceExists(): void
     {
         $composeFile = <<< 'EOT'
-version: '3.7'
-services:
-    database:
-EOT;
+            version: '3.7'
+            services:
+                database:
+            EOT;
         $manipulator = new ComposeFileManipulator($composeFile);
 
         self::assertTrue($manipulator->serviceExists('database'));
@@ -70,11 +70,11 @@ EOT;
     public function testRemoveDockerService(): void
     {
         $composeFile = <<< 'EOT'
-version: '3.7'
-services:
-    database:
-    rabbitmq:
-EOT;
+            version: '3.7'
+            services:
+                database:
+                rabbitmq:
+            EOT;
         $manipulator = new ComposeFileManipulator($composeFile);
         $manipulator->removeDockerService('rabbitmq');
 
@@ -91,11 +91,11 @@ EOT;
     public function testExposePorts(): void
     {
         $composeFile = <<< 'EOT'
-version: '3.7'
-services:
-    rabbitmq:
-        am: 'I next?'
-EOT;
+            version: '3.7'
+            services:
+                rabbitmq:
+                    am: 'I next?'
+            EOT;
         $manipulator = new ComposeFileManipulator($composeFile);
         $manipulator->exposePorts('rabbitmq', ['15672']);
 
@@ -117,11 +117,11 @@ EOT;
     public function testAddVolume(): void
     {
         $composeFile = <<< 'EOT'
-version: '3.7'
-services:
-    php:
-        yes: 'this looks fun'
-EOT;
+            version: '3.7'
+            services:
+                php:
+                    yes: 'this looks fun'
+            EOT;
 
         $manipulator = new ComposeFileManipulator($composeFile);
         $manipulator->addVolume('php', '/var/htdocs', '/var');
@@ -154,9 +154,9 @@ EOT;
     public function testCheckComposeFileVersionThrowsExceptionWithMissingVersion(): void
     {
         $composeFile = <<< 'EOT'
-services:
-    []
-EOT;
+            services:
+                []
+            EOT;
         $this->expectException(RuntimeCommandException::class);
         $this->expectExceptionMessage('docker-compose.yaml file version is not set.');
 

--- a/tests/Util/UseStatementGeneratorTest.php
+++ b/tests/Util/UseStatementGeneratorTest.php
@@ -30,12 +30,12 @@ class UseStatementGeneratorTest extends TestCase
         ]);
 
         $expected = <<< 'EOT'
-use App\Controller\SomeController;
-use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
-use Symfony\Bundle\MakerBundle\Util\Sorter;
-use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper;
+            use App\Controller\SomeController;
+            use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+            use Symfony\Bundle\MakerBundle\Util\Sorter;
+            use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper;
 
-EOT;
+            EOT;
         self::assertSame($expected, (string) $unsorted);
     }
 
@@ -57,20 +57,20 @@ EOT;
         ]);
 
         $expected = <<< 'EOT'
-use App\Entity\User;
-use App\Form\RegistrationFormType;
-use App\Security\EmailVerifier;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bridge\Twig\Mime\TemplatedEmail;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Mime\Address;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
+            use App\Entity\User;
+            use App\Form\RegistrationFormType;
+            use App\Security\EmailVerifier;
+            use Doctrine\ORM\EntityManagerInterface;
+            use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+            use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+            use Symfony\Component\HttpFoundation\Request;
+            use Symfony\Component\HttpFoundation\Response;
+            use Symfony\Component\Mime\Address;
+            use Symfony\Component\Routing\Annotation\Route;
+            use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+            use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
 
-EOT;
+            EOT;
         self::assertSame($expected, (string) $unsorted);
     }
 
@@ -83,11 +83,11 @@ EOT;
         ]);
 
         $expected = <<< 'EOT'
-use ApiPlatform\Core\Annotation\ApiResource;
-use Doctrine\ORM\Mapping as ORM;
-use Symfony\UX\Turbo\Attribute\Broadcast;
+            use ApiPlatform\Core\Annotation\ApiResource;
+            use Doctrine\ORM\Mapping as ORM;
+            use Symfony\UX\Turbo\Attribute\Broadcast;
 
-EOT;
+            EOT;
         self::assertSame($expected, (string) $unsorted);
     }
 }

--- a/tests/Util/YamlSourceManipulatorTest.php
+++ b/tests/Util/YamlSourceManipulatorTest.php
@@ -56,7 +56,7 @@ class YamlSourceManipulatorTest extends TestCase
             ->name('*.test');
 
         foreach ($finder as $file) {
-            list($source, $changeCode, $expected) = explode('===', $file->getContents());
+            [$source, $changeCode, $expected] = explode('===', $file->getContents());
 
             // Multiline string ends with an \n
             $source = substr_replace($source, '', (\strlen($source) - 1));


### PR DESCRIPTION
- adds the PHP 8 && PHPUnit 8.4 migration rulesets

- forces trailing commas in multiline parameter lists to improve diff readability. e.g.
```php
public function __construct(
    private int $number,
    private string $word,
)
```


I also added trailing line commas in multiline _argument_ lists and then reverted the commit. See commit https://github.com/symfony/maker-bundle/pull/1127/commits/352f951250cd7fda3c63996c8839cb8778e66e7a

If this we _should_ keep multiline trailing commas for args - I'll drop the commit that reverts it. Thoughts @weaverryan @OskarStark @wouterj ?