### PR TITLE
Erase password by default

### DIFF
--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -93,6 +93,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -88,6 +88,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -88,6 +88,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
@@ -78,6 +78,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/UserModelWithPassword.php
+++ b/tests/Security/fixtures/expected/UserModelWithPassword.php
@@ -73,6 +73,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
@@ -112,6 +112,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
@@ -107,6 +107,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -107,6 +107,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithEmailAsIdentifier.php
@@ -97,6 +97,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithPassword.php
@@ -92,6 +92,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function eraseCredentials()
     {
         // If you store any temporary, sensitive data on the user, clear it here
-        // $this->plainPassword = null;
+        $this->password = '';
     }
 }


### PR DESCRIPTION
While the password is hashed, we don't need it in the session storage, so we can erase it, isn't it?