### PR TITLE
[make:entity] Property types, Types:: constant & type guessing

### DIFF
--- a/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
+++ b/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
@@ -45,7 +45,7 @@ class MakeCommandRegistrationPass implements CompilerPassInterface
             $tagAttributes = ['command' => $class::getCommandName()];
 
             if (!method_exists($class, 'getCommandDescription')) {
-                // no-op
+            // no-op
             } elseif (class_exists(LazyCommand::class)) {
                 $tagAttributes['description'] = $class::getCommandDescription();
             } else {

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Doctrine;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
@@ -24,6 +25,8 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\MappingException as PersistenceMappingException;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\Ulid;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -228,6 +231,64 @@ final class DoctrineHelper
         }
 
         return (bool) $this->getMetadata($className);
+    }
+
+    /**
+     * Determines if the property-type will make the column type redundant.
+     *
+     * See ClassMetadataInfo::validateAndCompleteTypedFieldMapping()
+     */
+    public static function canColumnTypeBeInferredByPropertyType(string $columnType, string $propertyType): bool
+    {
+        // todo: guessing on enum's could be added
+
+        return match ($propertyType) {
+            '\\' . \DateInterval::class => $columnType === Types::DATEINTERVAL,
+            '\\' . \DateTime::class => $columnType === Types::DATETIME_MUTABLE,
+            '\\' . \DateTimeImmutable::class => $columnType === Types::DATETIME_IMMUTABLE,
+            'array' => $columnType === Types::JSON,
+            'bool' => $columnType === Types::BOOLEAN,
+            'float' => $columnType === Types::FLOAT,
+            'int' => $columnType === Types::INTEGER,
+            'string' => $columnType === Types::STRING,
+            default => false,
+        };
+    }
+
+    public static function getPropertyTypeForColumn(string $columnType): ?string
+    {
+        return match ($columnType) {
+            Types::STRING, Types::TEXT, Types::GUID, Types::BIGINT, Types::DECIMAL => 'string',
+            Types::ARRAY, Types::SIMPLE_ARRAY, Types::JSON => 'array',
+            Types::BOOLEAN => 'bool',
+            Types::INTEGER, Types::SMALLINT => 'int',
+            Types::FLOAT => 'float',
+            Types::DATETIME_MUTABLE, Types::DATETIMETZ_MUTABLE, Types::DATE_MUTABLE, Types::TIME_MUTABLE => '\\' . \DateTimeInterface::class,
+            Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE => '\\' . \DateTimeImmutable::class,
+            Types::DATEINTERVAL => '\\' . \DateInterval::class,
+            Types::OBJECT => 'object',
+            'uuid' => '\\' . Uuid::class,
+            'ulid' => '\\' . Ulid::class,
+            default => null,
+        };
+    }
+
+    /**
+     * Given the string "column type", this returns the "Types::STRING" constant.
+     *
+     * This is, effectively, a reverse lookup: given the final string, give us
+     * the constant to be used in the generated code.
+     */
+    public static function getTypeConstant(string $columnType): ?string
+    {
+        $reflection = new \ReflectionClass(Types::class);
+        $constants = array_flip($reflection->getConstants());
+
+        if (!isset($constants[$columnType])) {
+            return null;
+        }
+
+        return 'Types::'.$constants[$columnType];
     }
 
     private function isInstanceOf($object, string $class): bool

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -25,8 +25,8 @@ use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Persistence\Mapping\MappingException as PersistenceMappingException;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
-use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -243,14 +243,14 @@ final class DoctrineHelper
         // todo: guessing on enum's could be added
 
         return match ($propertyType) {
-            '\\' . \DateInterval::class => $columnType === Types::DATEINTERVAL,
-            '\\' . \DateTime::class => $columnType === Types::DATETIME_MUTABLE,
-            '\\' . \DateTimeImmutable::class => $columnType === Types::DATETIME_IMMUTABLE,
-            'array' => $columnType === Types::JSON,
-            'bool' => $columnType === Types::BOOLEAN,
-            'float' => $columnType === Types::FLOAT,
-            'int' => $columnType === Types::INTEGER,
-            'string' => $columnType === Types::STRING,
+            '\\'.\DateInterval::class => Types::DATEINTERVAL === $columnType,
+            '\\'.\DateTime::class => Types::DATETIME_MUTABLE === $columnType,
+            '\\'.\DateTimeImmutable::class => Types::DATETIME_IMMUTABLE === $columnType,
+            'array' => Types::JSON === $columnType,
+            'bool' => Types::BOOLEAN === $columnType,
+            'float' => Types::FLOAT === $columnType,
+            'int' => Types::INTEGER === $columnType,
+            'string' => Types::STRING === $columnType,
             default => false,
         };
     }
@@ -263,12 +263,12 @@ final class DoctrineHelper
             Types::BOOLEAN => 'bool',
             Types::INTEGER, Types::SMALLINT => 'int',
             Types::FLOAT => 'float',
-            Types::DATETIME_MUTABLE, Types::DATETIMETZ_MUTABLE, Types::DATE_MUTABLE, Types::TIME_MUTABLE => '\\' . \DateTimeInterface::class,
-            Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE => '\\' . \DateTimeImmutable::class,
-            Types::DATEINTERVAL => '\\' . \DateInterval::class,
+            Types::DATETIME_MUTABLE, Types::DATETIMETZ_MUTABLE, Types::DATE_MUTABLE, Types::TIME_MUTABLE => '\\'.\DateTimeInterface::class,
+            Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE => '\\'.\DateTimeImmutable::class,
+            Types::DATEINTERVAL => '\\'.\DateInterval::class,
             Types::OBJECT => 'object',
-            'uuid' => '\\' . Uuid::class,
-            'ulid' => '\\' . Ulid::class,
+            'uuid' => '\\'.Uuid::class,
+            'ulid' => '\\'.Ulid::class,
             default => null,
         };
     }

--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -288,7 +288,7 @@ final class DoctrineHelper
             return null;
         }
 
