### PR TITLE
[ci] fix blocked plugins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,7 +139,7 @@ jobs:
               run: composer diagnose
 
             - name: "Require symfony/flex"
-              run: composer global require --no-progress --no-scripts --no-plugins symfony/flex
+              run: composer global require --no-progress --no-scripts --no-plugins symfony/flex -vvv
 
             - name: "Composer install"
               uses: "ramsey/composer-install@v1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,9 +135,6 @@ jobs:
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: "TMP Diagnose Composer Issuer"
-              run: composer diagnose
-
             - name: "Require symfony/flex"
               run: composer global require --no-progress --no-scripts --no-plugins symfony/flex -vvv
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,7 @@ jobs:
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: "No Plugins"
-              run: composer config --no-plugins allow-plugins.symfony/flex false
+              run: composer global config --no-plugins allow-plugins.symfony/flex false
 
             - name: "Require symfony/flex"
               run: composer global require --no-progress --no-scripts --no-plugins symfony/flex -vvv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: "No Plugins"
+            - name: "Allow the Flex Plugin"
               run: composer global config --no-plugins allow-plugins.symfony/flex true
 
             - name: "Require symfony/flex"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,7 @@ jobs:
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: "No Plugins"
-              run: composer global config --no-plugins allow-plugins.symfony/flex false
+              run: composer global config --no-plugins allow-plugins.symfony/flex true
 
             - name: "Require symfony/flex"
               run: composer global require --no-progress --no-scripts --no-plugins symfony/flex

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,9 @@ jobs:
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+            - name: "No Plugins"
+              run: composer config --no-plugins allow-plugins.symfony/flex false
+
             - name: "Require symfony/flex"
               run: composer global require --no-progress --no-scripts --no-plugins symfony/flex -vvv
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,7 +139,7 @@ jobs:
               run: composer global config --no-plugins allow-plugins.symfony/flex false
 
             - name: "Require symfony/flex"
-              run: composer global require --no-progress --no-scripts --no-plugins symfony/flex -vvv
+              run: composer global require --no-progress --no-scripts --no-plugins symfony/flex
 
             - name: "Composer install"
               uses: "ramsey/composer-install@v1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,9 @@ jobs:
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+            - name: "TMP Diagnose Composer Issuer"
+              run: composer diagnose
+
             - name: "Require symfony/flex"
               run: composer global require --no-progress --no-scripts --no-plugins symfony/flex
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,7 @@ install:
     - del composer.phar
     - rename composer-stable.phar composer.phar
     - cd C:\projects\maker-bundle
+    - composer global config --no-plugins allow-plugins.symfony/flex false
     - composer global require --no-progress --no-scripts --no-plugins symfony/flex
     - IF %dependencies%==highest appveyor-retry composer update --no-progress --no-suggest --ansi
     - composer install --no-interaction --no-progress --ansi --no-scripts --working-dir=tools/twigcs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ install:
     - del composer.phar
     - rename composer-stable.phar composer.phar
     - cd C:\projects\maker-bundle
-    - composer global config --no-plugins allow-plugins.symfony/flex false
+    - composer global config --no-plugins allow-plugins.symfony/flex true
     - composer global require --no-progress --no-scripts --no-plugins symfony/flex
     - IF %dependencies%==highest appveyor-retry composer update --no-progress --no-suggest --ansi
     - composer install --no-interaction --no-progress --ansi --no-scripts --working-dir=tools/twigcs


### PR DESCRIPTION
Ref'd in https://github.com/composer/composer/issues/10925

Since Composer `2.3.9` unless you explicitly allow/disallow a plugin (`flex` in our case), an error is thrown (halts our CI run) before any tests are actually ran.