### PR TITLE
[Generator] correct createClassNameDetails doc

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -119,10 +119,10 @@ class Generator
      *      // App\Controller\FooController
      *      $gen->createClassNameDetails('foo', 'Controller', 'Controller');
      *
-     *      // App\Controller\Admin\FooController
+     *      // App\Controller\Foo\AdminController
      *      $gen->createClassNameDetails('Foo\\Admin', 'Controller', 'Controller');
      *
-     *      // App\Controller\Security\Voter\CoolController
+     *      // App\Security\Voter\CoolVoter
      *      $gen->createClassNameDetails('Cool', 'Security\Voter', 'Voter');
      *
      *      // Full class names can also be passed. Imagine the user has an autoload


### PR DESCRIPTION
you can use the following test cases in [GeneratorTest](https://github.com/symfony/maker-bundle/blob/main/tests/GeneratorTest.php) for a quick verification.

       yield 'example_1' => [
            'Foo\\Admin',
            'Controller',
            'Controller',
            'App\Controller\Foo\AdminController',
            'Foo\AdminController',
        ];`

        yield 'example_2' => [
            'Cool',
            'Security\Voter',
            'Voter',
            'App\Security\Voter\CoolVoter',
            'CoolVoter',
        ];`