-        return 'Types::'.$constants[$columnType];
+        return sprintf('Types::%s', $constants[$columnType]);
     }
 
     private function isInstanceOf($object, string $class): bool

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -47,7 +47,7 @@ final class EntityClassGenerator
 
         $useStatements = new UseStatementGenerator([
             $repoClassDetails->getFullName(),
-            [Mapping::class => 'ORM'],
+            ['Doctrine\\ORM\\Mapping' => 'ORM'],
         ]);
 
         if ($broadcast) {

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -13,8 +13,6 @@ namespace Symfony\Bundle\MakerBundle\Doctrine;
 
 use ApiPlatform\Metadata\ApiResource;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Str;
@@ -50,7 +48,6 @@ final class EntityClassGenerator
         $useStatements = new UseStatementGenerator([
             $repoClassDetails->getFullName(),
             [Mapping::class => 'ORM'],
-            Types::class,
         ]);
 
         if ($broadcast) {

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Doctrine;
 
 use ApiPlatform\Metadata\ApiResource;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -49,6 +50,7 @@ final class EntityClassGenerator
         $useStatements = new UseStatementGenerator([
             $repoClassDetails->getFullName(),
             [Mapping::class => 'ORM'],
+            Types::class,
         ]);
 
         if ($broadcast) {

--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -65,7 +65,7 @@ class MakeFunctionalTest extends AbstractMaker
         $pantherAvailable = trait_exists(PantherTestCaseTrait::class);
 
         $useStatements = new UseStatementGenerator([
-            ($pantherAvailable ? PantherTestCase::class : WebTestCase::class),
+            $pantherAvailable ? PantherTestCase::class : WebTestCase::class,
         ]);
 
         $generator->generateClass(

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -423,7 +423,7 @@ class MakeResetPassword extends AbstractMaker
             CODE
         );
 
-        $manipulator->addManyToOneRelation((new RelationManyToOne(
+        $manipulator->addManyToOneRelation(new RelationManyToOne(
             propertyName: 'user',
             targetClassName: $this->userClass,
             mapInverseRelation: false,
@@ -431,7 +431,7 @@ class MakeResetPassword extends AbstractMaker
             isCustomReturnTypeNullable: false,
             customReturnType: 'object',
             isOwning: true,
-        )));
+        ));
 
         $this->fileManager->dumpFile($requestEntityPath, $manipulator->getSourceCode());
 

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -17,7 +17,7 @@ class <?= $class_name."\n" ?>
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private int $id;
 
     public function getId(): ?int

--- a/src/Resources/skeleton/doctrine/Entity.tpl.php
+++ b/src/Resources/skeleton/doctrine/Entity.tpl.php
@@ -17,8 +17,8 @@ class <?= $class_name."\n" ?>
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private int $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -25,7 +25,7 @@ class <?= $class_name; ?> extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             // encode the plain password
             $user->set<?= ucfirst($password_field) ?>(
-            <?= $password_hasher_variable_name ?>-><?= $use_password_hasher ? 'hashPassword' : 'encodePassword' ?>(
+                <?= $password_hasher_variable_name ?>-><?= $use_password_hasher ? 'hashPassword' : 'encodePassword' ?>(
                     $user,
                     $form->get('plainPassword')->getData()
                 )

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -162,9 +162,8 @@ final class ClassSourceManipulator
 
         $this->addProperty(
             name: $propertyName,
-            defaultValue: null,
             attributes: $attributes,
-            propertyType: '?'.$typeHint,
+            propertyType: $typeHint,
         );
 
         // logic to avoid re-adding the same ArrayCollection line

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -461,6 +461,7 @@ final class ClassSourceManipulator
         } else {
             $annotationOptions['mappedBy'] = $relation->getTargetPropertyName();
         }
+
         if ($typeHint === 'self') {
             // Doctrine does not currently resolve "self" correctly for targetEntity guessing
             $annotationOptions['targetEntity'] = new ClassNameValue($typeHint, $relation->getTargetClassName());

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -809,12 +809,12 @@ final class ClassSourceManipulator
             // Use the Doctrine Types constant
             if ('type' === $option && str_starts_with($value, 'Types::')) {
                 return new Node\Arg(
-                        new Node\Expr\ConstFetch(new Node\Name($value)),
-                        false,
-                        false,
-                        [],
-                        new Node\Identifier($option)
-                    );
+                    new Node\Expr\ConstFetch(new Node\Name($value)),
+                    false,
+                    false,
+                    [],
+                    new Node\Identifier($option)
+                );
             }
 
             return new Node\Arg($context->buildNodeExprByValue($value), false, false, [], new Node\Identifier($option));

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -808,14 +808,14 @@ final class ClassSourceManipulator
 
             // Use the Doctrine Types constant
             if ('type' === $option && str_starts_with($value, 'Types::')) {
-                    return new Node\Arg(
+                return new Node\Arg(
                         new Node\Expr\ConstFetch(new Node\Name($value)),
                         false,
                         false,
                         [],
                         new Node\Identifier($option)
                     );
-                }
+            }
 
             return new Node\Arg($context->buildNodeExprByValue($value), false, false, [], new Node\Identifier($option));
         }, array_keys($options), array_values($options));

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -37,8 +37,6 @@ use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToOne;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToMany;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationOneToOne;
 use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Component\Uid\Ulid;
-use Symfony\Component\Uid\Uuid;
 
 /**
  * @internal
@@ -139,7 +137,7 @@ final class ClassSourceManipulator
             // getter methods always have nullable return values
             // because even though these are required in the db, they may not be set yet
             // unless there is a default value
-            $defaultValue === null
+            null === $defaultValue
         );
 
         // don't generate setters for id fields
@@ -376,7 +374,7 @@ final class ClassSourceManipulator
             $newPropertyBuilder->setDocComment($this->createDocBlock($comments));
         }
 
-        if ($defaultValue !== self::DEFAULT_VALUE_NONE) {
+        if (self::DEFAULT_VALUE_NONE !== $defaultValue) {
             $newPropertyBuilder->setDefault($defaultValue);
         }
         $newPropertyNode = $newPropertyBuilder->getNode();
@@ -462,7 +460,7 @@ final class ClassSourceManipulator
             $annotationOptions['mappedBy'] = $relation->getTargetPropertyName();
         }
 
-        if ($typeHint === 'self') {
+        if ('self' === $typeHint) {
             // Doctrine does not currently resolve "self" correctly for targetEntity guessing
             $annotationOptions['targetEntity'] = new ClassNameValue($typeHint, $relation->getTargetClassName());
         }

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -46,7 +46,6 @@ final class ClassSourceManipulator
     private const CONTEXT_OUTSIDE_CLASS = 'outside_class';
     private const CONTEXT_CLASS = 'class';
     private const CONTEXT_CLASS_METHOD = 'class_method';
-
     private const DEFAULT_VALUE_NONE = '__default_value_none';
 
     private Parser\Php7 $parser;

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -461,6 +461,10 @@ final class ClassSourceManipulator
         } else {
             $annotationOptions['mappedBy'] = $relation->getTargetPropertyName();
         }
+        if ($typeHint === 'self') {
+            // Doctrine does not currently resolve "self" correctly for targetEntity guessing
+            $annotationOptions['targetEntity'] = new ClassNameValue($typeHint, $relation->getTargetClassName());
+        }
 
         if ($relation instanceof RelationOneToOne) {
             $annotationOptions['cascade'] = ['persist', 'remove'];

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -1040,6 +1040,39 @@ final class ClassSourceManipulator
         };
     }
 
+    private function getTypeConstant(string $type): string
+    {
+        $typesMapping = [
+            'array' => 'Types::ARRAY',
+            'ascii_string' => 'Types::ASCII_STRING',
+            'bigint' => 'Types::BIGINT',
+            'binary' => 'Types::BINARY',
+            'blob' => 'Types::BLOB',
+            'boolean' => 'Types::BOOLEAN',
+            'date' => 'Types::DATE_MUTABLE',
+            'date_immutable' => 'Types::DATE_IMMUTABLE',
+            'dateinterval' => 'Types::DATEINTERVAL',
+            'datetime' => 'Types::DATETIME_MUTABLE',
+            'datetime_immutable' => 'Types::DATETIME_IMMUTABLE',
+            'datetimetz' => 'Types::DATETIMETZ_MUTABLE',
+            'datetimetz_immutable' => 'Types::DATETIMETZ_IMMUTABLE',
+            'decimal' => 'Types::DECIMAL',
+            'float' => 'Types::FLOAT',
+            'guid' => 'Types::GUID',
+            'integer' => 'Types::INTEGER',
+            'json' => 'Types::JSON',
+            'object' => 'Types::OBJECT',
+            'simple_array' => 'Types::SIMPLE_ARRAY',
+            'smallint' => 'Types::SMALLINT',
+            'string' => 'Types::STRING',
+            'text' => 'Types::TEXT',
+            'time' => 'Types::TIME_MUTABLE',
+            'time_immutable' => 'Types::TIME_IMMUTABLE',
+        ];
+
+        return $typesMapping[$type] ?? $type;
+    }
+
     private function isInSameNamespace(string $class): bool
     {
         $namespace = substr($class, 0, strrpos($class, '\\'));

--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -477,7 +477,7 @@ class YamlSourceManipulator
             // this means we need to break onto the next line
 
             // increase(override) the indentation
-            $newYamlValue = "\n".$this->indentMultilineYamlArray($newYamlValue, ($this->indentationForDepths[$this->depth] + $this->getPreferredIndentationSize()));
+            $newYamlValue = "\n".$this->indentMultilineYamlArray($newYamlValue, $this->indentationForDepths[$this->depth] + $this->getPreferredIndentationSize());
         } elseif ($this->isCurrentArrayMultiline() && $this->isCurrentArraySequence()) {
             // we are a multi-line sequence, so drop to next line, indent and add "- " in front
             $newYamlValue = "\n".$this->indentMultilineYamlArray('- '.$newYamlValue);
@@ -626,7 +626,7 @@ class YamlSourceManipulator
         }
 
         // find either a line break or a , that is the end of the previous key
-        while (\in_array(($char = substr($this->contents, $startOfKey - 1, 1)), [',', "\n"])) {
+        while (\in_array($char = substr($this->contents, $startOfKey - 1, 1), [',', "\n"])) {
             --$startOfKey;
         }
 

--- a/tests/Doctrine/DoctrineHelperTest.php
+++ b/tests/Doctrine/DoctrineHelperTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bundle\MakerBundle\Tests\Doctrine;
 
 use Doctrine\DBAL\Types\Types;

--- a/tests/Doctrine/DoctrineHelperTest.php
+++ b/tests/Doctrine/DoctrineHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Symfony\Bundle\MakerBundle\Tests\Doctrine;
+
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
+
+class DoctrineHelperTest extends TestCase
+{
+    /**
+     * @dataProvider getTypeConstantTests
+     */
+    public function testGetTypeConstant(string $columnType, ?string $expectedConstant)
+    {
+        $this->assertSame($expectedConstant, DoctrineHelper::getTypeConstant($columnType));
+    }
+
+    public function getTypeConstantTests(): \Generator
+    {
+        yield 'unknown_type' => ['foo', null];
+        yield 'string' => ['string', 'Types::STRING'];
+        yield 'datetimetz_immutable' => ['datetimetz_immutable', 'Types::DATETIMETZ_IMMUTABLE'];
+    }
+
+    /**
+     * @dataProvider getCanColumnTypeBeInferredTests
+     */
+    public function testCanColumnTypeBeInferredByPropertyType(string $columnType, string $propertyType, bool $expected)
+    {
+        $this->assertSame($expected, DoctrineHelper::canColumnTypeBeInferredByPropertyType($columnType, $propertyType));
+    }
+
+    public function getCanColumnTypeBeInferredTests(): \Generator
+    {
+        yield 'non_matching' => [Types::TEXT, 'string', false];
+        yield 'yes_matching' => [Types::STRING, 'string', true];
+    }
+}

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
@@ -12,17 +12,17 @@ class BaseClient
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING)]
-    private $name;
+    #[ORM\Column]
+    private ?string $name = null;
 
-    #[ORM\ManyToOne(targetEntity: User::class)]
-    private $creator;
+    #[ORM\ManyToOne]
+    private ?User $creator = null;
 
-    #[ORM\Column(type: Types::INTEGER)]
-    private $magic;
+    #[ORM\Column()]
+    private int $magic;
 
     public function __construct()
     {
@@ -46,7 +46,7 @@ class BaseClient
         return $this;
     }
 
