### PR TITLE
Fix for #1090 while keeping the symfony to 4.4

### DIFF
--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -177,13 +177,20 @@ final class DoctrineHelper
      */
     public function getMetadata(string $classOrNamespace = null, bool $disconnected = false)
     {
-        $classNames = (new \ReflectionClass(AnnotationDriver::class))->getProperty('classNames');
-        $classNames->setAccessible(true);
-
-        // Invalidating the cached AnnotationDriver::$classNames to find new Entity classes
         foreach ($this->mappingDriversByPrefix ?? [] as $managerName => $prefixes) {
             foreach ($prefixes as [$prefix, $annotationDriver]) {
-                if (null !== $annotationDriver) {
+                if ($annotationDriver === null) {
+                    continue;
+                }
+                if (class_exists(AnnotationDriver::class)) {
+                    $classNames = (new \ReflectionClass(AnnotationDriver::class))->getProperty('classNames');
+                }
+                if ($annotationDriver instanceof AttributeDriver) {
+                    $classNames = (new \ReflectionClass(AttributeDriver::class))->getProperty('classNames');
+                }
+
+                if (isset($classNames)) {
+                    $classNames->setAccessible(true);
                     $classNames->setValue($annotationDriver, null);
                 }
             }

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -179,7 +179,7 @@ final class DoctrineHelper
     {
         foreach ($this->mappingDriversByPrefix ?? [] as $managerName => $prefixes) {
             foreach ($prefixes as [$prefix, $annotationDriver]) {
-                if ($annotationDriver === null) {
+                if (null === $annotationDriver) {
                     continue;
                 }
                 if (class_exists(AnnotationDriver::class)) {


### PR DESCRIPTION
LTS should be supported until the end of it's life.
This change allows for maker bundle to work with an updated Symfony 4.4 installation, fixes issue #1090 