### PR TITLE
[make:entity] Improve uid support

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -374,7 +374,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         } elseif (str_starts_with($snakeCasedField, 'has_')) {
             $defaultType = 'boolean';
         } elseif ('uuid' === $snakeCasedField) {
-            $defaultType = 'uuid';
+            $defaultType = Type::hasType('uuid') ? 'uuid' : 'guid';
         } elseif ('guid' === $snakeCasedField) {
             $defaultType = 'guid';
         }

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -35,6 +35,8 @@ use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToOne;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToMany;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToOne;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @internal
@@ -94,6 +96,8 @@ final class ClassSourceManipulator
         $defaultValue = null;
         if ('array' === $typeHint) {
             $defaultValue = new Node\Expr\Array_([], ['kind' => Node\Expr\Array_::KIND_SHORT]);
+        } elseif ('\\' === $typeHint[0] && false !== strpos($typeHint, '\\', 1)) {
+            $typeHint = $this->addUseStatementIfNecessary(substr($typeHint, 1));
         }
 
         $this->addProperty(
@@ -1030,6 +1034,8 @@ final class ClassSourceManipulator
             'datetime_immutable', 'datetimetz_immutable', 'date_immutable', 'time_immutable' => '\\'.\DateTimeImmutable::class,
             'dateinterval' => '\\'.\DateInterval::class,
             'object' => 'object',
+            'uuid' => '\\'.Uuid::class,
+            'ulid' => '\\'.Ulid::class,
             default => null,
         };
     }

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -279,6 +279,24 @@ class ClassSourceManipulatorTest extends TestCase
             ],
             'User_simple_object.php',
         ];
+
+        yield 'entity_add_uuid' => [
+            'User_simple.php',
+            'uuid',
+            [
+                'type' => 'uuid',
+            ],
+            'User_simple_uuid.php',
+        ];
+
+        yield 'entity_add_ulid' => [
+            'User_simple.php',
+            'ulid',
+            [
+                'type' => 'ulid',
+            ],
+            'User_simple_ulid.php',
+        ];
     }
 
     /**

--- a/tests/Util/fixtures/add_entity_field/User_simple_ulid.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_ulid.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Ulid;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'ulid')]
+    private $ulid;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUlid(): ?Ulid
+    {
+        return $this->ulid;
+    }
+
+    public function setUlid(Ulid $ulid): self
+    {
+        $this->ulid = $ulid;
+
+        return $this;
+    }
+}

--- a/tests/Util/fixtures/add_entity_field/User_simple_uuid.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_uuid.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'uuid')]
+    private $uuid;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUuid(): ?Uuid
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(Uuid $uuid): self
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
1. Currently `uuid` is offered as the default type when the field name is uuid, which breaks when the `symfony/uid` component is not installed. Now `guid` is used when `uuid` is not available.

2. Getters & setters for `uuid`/`ulid` types now have type hints added when generated.