-    public function getMagic(): ?int
+    public function getMagic(): int
     {
         return $this->magic;
     }

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]
@@ -11,16 +12,16 @@ class BaseClient
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $name;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     private $creator;
 
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $magic;
 
     public function __construct()

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/BaseClient.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]
@@ -46,7 +45,7 @@ class BaseClient
         return $this;
     }
 
-    public function getMagic(): int
+    public function getMagic(): ?int
     {
         return $this->magic;
     }

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
@@ -4,7 +4,6 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
@@ -4,6 +4,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -14,7 +15,7 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    #[ORM\Column(type: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $apiKey;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Client.php
@@ -15,14 +15,14 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    #[ORM\Column(type: Types::STRING)]
-    private $apiKey;
+    #[ORM\Column()]
+    private ?string $apiKey = null;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]
-    private $tags;
+    private Collection $tags;
 
-    #[ORM\Embedded(class: Embed::class)]
-    private $embed;
+    #[ORM\Embedded()]
+    private Embed $embed;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Embed.php
@@ -2,12 +2,13 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
 class Embed
 {
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $val;
 
     public function getVal(): ?int

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Embed.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Embeddable]
 class Embed
 {
-    #[ORM\Column(type: Types::INTEGER)]
-    private $val;
+    #[ORM\Column()]
+    private ?int $val = null;
 
     public function getVal(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Tag.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Tag.php
@@ -10,8 +10,8 @@ class Tag
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Tag.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/Tag.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class Tag
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
@@ -4,7 +4,6 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
@@ -12,17 +12,17 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]
-    private $avatars;
+    private Collection $avatars;
 
-    #[ORM\OneToOne(targetEntity: UserProfile::class, mappedBy: 'user')]
-    private $userProfile;
+    #[ORM\OneToOne(mappedBy: 'user')]
+    private ?UserProfile $userProfile = null;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]
-    private $tags;
+    private Collection $tags;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/User.php
@@ -4,6 +4,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserAvatar.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserAvatar.php
@@ -10,12 +10,12 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]
+    #[ORM\ManyToOne(inversedBy: 'avatars', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserAvatar.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserProfile.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserProfile.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(targetEntity: User::class, inversedBy: 'userProfile', cascade: ['persist', 'remove'])]

--- a/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserProfile.php
+++ b/tests/Doctrine/fixtures/expected_no_overwrite/src/Entity/UserProfile.php
@@ -10,12 +10,12 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(targetEntity: User::class, inversedBy: 'userProfile', cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(inversedBy: 'userProfile', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
@@ -12,17 +12,17 @@ class BaseClient
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING)]
-    private $name;
+    #[ORM\Column]
+    private ?string $name = null;
 
-    #[ORM\ManyToOne(targetEntity: User::class)]
-    private $creator;
+    #[ORM\ManyToOne]
+    private ?User $creator = null;
 
-    #[ORM\Column(type: Types::INTEGER)]
-    private $magic;
+    #[ORM\Column()]
+    private int $magic;
 
     public function __construct()
     {
@@ -46,7 +46,7 @@ class BaseClient
         return $this;
     }
 
-    public function getMagic(): ?int
+    public function getMagic(): int
     {
         return $this->magic;
     }

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]
@@ -11,16 +12,16 @@ class BaseClient
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $name;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     private $creator;
 
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $magic;
 
     public function __construct()

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/BaseClient.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]
@@ -46,7 +45,7 @@ class BaseClient
         return $this;
     }
 
-    public function getMagic(): int
+    public function getMagic(): ?int
     {
         return $this->magic;
     }

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
@@ -4,7 +4,6 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
@@ -4,6 +4,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -14,7 +15,7 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    #[ORM\Column(type: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $apiKey;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Client.php
@@ -15,14 +15,14 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    #[ORM\Column(type: Types::STRING)]
-    private $apiKey;
+    #[ORM\Column()]
+    private ?string $apiKey = null;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]
-    private $tags;
+    private Collection $tags;
 
-    #[ORM\Embedded(class: Embed::class)]
-    private $embed;
+    #[ORM\Embedded()]
+    private Embed $embed;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Embed.php
@@ -2,12 +2,13 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
 class Embed
 {
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $val;
 
     public function getVal(): ?int

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Embed.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Embeddable]
 class Embed
 {
-    #[ORM\Column(type: Types::INTEGER)]
-    private $val;
+    #[ORM\Column()]
+    private ?int $val = null;
 
     public function getVal(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Tag.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Tag.php
@@ -10,8 +10,8 @@ class Tag
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Tag.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/Tag.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class Tag
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
@@ -4,7 +4,6 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
@@ -12,17 +12,17 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]
-    private $avatars;
+    private Collection $avatars;
 
-    #[ORM\OneToOne(targetEntity: UserProfile::class, mappedBy: 'user')]
-    private $userProfile;
+    #[ORM\OneToOne(mappedBy: 'user')]
+    private ?UserProfile $userProfile = null;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]
-    private $tags;
+    private Collection $tags;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/User.php
@@ -4,6 +4,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserAvatar.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserAvatar.php
@@ -10,12 +10,12 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]
+    #[ORM\ManyToOne(inversedBy: 'avatars', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserAvatar.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserProfile.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserProfile.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(targetEntity: User::class, inversedBy: 'userProfile', cascade: ['persist', 'remove'])]

--- a/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserProfile.php
+++ b/tests/Doctrine/fixtures/expected_overwrite/src/Entity/UserProfile.php
@@ -10,12 +10,12 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(targetEntity: User::class, inversedBy: 'userProfile', cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(inversedBy: 'userProfile', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_xml/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Entity/UserAvatar.php
@@ -4,9 +4,9 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity;
 
 class UserAvatar
 {
-    private $id;
+    private ?int $id = null;
 
-    private $user;
+    private ?UserXml $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/expected_xml/src/Entity/UserXml.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Entity/UserXml.php
@@ -9,9 +9,9 @@ class UserXml
 {
     private $id;
 
-    private $name;
+    private ?string $name = null;
 
-    private $avatars;
+    private Collection $avatars;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/expected_xml/src/Entity/XOther.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Entity/XOther.php
@@ -4,7 +4,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity;
 
 class XOther
 {
-    private $id;
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]
@@ -11,16 +12,16 @@ class BaseClient
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $name;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     private $creator;
 
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $magic;
 
     public function __construct()

--- a/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
@@ -12,17 +12,17 @@ class BaseClient
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING)]
-    private $name;
+    #[ORM\Column]
+    private ?string $name = null;
 
-    #[ORM\ManyToOne(targetEntity: User::class)]
-    private $creator;
+    #[ORM\ManyToOne]
+    private ?User $creator = null;
 
-    #[ORM\Column(type: Types::INTEGER)]
-    private $magic;
+    #[ORM\Column()]
+    private int $magic;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/BaseClient.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\MappedSuperclass]

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Client.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -12,7 +13,7 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    #[ORM\Column(type: 'string')]
+    #[ORM\Column(type: Types::STRING)]
     private $apiKey;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Client.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Client.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
-use Doctrine\DBAL\Types\Types;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -13,12 +13,12 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    #[ORM\Column(type: Types::STRING)]
-    private $apiKey;
+    #[ORM\Column()]
+    private ?string $apiKey = null;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]
-    private $tags;
+    private Collection $tags;
 
-    #[ORM\Embedded(class: Embed::class)]
-    private $embed;
+    #[ORM\Embedded()]
+    private Embed $embed;
 }

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Embed.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
 class Embed
 {
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $val;
 }

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Embed.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Embed.php
@@ -8,6 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Embeddable]
 class Embed
 {
-    #[ORM\Column(type: Types::INTEGER)]
-    private $val;
+    #[ORM\Column()]
+    private ?int $val = null;
 }

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Tag.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Tag.php
@@ -10,8 +10,8 @@ class Tag
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Doctrine/fixtures/source_project/src/Entity/Tag.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/Tag.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class Tag
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Doctrine/fixtures/source_project/src/Entity/TimestampableTrait.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/TimestampableTrait.php
@@ -8,10 +8,10 @@ use Doctrine\ORM\Mapping as ORM;
 trait TimestampableTrait
 {
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private $createdAt;
+    private ?\DateTimeInterface $createdAt = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private $updatedAt;
+    private ?\DateTimeInterface $updatedAt = null;
 
     /**
      * @return mixed

--- a/tests/Doctrine/fixtures/source_project/src/Entity/TimestampableTrait.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/TimestampableTrait.php
@@ -2,14 +2,15 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 trait TimestampableTrait
 {
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private $createdAt;
 
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private $updatedAt;
 
     /**

--- a/tests/Doctrine/fixtures/source_project/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/User.php
@@ -4,7 +4,6 @@ namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/source_project/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/User.php
@@ -3,6 +3,7 @@
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -11,17 +12,17 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]
-    private $avatars;
+    private Collection $avatars;
 
-    #[ORM\OneToOne(targetEntity: UserProfile::class, mappedBy: 'user')]
-    private $userProfile;
+    #[ORM\OneToOne(mappedBy: 'user')]
+    private ?UserProfile $userProfile = null;
 
     #[ORM\ManyToMany(targetEntity: Tag::class)]
-    private $tags;
+    private Collection $tags;
 
     public function __construct()
     {

--- a/tests/Doctrine/fixtures/source_project/src/Entity/User.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/User.php
@@ -3,6 +3,7 @@
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,7 +11,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]

--- a/tests/Doctrine/fixtures/source_project/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/UserAvatar.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]

--- a/tests/Doctrine/fixtures/source_project/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/UserAvatar.php
@@ -10,10 +10,10 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]
+    #[ORM\ManyToOne(inversedBy: 'avatars', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 }

--- a/tests/Doctrine/fixtures/source_project/src/Entity/UserAvatar.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/UserAvatar.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Doctrine/fixtures/source_project/src/Entity/UserProfile.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/UserProfile.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(targetEntity: User::class, inversedBy: 'userProfile', cascade: ['persist', 'remove'])]

--- a/tests/Doctrine/fixtures/source_project/src/Entity/UserProfile.php
+++ b/tests/Doctrine/fixtures/source_project/src/Entity/UserProfile.php
@@ -10,10 +10,10 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(targetEntity: User::class, inversedBy: 'userProfile', cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(inversedBy: 'userProfile', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 }

--- a/tests/Maker/MakeMessengerMiddlewareTest.php
+++ b/tests/Maker/MakeMessengerMiddlewareTest.php
@@ -27,10 +27,10 @@ class MakeMessengerMiddlewareTest extends MakerTestCase
         yield 'it_generates_messenger_middleware' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
-                [
-                    // middleware name
-                    'CustomMiddleware',
-                ]);
+                    [
+                        // middleware name
+                        'CustomMiddleware',
+                    ]);
 
                 $this->assertFileExists($runner->getPath('src/Middleware/CustomMiddleware.php'));
             }),

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -185,7 +185,7 @@ class MakeResetPasswordTest extends MakerTestCase
                 // check ResetPasswordRequest
                 $contentResetPasswordRequest = file_get_contents($runner->getPath('src/Entity/ResetPasswordRequest.php'));
 
-                $this->assertStringContainsString('ORM\ManyToOne(targetEntity: UserCustom::class)', $contentResetPasswordRequest);
+                $this->assertStringContainsString('ORM\ManyToOne', $contentResetPasswordRequest);
 
                 // check ResetPasswordRequestFormType
                 $contentResetPasswordRequestFormType = file_get_contents($runner->getPath('/src/Form/ResetPasswordRequestFormType.php'));

--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -17,13 +17,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $email = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column()]
+    #[ORM\Column]
     private ?string $password = null;
 
     public function getId(): ?int

--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -11,20 +11,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $email;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $email = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column(type: 'string')]
-    private $password;
+    #[ORM\Column()]
+    private ?string $password = null;
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -17,13 +17,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $userIdentifier = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column()]
+    #[ORM\Column]
     private ?string $password = null;
 
     public function getId(): ?int

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -11,20 +11,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $userIdentifier;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $userIdentifier = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column(type: 'string')]
-    private $password;
+    #[ORM\Column()]
+    private ?string $password = null;
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -17,13 +17,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $user_identifier = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column()]
+    #[ORM\Column]
     private ?string $password = null;
 
     public function getId(): ?int

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -11,20 +11,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $user_identifier;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $user_identifier = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column(type: 'string')]
-    private $password;
+    #[ORM\Column()]
+    private ?string $password = null;
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
@@ -10,14 +10,14 @@ class User implements UserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $userIdentifier;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $userIdentifier = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
@@ -16,7 +16,7 @@ class User implements UserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $userIdentifier = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     public function getId(): ?int

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
@@ -17,13 +17,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $email = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column()]
+    #[ORM\Column]
     private ?string $password = null;
 
     public function getId(): ?int

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
@@ -11,20 +11,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $email;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $email = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column(type: 'string')]
-    private $password;
+    #[ORM\Column()]
+    private ?string $password = null;
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
@@ -17,13 +17,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $userIdentifier = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column()]
+    #[ORM\Column]
     private ?string $password = null;
 
     public function getId(): ?int

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
@@ -11,20 +11,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $userIdentifier;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $userIdentifier = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column(type: 'string')]
-    private $password;
+    #[ORM\Column()]
+    private ?string $password = null;
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -17,13 +17,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $user_identifier = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column()]
+    #[ORM\Column]
     private ?string $password = null;
 
     public function getId(): ?int

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -11,20 +11,20 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $user_identifier;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $user_identifier = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     /**
      * @var string The hashed password
      */
-    #[ORM\Column(type: 'string')]
-    private $password;
+    #[ORM\Column()]
+    private ?string $password = null;
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithoutPassword.php
@@ -10,14 +10,14 @@ class User implements UserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 180, unique: true)]
-    private $userIdentifier;
+    #[ORM\Column(length: 180, unique: true)]
+    private ?string $userIdentifier = null;
 
-    #[ORM\Column(type: 'json')]
-    private $roles = [];
+    #[ORM\Column()]
+    private array $roles = [];
 
     public function getId(): ?int
     {

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithoutPassword.php
@@ -16,7 +16,7 @@ class User implements UserInterface
     #[ORM\Column(length: 180, unique: true)]
     private ?string $userIdentifier = null;
 
-    #[ORM\Column()]
+    #[ORM\Column]
     private array $roles = [];
 
     public function getId(): ?int

--- a/tests/Security/fixtures/source/UserEntity.php
+++ b/tests/Security/fixtures/source/UserEntity.php
@@ -9,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -210,11 +210,11 @@ class ClassSourceManipulatorTest extends TestCase
         $expectedPath = __DIR__.'/fixtures/add_entity_field';
 
         $this->runAddEntityFieldTests(
-                file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
-                $propertyName,
-                $fieldOptions,
-                file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename))
-            );
+            file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
+            $propertyName,
+            $fieldOptions,
+            file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename))
+        );
     }
 
     private function runAddEntityFieldTests(string $source, string $propertyName, array $fieldOptions, string $expected): void
@@ -308,10 +308,10 @@ class ClassSourceManipulatorTest extends TestCase
         $expectedPath = __DIR__.'/fixtures/add_many_to_one_relation';
 
         $this->runAddManyToOneRelationTests(
-                file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
-                file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
-                $manyToOne
-            );
+            file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
+            file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
+            $manyToOne
+        );
     }
 
     public function runAddManyToOneRelationTests(string $source, string $expected, RelationManyToOne $manyToOne): void
@@ -327,73 +327,73 @@ class ClassSourceManipulatorTest extends TestCase
         yield 'many_to_one_not_nullable' => [
             'User_simple.php',
             'User_simple_not_nullable.php',
-            (new RelationManyToOne(
+            new RelationManyToOne(
                 propertyName: 'category',
                 targetClassName: \App\Entity\Category::class,
                 targetPropertyName: 'foods',
                 isOwning: true,
-            )),
+            ),
         ];
 
         yield 'many_to_one_nullable' => [
             'User_simple.php',
             'User_simple_nullable.php',
-            (new RelationManyToOne(
+            new RelationManyToOne(
                 propertyName: 'category',
                 targetClassName: \App\Entity\Category::class,
                 targetPropertyName: 'foods',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'many_to_one_other_namespace' => [
             'User_simple.php',
             'User_simple_other_namespace.php',
-            (new RelationManyToOne(
+            new RelationManyToOne(
                 propertyName: 'category',
                 targetClassName: \Foo\Entity\Category::class,
                 targetPropertyName: 'foods',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'many_to_one_empty_other_namespace' => [
             'User_empty.php',
             'User_empty_other_namespace.php',
-            (new RelationManyToOne(
+            new RelationManyToOne(
                 propertyName: 'category',
                 targetClassName: \Foo\Entity\Category::class,
                 targetPropertyName: 'foods',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'many_to_one_same_and_other_namespaces' => [
             'User_with_relation.php',
             'User_with_relation_same_and_other_namespaces.php',
-            (new RelationManyToOne(
+            new RelationManyToOne(
                 propertyName: 'subCategory',
                 targetClassName: \App\Entity\SubDirectory\Category::class,
                 targetPropertyName: 'foods',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'many_to_one_no_inverse' => [
             'User_simple.php',
             'User_simple_no_inverse.php',
-            (new RelationManyToOne(
+            new RelationManyToOne(
                 propertyName: 'category',
                 targetClassName: \App\Entity\Category::class,
                 targetPropertyName: 'foods',
                 mapInverseRelation: false,
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
     }
 
@@ -406,10 +406,10 @@ class ClassSourceManipulatorTest extends TestCase
         $expectedPath = __DIR__.'/fixtures/add_one_to_many_relation';
 
         $this->runAddOneToManyRelationTests(
-                file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
-                file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
-                $oneToMany
-            );
+            file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
+            file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
+            $oneToMany
+        );
     }
 
     private function runAddOneToManyRelationTests(string $source, string $expected, RelationOneToMany $oneToMany): void
@@ -425,11 +425,11 @@ class ClassSourceManipulatorTest extends TestCase
         yield 'one_to_many_simple' => [
             'User_simple.php',
             'User_simple.php',
-            (new RelationOneToMany(
+            new RelationOneToMany(
                 propertyName: 'avatarPhotos',
                 targetClassName: \App\Entity\UserAvatarPhoto::class,
                 targetPropertyName: 'user',
-            )),
+            ),
         ];
 
         // interesting also because the source file has its
@@ -437,22 +437,22 @@ class ClassSourceManipulatorTest extends TestCase
         yield 'one_to_many_simple_no_duplicate_use' => [
             'User_with_use_statements.php',
             'User_with_use_statements.php',
-            (new RelationOneToMany(
+            new RelationOneToMany(
                 propertyName: 'avatarPhotos',
                 targetClassName: \App\Entity\UserAvatarPhoto::class,
                 targetPropertyName: 'user',
-            )),
+            ),
         ];
 
         yield 'one_to_many_orphan_removal' => [
             'User_simple.php',
             'User_simple_orphan_removal.php',
-            (new RelationOneToMany(
+            new RelationOneToMany(
                 propertyName: 'avatarPhotos',
                 targetClassName: \App\Entity\UserAvatarPhoto::class,
                 targetPropertyName: 'user',
                 orphanRemoval: true,
-            )),
+            ),
         ];
 
         // todo test existing constructor
@@ -467,10 +467,10 @@ class ClassSourceManipulatorTest extends TestCase
         $expectedPath = __DIR__.'/fixtures/add_many_to_many_relation';
 
         $this->runAddManyToManyRelationTest(
-                file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
-                file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
-                $manyToMany
-            );
+            file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
+            file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
+            $manyToMany
+        );
     }
 
     private function runAddManyToManyRelationTest(string $source, string $expected, RelationManyToMany $manyToMany): void
@@ -486,34 +486,34 @@ class ClassSourceManipulatorTest extends TestCase
         yield 'many_to_many_owning' => [
             'User_simple.php',
             'User_simple_owning.php',
-            (new RelationManyToMany(
+            new RelationManyToMany(
                 propertyName: 'recipes',
                 targetClassName: \App\Entity\Recipe::class,
                 targetPropertyName: 'foods',
                 isOwning: true,
-            )),
+            ),
         ];
 
         yield 'many_to_many_inverse' => [
             'User_simple.php',
             'User_simple_inverse.php',
-            (new RelationManyToMany(
+            new RelationManyToMany(
                 propertyName: 'recipes',
                 targetClassName: \App\Entity\Recipe::class,
                 targetPropertyName: 'foods',
-            )),
+            ),
         ];
 
         yield 'many_to_many_owning_inverse' => [
             'User_simple.php',
             'User_simple_no_inverse.php',
-            (new RelationManyToMany(
+            new RelationManyToMany(
                 propertyName: 'recipes',
                 targetClassName: \App\Entity\Recipe::class,
                 targetPropertyName: 'foods',
                 mapInverseRelation: false,
                 isOwning: true,
-            )),
+            ),
         ];
     }
 
@@ -526,10 +526,10 @@ class ClassSourceManipulatorTest extends TestCase
         $expectedPath = __DIR__.'/fixtures/add_one_to_one_relation';
 
         $this->runAddOneToOneRelation(
-                file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
-                file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
-                $oneToOne
-            );
+            file_get_contents(sprintf('%s/%s', $sourcePath, $sourceFilename)),
+            file_get_contents(sprintf('%s/%s', $expectedPath, $expectedSourceFilename)),
+            $oneToOne
+        );
     }
 
     private function runAddOneToOneRelation(string $source, string $expected, RelationOneToOne $oneToOne): void
@@ -545,94 +545,94 @@ class ClassSourceManipulatorTest extends TestCase
         yield 'one_to_one_owning' => [
             'User_simple.php',
             'User_simple_owning.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'userProfile',
                 targetClassName: \App\Entity\UserProfile::class,
                 targetPropertyName: 'user',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         // a relationship to yourself - return type is self
         yield 'one_to_one_owning_self' => [
             'User_simple.php',
             'User_simple_self.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'embeddedUser',
                 targetClassName: \App\Entity\User::class,
                 targetPropertyName: 'user',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'one_to_one_inverse' => [
             'UserProfile_simple.php',
             'UserProfile_simple_inverse.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'user',
                 targetClassName: \App\Entity\User::class,
                 targetPropertyName: 'userProfile',
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'one_to_one_inverse_not_nullable' => [
             'UserProfile_simple.php',
             'UserProfile_simple_inverse_not_nullable.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'user',
                 targetClassName: \App\Entity\User::class,
                 targetPropertyName: 'userProfile',
-            )),
+            ),
         ];
 
         yield 'one_to_one_no_inverse' => [
             'User_simple.php',
             'User_simple_no_inverse.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'userProfile',
                 targetClassName: \App\Entity\UserProfile::class,
                 mapInverseRelation: false,
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'one_to_one_no_inverse_not_nullable' => [
             'User_simple.php',
             'User_simple_no_inverse_not_nullable.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'userProfile',
                 targetClassName: \App\Entity\UserProfile::class,
                 mapInverseRelation: false,
                 isOwning: true,
-            )),
+            ),
         ];
 
         yield 'avoid_duplicate_use_statement' => [
             'User_with_use_statements.php',
             'User_with_use_statements_avoid_duplicate_use.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'userProfile',
                 targetClassName: \App\OtherEntity\UserProfile::class,
                 targetPropertyName: 'user',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
 
         yield 'avoid_duplicate_use_statement_with_alias' => [
             'User_with_use_statements.php',
             'User_with_use_statements_avoid_duplicate_use_alias.php',
-            (new RelationOneToOne(
+            new RelationOneToOne(
                 propertyName: 'category',
                 targetClassName: \App\OtherEntity\Category::class,
                 targetPropertyName: 'user',
                 isOwning: true,
                 isNullable: true,
-            )),
+            ),
         ];
     }
 
@@ -675,7 +675,7 @@ class ClassSourceManipulatorTest extends TestCase
                 <?php
                 $this->someParam = $someParam;
                 CODE
-);
+        );
 
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
     }
@@ -692,10 +692,10 @@ class ClassSourceManipulatorTest extends TestCase
             (new Param('param'))->setTypeHint('string')
         );
         $manipulator->addMethodBody($methodBuilder,
-<<<'CODE'
-    <?php
-    return new JsonResponse(['param' => $param]);
-    CODE
+            <<<'CODE'
+                <?php
+                return new JsonResponse(['param' => $param]);
+                CODE
         );
         $manipulator->addMethodBuilder($methodBuilder);
         $manipulator->addUseStatementIfNecessary('Symfony\\Component\\HttpFoundation\\JsonResponse');

--- a/tests/Util/MakerFileLinkFormatterTest.php
+++ b/tests/Util/MakerFileLinkFormatterTest.php
@@ -50,8 +50,8 @@ final class MakerFileLinkFormatterTest extends TestCase
 
         $sut = new MakerFileLinkFormatter($fileLinkFormatter);
         $this->assertEquals(
-           $expectedOutput,
-           $sut->makeLinkedPath('/my/absolute/path', './my/relative/path')
-       );
+            $expectedOutput,
+            $sut->makeLinkedPath('/my/absolute/path', './my/relative/path')
+        );
     }
 }

--- a/tests/Util/YamlSourceManipulatorTest.php
+++ b/tests/Util/YamlSourceManipulatorTest.php
@@ -59,7 +59,7 @@ class YamlSourceManipulatorTest extends TestCase
             [$source, $changeCode, $expected] = explode('===', $file->getContents());
 
             // Multiline string ends with an \n
-            $source = substr_replace($source, '', (\strlen($source) - 1));
+            $source = substr_replace($source, '', \strlen($source) - 1);
             $expected = ltrim($expected, "\n");
 
             $data = Yaml::parse($source);

--- a/tests/Util/fixtures/add_class_attribute/User_simple.php
+++ b/tests/Util/fixtures/add_class_attribute/User_simple.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Column;
 
@@ -12,8 +11,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_class_attribute/User_simple.php
+++ b/tests/Util/fixtures/add_class_attribute/User_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Column;
 
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_constructor/UserSimple_with_constructor.php
+++ b/tests/Util/fixtures/add_constructor/UserSimple_with_constructor.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function __construct(object $someObjectParam, string $someStringParam)

--- a/tests/Util/fixtures/add_constructor/UserSimple_with_constructor.php
+++ b/tests/Util/fixtures/add_constructor/UserSimple_with_constructor.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function __construct(object $someObjectParam, string $someStringParam)
     {

--- a/tests/Util/fixtures/add_entity_field/User_simple.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: false, options: ['comment' => 'new field'])]
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: false, options: ['comment' => 'new field'])]
     private $fooProp;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_entity_field/User_simple.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255, nullable: false, options: ['comment' => 'new field'])]
-    private $fooProp;
+    #[ORM\Column(length: 255, nullable: false, options: ['comment' => 'new field'])]
+    private ?string $fooProp = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_entity_field/User_simple_datetime.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_datetime.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private $createdAt;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_entity_field/User_simple_datetime.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_datetime.php
@@ -10,11 +10,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $createdAt;
+    private ?\DateTimeInterface $createdAt = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_entity_field/User_simple_object.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_object.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'object')]
+    #[ORM\Column(type: Types::OBJECT)]
     private $someObject;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_entity_field/User_simple_object.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_object.php
@@ -10,11 +10,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\Column(type: Types::OBJECT)]
-    private $someObject;
+    private ?object $someObject = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_entity_field/User_simple_prop_already_exists.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_prop_already_exists.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\Column]

--- a/tests/Util/fixtures/add_entity_field/User_simple_prop_already_exists.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_prop_already_exists.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\Column]
-    private $firstName;
+    private ?string $firstName = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_entity_field/User_simple_prop_zero.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_prop_zero.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'decimal', precision: 6, scale: 0)]
+    #[ORM\Column(type: Types::DECIMAL, precision: 6, scale: 0)]
     private $decimal;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_entity_field/User_simple_prop_zero.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_prop_zero.php
@@ -10,11 +10,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 6, scale: 0)]
-    private $decimal;
+    private ?string $decimal = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_entity_field/User_simple_ulid.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_ulid.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Ulid;
 
@@ -11,11 +10,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::ULID)]
-    private $ulid;
+    #[ORM\Column(type: 'ulid')]
+    private ?Ulid $ulid = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_entity_field/User_simple_ulid.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_ulid.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Ulid;
 
@@ -10,10 +11,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'ulid')]
+    #[ORM\Column(type: Types::ULID)]
     private $ulid;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_entity_field/User_simple_uuid.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_uuid.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
@@ -10,10 +11,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'uuid')]
+    #[ORM\Column(type: Types::UUID)]
     private $uuid;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_entity_field/User_simple_uuid.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_uuid.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
@@ -11,11 +10,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::UUID)]
-    private $uuid;
+    #[ORM\Column(type: 'uuid')]
+    private ?Uuid $uuid = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_getter/User_simple.php
+++ b/tests/Util/fixtures/add_getter/User_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_getter/User_simple.php
+++ b/tests/Util/fixtures/add_getter/User_simple.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_getter/User_simple_bool.php
+++ b/tests/Util/fixtures/add_getter/User_simple_bool.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_getter/User_simple_bool.php
+++ b/tests/Util/fixtures/add_getter/User_simple_bool.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToMany(targetEntity: Recipe::class, mappedBy: 'foods')]

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -12,11 +11,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\ManyToMany(targetEntity: Recipe::class, mappedBy: 'foods')]
-    private $recipes;
+    private Collection $recipes;
 
     public function __construct()
     {

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_no_inverse.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_no_inverse.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToMany(targetEntity: Recipe::class)]

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_no_inverse.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_no_inverse.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -12,11 +11,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\ManyToMany(targetEntity: Recipe::class)]
-    private $recipes;
+    private Collection $recipes;
 
     public function __construct()
     {

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_owning.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_owning.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -12,11 +11,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\ManyToMany(targetEntity: Recipe::class, inversedBy: 'foods')]
-    private $recipes;
+    private Collection $recipes;
 
     public function __construct()
     {

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_owning.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_owning.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToMany(targetEntity: Recipe::class, inversedBy: 'foods')]

--- a/tests/Util/fixtures/add_many_to_one_relation/User_empty_other_namespace.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_empty_other_namespace.php
@@ -6,8 +6,8 @@ use Foo\Entity\Category;
 
 class User
 {
-    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]
-    private $category;
+    #[ORM\ManyToOne(inversedBy: 'foods')]
+    private ?Category $category = null;
 
     public function getCategory(): ?Category
     {

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_no_inverse.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_no_inverse.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: Category::class)]
-    private $category;
+    #[ORM\ManyToOne]
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_no_inverse.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_no_inverse.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: Category::class)]

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_not_nullable.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_not_nullable.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_not_nullable.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_not_nullable.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,12 +9,12 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]
+    #[ORM\ManyToOne(inversedBy: 'foods')]
     #[ORM\JoinColumn(nullable: false)]
-    private $category;
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_nullable.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_nullable.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_nullable.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_nullable.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]
-    private $category;
+    #[ORM\ManyToOne(inversedBy: 'foods')]
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_other_namespace.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_other_namespace.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Foo\Entity\Category;
 
@@ -11,11 +10,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]
-    private $category;
+    #[ORM\ManyToOne(inversedBy: 'foods')]
+    private ?Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_other_namespace.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_other_namespace.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Foo\Entity\Category;
 
@@ -10,7 +11,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]

--- a/tests/Util/fixtures/add_many_to_one_relation/User_with_relation_same_and_other_namespaces.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_with_relation_same_and_other_namespaces.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Category;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Util/fixtures/add_many_to_one_relation/User_with_relation_same_and_other_namespaces.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_with_relation_same_and_other_namespaces.php
@@ -3,17 +3,16 @@
 namespace App\Entity;
 
 use App\Entity\Category;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
 class User
 {
-    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]
-    private $category;
+    #[ORM\ManyToOne(inversedBy: 'foods')]
+    private ?Category $category = null;
 
-    #[ORM\ManyToOne(targetEntity: \App\Entity\SubDirectory\Category::class, inversedBy: 'foods')]
-    private $subCategory;
+    #[ORM\ManyToOne(inversedBy: 'foods')]
+    private ?\App\Entity\SubDirectory\Category $subCategory = null;
 
     public function getCategory(): ?Category
     {

--- a/tests/Util/fixtures/add_one_to_many_relation/User_simple.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_simple.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserAvatarPhoto::class)]

--- a/tests/Util/fixtures/add_one_to_many_relation/User_simple.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_simple.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -12,11 +11,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserAvatarPhoto::class)]
-    private $avatarPhotos;
+    private Collection $avatarPhotos;
 
     public function __construct()
     {

--- a/tests/Util/fixtures/add_one_to_many_relation/User_simple_orphan_removal.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_simple_orphan_removal.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -12,11 +11,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserAvatarPhoto::class, orphanRemoval: true)]
-    private $avatarPhotos;
+    private Collection $avatarPhotos;
 
     public function __construct()
     {

--- a/tests/Util/fixtures/add_one_to_many_relation/User_simple_orphan_removal.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_simple_orphan_removal.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -11,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserAvatarPhoto::class, orphanRemoval: true)]

--- a/tests/Util/fixtures/add_one_to_many_relation/User_with_use_statements.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_with_use_statements.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Some\Other\UserProfile;
@@ -13,7 +14,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserAvatarPhoto::class)]

--- a/tests/Util/fixtures/add_one_to_many_relation/User_with_use_statements.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_with_use_statements.php
@@ -14,11 +14,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserAvatarPhoto::class)]
-    private $avatarPhotos;
+    private Collection $avatarPhotos;
 
     public function __construct()
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse.php
@@ -10,11 +10,11 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(mappedBy: 'userProfile', targetEntity: User::class, cascade: ['persist', 'remove'])]
-    private $user;
+    #[ORM\OneToOne(mappedBy: 'userProfile', cascade: ['persist', 'remove'])]
+    private ?User $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(mappedBy: 'userProfile', targetEntity: User::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse_not_nullable.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse_not_nullable.php
@@ -10,11 +10,11 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(mappedBy: 'userProfile', targetEntity: User::class, cascade: ['persist', 'remove'])]
-    private $user;
+    #[ORM\OneToOne(mappedBy: 'userProfile', cascade: ['persist', 'remove'])]
+    private ?User $user = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse_not_nullable.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/UserProfile_simple_inverse_not_nullable.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(mappedBy: 'userProfile', targetEntity: User::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(targetEntity: UserProfile::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(targetEntity: UserProfile::class, cascade: ['persist', 'remove'])]
-    private $userProfile;
+    #[ORM\OneToOne(cascade: ['persist', 'remove'])]
+    private ?UserProfile $userProfile = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse_not_nullable.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse_not_nullable.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(targetEntity: UserProfile::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse_not_nullable.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_no_inverse_not_nullable.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,12 +9,12 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(targetEntity: UserProfile::class, cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $userProfile;
+    private ?UserProfile $userProfile = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_owning.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_owning.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(inversedBy: 'user', targetEntity: UserProfile::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_owning.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_owning.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(inversedBy: 'user', targetEntity: UserProfile::class, cascade: ['persist', 'remove'])]
-    private $userProfile;
+    #[ORM\OneToOne(inversedBy: 'user', cascade: ['persist', 'remove'])]
+    private ?UserProfile $userProfile = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
@@ -12,7 +12,7 @@ class User
     #[ORM\Column()]
     private ?int $id = null;
 
-    #[ORM\OneToOne(inversedBy: 'user', targetEntity: User::class, cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(inversedBy: 'user', targetEntity: self::class, cascade: ['persist', 'remove'])]
     private ?self $embeddedUser = null;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(inversedBy: 'user', targetEntity: self::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
@@ -12,7 +12,7 @@ class User
     #[ORM\Column()]
     private ?int $id = null;
 
-    #[ORM\OneToOne(inversedBy: 'user', cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(inversedBy: 'user', targetEntity: User::class, cascade: ['persist', 'remove'])]
     private ?self $embeddedUser = null;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_simple_self.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(inversedBy: 'user', targetEntity: self::class, cascade: ['persist', 'remove'])]
-    private $embeddedUser;
+    #[ORM\OneToOne(inversedBy: 'user', cascade: ['persist', 'remove'])]
+    private ?self $embeddedUser = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use.php
@@ -13,11 +13,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(inversedBy: 'user', targetEntity: \App\OtherEntity\UserProfile::class, cascade: ['persist', 'remove'])]
-    private $userProfile;
+    #[ORM\OneToOne(inversedBy: 'user', cascade: ['persist', 'remove'])]
+    private ?\App\OtherEntity\UserProfile $userProfile = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Some\Other\UserProfile;
@@ -12,7 +13,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(inversedBy: 'user', targetEntity: \App\OtherEntity\UserProfile::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use_alias.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use_alias.php
@@ -13,11 +13,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\OneToOne(inversedBy: 'user', targetEntity: \App\OtherEntity\Category::class, cascade: ['persist', 'remove'])]
-    private $category;
+    #[ORM\OneToOne(inversedBy: 'user', cascade: ['persist', 'remove'])]
+    private ?\App\OtherEntity\Category $category = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use_alias.php
+++ b/tests/Util/fixtures/add_one_to_one_relation/User_with_use_statements_avoid_duplicate_use_alias.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Some\Other\UserProfile;
@@ -12,7 +13,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\OneToOne(inversedBy: 'user', targetEntity: \App\OtherEntity\Category::class, cascade: ['persist', 'remove'])]

--- a/tests/Util/fixtures/add_property/User_simple.php
+++ b/tests/Util/fixtures/add_property/User_simple.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     private $fooProp;
 

--- a/tests/Util/fixtures/add_property/User_simple.php
+++ b/tests/Util/fixtures/add_property/User_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     private $fooProp;

--- a/tests/Util/fixtures/add_setter/User_simple.php
+++ b/tests/Util/fixtures/add_setter/User_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_setter/User_simple.php
+++ b/tests/Util/fixtures/add_setter/User_simple.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/add_trait/User_with_prop_trait.php
+++ b/tests/Util/fixtures/add_trait/User_with_prop_trait.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\TestTrait;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -12,7 +13,7 @@ class User
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/add_trait/User_with_prop_trait.php
+++ b/tests/Util/fixtures/add_trait/User_with_prop_trait.php
@@ -3,7 +3,6 @@
 namespace App\Entity;
 
 use App\TestTrait;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -13,8 +12,8 @@ class User
 
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/implements_interface/User_simple.php
+++ b/tests/Util/fixtures/implements_interface/User_simple.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -11,8 +10,8 @@ class User implements UserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/implements_interface/User_simple.php
+++ b/tests/Util/fixtures/implements_interface/User_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -10,7 +11,7 @@ class User implements UserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/implements_interface/User_simple_with_interface.php
+++ b/tests/Util/fixtures/implements_interface/User_simple_with_interface.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -11,8 +10,8 @@ class User implements DummyInterface, UserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/implements_interface/User_simple_with_interface.php
+++ b/tests/Util/fixtures/implements_interface/User_simple_with_interface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -10,7 +11,7 @@ class User implements DummyInterface, UserInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/source/UserProfile_simple.php
+++ b/tests/Util/fixtures/source/UserProfile_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Util/fixtures/source/UserProfile_simple.php
+++ b/tests/Util/fixtures/source/UserProfile_simple.php
@@ -9,7 +9,7 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/source/UserProfile_simple.php
+++ b/tests/Util/fixtures/source/UserProfile_simple.php
@@ -10,8 +10,8 @@ class UserProfile
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/source/User_only_props.php
+++ b/tests/Util/fixtures/source/User_only_props.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     /**

--- a/tests/Util/fixtures/source/User_only_props.php
+++ b/tests/Util/fixtures/source/User_only_props.php
@@ -10,8 +10,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     /**
      * @ORM\Column()

--- a/tests/Util/fixtures/source/User_simple.php
+++ b/tests/Util/fixtures/source/User_simple.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Util/fixtures/source/User_simple.php
+++ b/tests/Util/fixtures/source/User_simple.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/source/User_simple.php
+++ b/tests/Util/fixtures/source/User_simple.php
@@ -9,7 +9,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/source/User_simple_with_interface.php
+++ b/tests/Util/fixtures/source/User_simple_with_interface.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User implements DummyInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/source/User_simple_with_interface.php
+++ b/tests/Util/fixtures/source/User_simple_with_interface.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User implements DummyInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/source/User_some_props.php
+++ b/tests/Util/fixtures/source/User_some_props.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Util/fixtures/source/User_some_props.php
+++ b/tests/Util/fixtures/source/User_some_props.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     #[ORM\Column]
-    private $firstName;
+    private ?string $firstName = null;
 
     public function getId(): ?int
     {

--- a/tests/Util/fixtures/source/User_some_props.php
+++ b/tests/Util/fixtures/source/User_some_props.php
@@ -9,7 +9,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\Column]

--- a/tests/Util/fixtures/source/User_with_relation.php
+++ b/tests/Util/fixtures/source/User_with_relation.php
@@ -3,14 +3,13 @@
 namespace App\Entity;
 
 use App\Entity\Category;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
 class User
 {
-    #[ORM\ManyToOne(targetEntity: Category::class, inversedBy: 'foods')]
-    private $category;
+    #[ORM\ManyToOne(inversedBy: 'foods')]
+    private ?Category $category = null;
 
     public function getCategory(): ?Category
     {

--- a/tests/Util/fixtures/source/User_with_relation.php
+++ b/tests/Util/fixtures/source/User_with_relation.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Category;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/Util/fixtures/source/User_with_use_statements.php
+++ b/tests/Util/fixtures/source/User_with_use_statements.php
@@ -12,7 +12,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId(): ?int

--- a/tests/Util/fixtures/source/User_with_use_statements.php
+++ b/tests/Util/fixtures/source/User_with_use_statements.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Some\Other\UserProfile;

--- a/tests/Util/fixtures/source/User_with_use_statements.php
+++ b/tests/Util/fixtures/source/User_with_use_statements.php
@@ -13,8 +13,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/fixtures/make-crud/SweetFood-custom-namespace.php
+++ b/tests/fixtures/make-crud/SweetFood-custom-namespace.php
@@ -9,11 +9,11 @@ class SweetFood
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 255)]
-    private $title;
+    #[ORM\Column(length: 255)]
+    private ?string $title = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-crud/SweetFood.php
+++ b/tests/fixtures/make-crud/SweetFood.php
@@ -9,11 +9,11 @@ class SweetFood
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 255)]
-    private $title;
+    #[ORM\Column(length: 255)]
+    private ?string $title = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-crud/SweetFoodCustomRepository.php
+++ b/tests/fixtures/make-crud/SweetFoodCustomRepository.php
@@ -10,11 +10,11 @@ class SweetFood
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: 'string', length: 255)]
-    private $title;
+    #[ORM\Column(length: 255)]
+    private ?string $title = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/entities/attributes/User-basic.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-basic.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
-    private $firstName;
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $firstName = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/entities/attributes/User-basic.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-basic.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
     private $firstName;
 
     public function getId()

--- a/tests/fixtures/make-entity/entities/attributes/User-custom-namespace.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-custom-namespace.php
@@ -2,7 +2,6 @@
 
 namespace Custom\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/fixtures/make-entity/entities/attributes/User-custom-namespace.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-custom-namespace.php
@@ -2,6 +2,7 @@
 
 namespace Custom\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,13 +10,13 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
     private $firstName;
 
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private $createdAt;
 
     public function getId()

--- a/tests/fixtures/make-entity/entities/attributes/User-custom-namespace.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-custom-namespace.php
@@ -10,14 +10,14 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
-    private $firstName;
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $firstName = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $createdAt;
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeInterface $createdAt = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/entities/attributes/User-invalid-method-no-property.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-invalid-method-no-property.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId()

--- a/tests/fixtures/make-entity/entities/attributes/User-invalid-method-no-property.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-invalid-method-no-property.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/entities/attributes/User-invalid-method.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-invalid-method.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,11 +9,11 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
-    private $firstName;
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $firstName = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/entities/attributes/User-invalid-method.php
+++ b/tests/fixtures/make-entity/entities/attributes/User-invalid-method.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
     private $firstName;
 
     public function getId()

--- a/tests/fixtures/make-entity/entities/attributes/UserAvatarPhoto-basic.php
+++ b/tests/fixtures/make-entity/entities/attributes/UserAvatarPhoto-basic.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserAvatarPhoto
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     public function getId()

--- a/tests/fixtures/make-entity/entities/attributes/UserAvatarPhoto-basic.php
+++ b/tests/fixtures/make-entity/entities/attributes/UserAvatarPhoto-basic.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -10,8 +9,8 @@ class UserAvatarPhoto
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Food.php
+++ b/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Food.php
@@ -10,12 +10,12 @@ class Food
 {
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    #[ORM\Column(name: 'id', type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column(name: 'id')]
+    private ?int $id = null;
 
-    #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
-    private $title;
+    #[ORM\Column(name: 'title', length: 255)]
+    private ?string $title = null;
 
-    #[ORM\Embedded(class: Recipe::class)]
-    private $recipe;
+    #[ORM\Embedded()]
+    private Recipe $recipe;
 }

--- a/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Food.php
+++ b/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Food.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class Food
 {
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\Column(name: 'id', type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(name: 'title', type: 'string', length: 255)]
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
     private $title;
 
     #[ORM\Embedded(class: Recipe::class)]

--- a/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Food.php
+++ b/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Food.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Recipe.php
+++ b/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Recipe.php
@@ -2,14 +2,15 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
 class Recipe
 {
-    #[ORM\Column(type: 'string', length: 255)]
+    #[ORM\Column(type: Types::STRING, length: 255)]
     private $ingredients;
 
-    #[ORM\Column(type: 'string', length: 255)]
+    #[ORM\Column(type: Types::STRING, length: 255)]
     private $steps;
 }

--- a/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Recipe.php
+++ b/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Recipe.php
@@ -8,9 +8,9 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Embeddable]
 class Recipe
 {
-    #[ORM\Column(type: Types::STRING, length: 255)]
-    private $ingredients;
+    #[ORM\Column()]
+    private ?string $ingredients = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255)]
-    private $steps;
+    #[ORM\Column()]
+    private ?string $steps = null;
 }

--- a/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Recipe.php
+++ b/tests/fixtures/make-entity/regenerate-embeddable/attributes/src/Entity/Recipe.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Currency.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Currency.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
@@ -10,7 +11,7 @@ class Currency
     /**
      * @var string
      */
-    #[ORM\Column(type: 'string', name: 'currency')]
+    #[ORM\Column(type: Types::STRING, name: 'currency')]
     private $currency;
 
     public function __construct($currency = null)

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Currency.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Currency.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Currency.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Currency.php
@@ -11,8 +11,8 @@ class Currency
     /**
      * @var string
      */
-    #[ORM\Column(type: Types::STRING, name: 'currency')]
-    private $currency;
+    #[ORM\Column()]
+    private ?string $currency = null;
 
     public function __construct($currency = null)
     {

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Invoice.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Invoice.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,10 +10,10 @@ class Invoice
 {
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255, name: 'title')]
+    #[ORM\Column(type: Types::STRING, length: 255, name: 'title')]
     private $title;
 
     #[ORM\Embedded(class: Money::class)]

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Invoice.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Invoice.php
@@ -10,12 +10,12 @@ class Invoice
 {
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255, name: 'title')]
-    private $title;
+    #[ORM\Column(length: 255, name: 'title')]
+    private ?string $title = null;
 
-    #[ORM\Embedded(class: Money::class)]
-    private $total;
+    #[ORM\Embedded()]
+    private Money $total;
 }

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Invoice.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Invoice.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
@@ -11,14 +11,14 @@ class Money
     /**
      * @var Currency
      */
-    #[ORM\Embedded(class: Currency::class)]
-    private $currency;
+    #[ORM\Embedded()]
+    private Currency $currency;
 
     /**
      * @var int
      */
-    #[ORM\Column(name: 'amount', type: Types::INTEGER)]
-    private $amount;
+    #[ORM\Column(name: 'amount')]
+    private int $amount;
 
     public function __construct($amount = null, Currency $currency = null)
     {

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
@@ -18,7 +17,7 @@ class Money
      * @var int
      */
     #[ORM\Column(name: 'amount')]
-    private int $amount;
+    private ?int $amount;
 
     public function __construct($amount = null, Currency $currency = null)
     {

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Embeddable]
@@ -16,7 +17,7 @@ class Money
     /**
      * @var int
      */
-    #[ORM\Column(name: 'amount', type: 'integer')]
+    #[ORM\Column(name: 'amount', type: Types::INTEGER)]
     private $amount;
 
     public function __construct($amount = null, Currency $currency = null)

--- a/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
+++ b/tests/fixtures/make-entity/regenerate-embedded/attributes/src/Entity/Money.php
@@ -7,9 +7,6 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Embeddable]
 class Money
 {
-    /**
-     * @var Currency
-     */
     #[ORM\Embedded()]
     private Currency $currency;
 

--- a/tests/fixtures/make-entity/regenerate/attributes/src/Entity/User.php
+++ b/tests/fixtures/make-entity/regenerate/attributes/src/Entity/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,13 +10,13 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
     private $firstName;
 
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private $createdAt;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]

--- a/tests/fixtures/make-entity/regenerate/attributes/src/Entity/User.php
+++ b/tests/fixtures/make-entity/regenerate/attributes/src/Entity/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -10,17 +11,17 @@ class User
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\Column(type: Types::STRING, length: 255, nullable: true)]
-    private $firstName;
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $firstName = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private $createdAt;
+    private ?\DateTimeInterface $createdAt = null;
 
     #[ORM\OneToMany(targetEntity: UserAvatar::class, mappedBy: 'user')]
-    private $avatars;
+    private Collection $avatars;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/regenerate/attributes/src/Entity/UserAvatar.php
+++ b/tests/fixtures/make-entity/regenerate/attributes/src/Entity/UserAvatar.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -9,7 +10,7 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    #[ORM\Column(type: Types::INTEGER)]
     private $id;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]

--- a/tests/fixtures/make-entity/regenerate/attributes/src/Entity/UserAvatar.php
+++ b/tests/fixtures/make-entity/regenerate/attributes/src/Entity/UserAvatar.php
@@ -10,12 +10,12 @@ class UserAvatar
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
-    #[ORM\Column(type: Types::INTEGER)]
-    private $id;
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'avatars', cascade: ['persist', 'remove'])]
+    #[ORM\ManyToOne(inversedBy: 'avatars', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
-    private $user;
+    private ?User $user = null;
 
     public function getId()
     {

--- a/tests/fixtures/make-entity/regenerate/attributes/src/Entity/UserAvatar.php
+++ b/tests/fixtures/make-entity/regenerate/attributes/src/Entity/UserAvatar.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]

--- a/tests/fixtures/make-form/Property.php
+++ b/tests/fixtures/make-form/Property.php
@@ -4,23 +4,18 @@ namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Property
 {
-    /**
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
 
     /**
      * Many Features have One Product.
-     *
-     * @ORM\ManyToOne(targetEntity=SourFood::class, inversedBy="properties")
-     * @ORM\JoinColumn(name="sour_food_id", referencedColumnName="id")
      */
-    private $sourFood;
+    #[ORM\ManyToOne(inversedBy: 'properties')]
+    #[ORM\JoinColumn(name: 'sour_food_id', referencedColumnName: 'id')]
+    private ?SourFood $sourFood = null;
 }

--- a/tests/fixtures/make-form/SourFood.php
+++ b/tests/fixtures/make-form/SourFood.php
@@ -3,29 +3,22 @@
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity()
- */
+#[ORM\Entity]
 class SourFood
 {
-    /**
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    /**
-     * @ORM\Column(name="title", type="string", length=255)
-     */
-    private $title;
+    #[ORM\Column(name: 'title', length: 255)]
+    private ?string $title = null;
 
-    /**
-     * @ORM\OneToMany(targetEntity=Property::class, mappedBy="sourFood")
-     */
-    private $properties;
+    #[ORM\OneToMany(targetEntity: Property::class, mappedBy: 'sourFood')]
+    private Collection $properties;
 
     public function __construct()
     {

--- a/tests/fixtures/make-form/embeddable/Food.php
+++ b/tests/fixtures/make-form/embeddable/Food.php
@@ -4,22 +4,16 @@ namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity()
- */
+#[ORM\Entity]
 class Food
 {
-    /**
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    /**
-     * @ORM\Column(name="title", type="string", length=255)
-     */
-    private $title;
+    #[ORM\Column]
+    private ?string $title = null;
 
     /**
      * @ORM\Embedded(class=Receipt::class)

--- a/tests/fixtures/make-form/inheritance/Food.php
+++ b/tests/fixtures/make-form/inheritance/Food.php
@@ -4,25 +4,19 @@ namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity()
- * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorColumn(name="food_type", type="string", length=250)
- * @ORM\DiscriminatorMap({"food" = "Food", "sour_food" = "SourFood"})
- */
+#[ORM\Entity]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'food_type', type: 'string', length: 250)]
+#[ORM\DiscriminatorMap(['food' => 'Food', 'sour_food' => 'SourFood'])]
 class Food
 {
-    /**
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
 
-    /**
-     * @ORM\Column(name="title", type="string", length=255)
-     */
-    private $title;
+    #[ORM\Column]
+    private ?string $title = null;
 
     /**
      * @return mixed

--- a/tests/fixtures/make-form/inheritance/SourFood.php
+++ b/tests/fixtures/make-form/inheritance/SourFood.php
@@ -4,9 +4,7 @@ namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity()
- */
+#[ORM\Entity]
 class SourFood extends Food
 {
 }

--- a/tests/fixtures/make-migration/SpicyFood.php
+++ b/tests/fixtures/make-migration/SpicyFood.php
@@ -4,15 +4,11 @@ namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity()
- */
+#[ORM\Entity]
 class SpicyFood
 {
-    /**
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
 }


### PR DESCRIPTION
Hi!

This expands on the excellent work in #1039. This adds to `make:entity`:

A) Property types - e.g. `private ?int $id = null`. Most property types are nullable and default to null, effectively making them typed, but identical to how things worked before (before types, properties were naturally nullable and defaulted to null).

B) Removes *most* `type:` options in `ORM\Column` as these are now "guessed" since doctrine/orm 2.9 from the property types.

C) For the few `type:` options that remain, we use a `Types::` constant.

Cheers!