### PR TITLE
WIP - [ci] use github actions for windows ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,5 +156,5 @@ jobs:
             - name: "PHPUnit version"
               run: vendor/bin/simple-phpunit --version
 
-            - name: "Run tests"
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+#            - name: "Run tests"
+#              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -77,7 +77,8 @@ jobs:
             - name: "Setup MySQL"
               uses: ankane/setup-mysql@v1
               with:
-                  mysql-version: 5.4
+                  mysql-version: 5.6
+                  database: test_maker
 
             - name: "Verify MySQL connection from host"
               run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -70,9 +70,9 @@ jobs:
             - name: "Checkout code"
               uses: actions/checkout@v2.3.3
 
-            - name: "Start MySQL"
-              run: |
-                  sudo /etc/init.d/mysql start
+#            - name: "Start MySQL"
+#              run: |
+#                  sudo /etc/init.d/mysql start
 
             - name: "Verify MySQL connection from host"
               run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -69,6 +69,7 @@ jobs:
 #                      dependency-versions: 'highest'
 
         steps:
+              # This is needed in Windows, otherwise assertions comparing fixtures and generated code will fail.
             - name: "Use INPUT for autocrlf in Git Config"
               run: git config --global core.autocrlf input
 
@@ -81,7 +82,7 @@ jobs:
 
             - name: "Setup MySQL"
               run: |
-                  choco install mysql --version=5.7.18
+                  choco install mysql
 
             - name: "Set MySQL Root Password"
               run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "Windows Builds"
 
 on:
     pull_request:
@@ -13,53 +13,10 @@ env:
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
 
 jobs:
-    coding-standards:
-        name: "Coding Standards (${{ matrix.php-version }})"
-
-        runs-on: "windows-latest"
-
-        strategy:
-            fail-fast: false
-            matrix:
-                php-version:
-                    - '8.0'
-
-        steps:
-            -
-                name: "Checkout code"
-                uses: "actions/checkout@v2"
-
-            -
-                name: "Install PHP"
-                uses: "shivammathur/setup-php@v2"
-                with:
-                    coverage: "none"
-                    php-version: "${{ matrix.php-version }}"
-
-            -
-                name: "Validate composer.json"
-                run: "composer validate --strict --no-check-lock"
-
-            -
-                name: "Composer install"
-                uses: "ramsey/composer-install@v1"
-                with:
-                    composer-options: "--no-scripts"
-
-            -
-                name: "Composer install php-cs-fixer"
-                uses: "ramsey/composer-install@v1"
-                with:
-                    composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
-
-            -
-                name: "Run friendsofphp/php-cs-fixer"
-                run: "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff"
-
     test:
         name: "PHP ${{ matrix.php-version }} + @${{ matrix.symfony-version }} ${{ matrix.dependency-versions }} deps"
 
-        runs-on: ubuntu-18.04
+        runs-on: windows-latest
 
         services:
             mysql:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -131,5 +131,5 @@ jobs:
 #            - name: "List Windows Env"
 #              run: "Get-ChildItem Env: | Format-Table -Wrap -AutoSize"
 #
-#            - name: "Run tests"
-#              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+            - name: "Run tests"
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -78,7 +78,7 @@ jobs:
 
             - name: "Setup MySQL"
               run: |
-                  choco install mysql --version=5.7
+                  choco install mysql --version=5.7.18
 
             - name: "Set MySQL Root Password"
               run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -74,6 +74,11 @@ jobs:
 #              run: |
 #                  sudo /etc/init.d/mysql start
 
+            - name: "Setup MySQL"
+              uses: ankane/setup-mysql@v1
+              with:
+                  mysql-version: 5.4
+
             - name: "Verify MySQL connection from host"
               run: |
                   mysql --host 127.0.0.1 --port 3306 -uroot -proot -e "SHOW DATABASES;"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -17,27 +17,27 @@ jobs:
         name: "PHP ${{ matrix.php-version }} + @${{ matrix.symfony-version }} ${{ matrix.dependency-versions }} deps"
 
         runs-on: windows-latest
-
-        services:
-            mysql:
-                image: mysql:5.7 # Update server_version in phpunit.xml.dist if this changes.
-                env:
-                    MYSQL_ROOT_PASSWORD: root
-                    MYSQL_DATABASE: test_maker
-                ports:
-                    - 3306
-                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-            mercure:
-                image: dunglas/mercure
-                env:
-                    SERVER_NAME: :1337
-                    MERCURE_PUBLISHER_JWT_KEY: '!ChangeMe!'
-                    MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeMe!'
-                    MERCURE_EXTRA_DIRECTIVES: |
-                        anonymous
-                        cors_origins *
-                ports:
-                    - 1337:1337
+#
+#        services:
+#            mysql:
+#                image: mysql:5.7 # Update server_version in phpunit.xml.dist if this changes.
+#                env:
+#                    MYSQL_ROOT_PASSWORD: root
+#                    MYSQL_DATABASE: test_maker
+#                ports:
+#                    - 3306
+#                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+#            mercure:
+#                image: dunglas/mercure
+#                env:
+#                    SERVER_NAME: :1337
+#                    MERCURE_PUBLISHER_JWT_KEY: '!ChangeMe!'
+#                    MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeMe!'
+#                    MERCURE_EXTRA_DIRECTIVES: |
+#                        anonymous
+#                        cors_origins *
+#                ports:
+#                    - 1337:1337
 
         env:
             SYMFONY_VERSION: ${{ matrix.symfony-version }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -130,5 +130,5 @@ jobs:
 #            - name: "List Windows Env"
 #              run: "Get-ChildItem Env: | Format-Table -Wrap -AutoSize"
 #
-            - name: "Run tests"
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+#            - name: "Run tests"
+#              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -9,7 +9,7 @@ on:
 #        -   cron: '0 0 * * *'
 
 env:
-    PHPUNIT_FLAGS: "-v"
+    PHPUNIT_FLAGS: "-vvv"
 #    SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
     MAKER_DISABLE_FILE_LINKS: 1
     MAKER_SKIP_MERCURE_TEST: 1
@@ -136,4 +136,4 @@ jobs:
 #              run: "Get-ChildItem Env: | Format-Table -Wrap -AutoSize"
 #
             - name: "Run tests"
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }} --filter auth_empty_one_firewall

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,6 +11,8 @@ on:
 env:
     PHPUNIT_FLAGS: "-v"
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
+    MAKER_DISABLE_FILE_LINKS: 1
+    MAKER_SKIP_MERCURE_TEST: 1
 
 jobs:
     test:
@@ -70,15 +72,15 @@ jobs:
             - name: "Checkout code"
               uses: actions/checkout@v2.3.3
 
-#            - name: "Start MySQL"
-#              run: |
-#                  sudo /etc/init.d/mysql start
+            - name: "Setup SQLite For Entity Regen Tests"
+              run: |
+                  choco install sqlite --params "/NoTools"
 
             - name: "Setup MySQL"
               run: |
                   choco install mysql
 
-            - name: "Set Root Password"
+            - name: "Set MySQL Root Password"
               run: |
                   mysqladmin --user=root password "root"
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -78,6 +78,10 @@ jobs:
               run: |
                   choco install mysql
 
+            - name: "Set Root Password"
+              run: |
+                  mysqladmin --user=root password "root"
+
             - name: "Verify MySQL connection from host"
               run: |
                   mysql --host 127.0.0.1 --port 3306 -uroot -proot -e "SHOW DATABASES;"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -78,7 +78,7 @@ jobs:
 
             - name: "Setup MySQL"
               run: |
-                  choco install mysql
+                  choco install mysql --version=5.7
 
             - name: "Set MySQL Root Password"
               run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -75,10 +75,8 @@ jobs:
 #                  sudo /etc/init.d/mysql start
 
             - name: "Setup MySQL"
-              uses: ankane/setup-mysql@v1
-              with:
-                  mysql-version: 5.6
-                  database: test_maker
+              run: |
+                  choco install mysql
 
             - name: "Verify MySQL connection from host"
               run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -98,7 +98,7 @@ jobs:
                   coverage: "none"
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
-                  extensions: pdo pdo_mysql pdo_sqlite
+                  extensions: pdo, pdo_mysql, pdo_sqlite
 
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -120,6 +120,6 @@ jobs:
 
             - name: "PHPUnit version"
               run: vendor/bin/simple-phpunit --version
-#
-#            - name: "Run tests"
-#              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+
+            - name: "Run tests"
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -98,6 +98,7 @@ jobs:
                   coverage: "none"
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
+                  extensions: pdo pdo-mysql pdo-sqlite
 
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
     PHPUNIT_FLAGS: "-v"
-    SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
+#    SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
     MAKER_DISABLE_FILE_LINKS: 1
     MAKER_SKIP_MERCURE_TEST: 1
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,7 +18,7 @@ jobs:
     test:
         name: "PHP ${{ matrix.php-version }} + @${{ matrix.symfony-version }} ${{ matrix.dependency-versions }} deps"
 
-        runs-on: windows-latest
+        runs-on: windows-2019
 #
 #        services:
 #            mysql:
@@ -99,6 +99,7 @@ jobs:
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
                   extensions: pdo, pdo_mysql, pdo_sqlite, fileinfo, mbstring, openssl, curl
+                  ini-values: zend.assertions=1
 
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,7 +18,7 @@ jobs:
     test:
         name: "PHP ${{ matrix.php-version }} + @${{ matrix.symfony-version }} ${{ matrix.dependency-versions }} deps"
 
-        runs-on: windows-2019
+        runs-on: windows-latest
 #
 #        services:
 #            mysql:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -123,5 +123,11 @@ jobs:
             - name: "PHPUnit version"
               run: vendor/bin/simple-phpunit --version
 
-            - name: "Run tests"
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+            - name: "PHP Info"
+              run: php -i
+
+            - name: "List Windows Env"
+              run: SET
+#
+#            - name: "Run tests"
+#              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -98,7 +98,7 @@ jobs:
                   coverage: "none"
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
-                  extensions: pdo pdo-mysql pdo-sqlite
+                  extensions: pdo pdo_mysql pdo_sqlite
 
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -127,8 +127,8 @@ jobs:
             - name: "PHP Info"
               run: php -i
 
-            - name: "List Windows Env"
-              run: "Get-ChildItem Env: | Format-Table -Wrap -AutoSize"
+#            - name: "List Windows Env"
+#              run: "Get-ChildItem Env: | Format-Table -Wrap -AutoSize"
 #
-#            - name: "Run tests"
-#              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+            - name: "Run tests"
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,11 +2,11 @@ name: "Windows Builds"
 
 on:
     pull_request:
-    push:
-        branches:
-            - 'main'
-    schedule:
-        -   cron: '0 0 * * *'
+#    push:
+#        branches:
+#            - 'main'
+#    schedule:
+#        -   cron: '0 0 * * *'
 
 env:
     PHPUNIT_FLAGS: "-v"
@@ -50,21 +50,21 @@ jobs:
                     - '8.1'
                 symfony-version:
                     - '5.4.*'
-                    - '5.4.x-dev'
-                    - '6.0.x-dev'
-                    - '6.1.x-dev'
-                    - '6.2.x-dev'
+#                    - '5.4.x-dev'
+#                    - '6.0.x-dev'
+#                    - '6.1.x-dev'
+#                    - '6.2.x-dev'
                 dependency-versions: ['highest']
                 allow-dev-deps-in-apps: ['0']
-                include:
-                    # testing lowest PHP version with LTS
-                    - php-version: '8.0.0'
-                      symfony-version: '5.4.*'
-                      dependency-versions: 'lowest'
-                    # testing lowest php version with highest 5.x stable
-                    - php-version: '8.0.0'
-                      symfony-version: '5.4.*'
-                      dependency-versions: 'highest'
+#                include:
+#                    # testing lowest PHP version with LTS
+#                    - php-version: '8.0.0'
+#                      symfony-version: '5.4.*'
+#                      dependency-versions: 'lowest'
+#                    # testing lowest php version with highest 5.x stable
+#                    - php-version: '8.0.0'
+#                      symfony-version: '5.4.*'
+#                      dependency-versions: 'highest'
 
         steps:
             - name: "Checkout code"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -98,7 +98,7 @@ jobs:
                   coverage: "none"
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
-                  extensions: pdo, pdo_mysql, pdo_sqlite
+                  extensions: pdo, pdo_mysql, pdo_sqlite, fileinfo, mbstring, openssl, curl
 
             - name: "Add PHPUnit matcher"
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,160 @@
+name: "CI"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - 'main'
+    schedule:
+        -   cron: '0 0 * * *'
+
+env:
+    PHPUNIT_FLAGS: "-v"
+    SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
+
+jobs:
+    coding-standards:
+        name: "Coding Standards (${{ matrix.php-version }})"
+
+        runs-on: "windows-latest"
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version:
+                    - '8.0'
+
+        steps:
+            -
+                name: "Checkout code"
+                uses: "actions/checkout@v2"
+
+            -
+                name: "Install PHP"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    coverage: "none"
+                    php-version: "${{ matrix.php-version }}"
+
+            -
+                name: "Validate composer.json"
+                run: "composer validate --strict --no-check-lock"
+
+            -
+                name: "Composer install"
+                uses: "ramsey/composer-install@v1"
+                with:
+                    composer-options: "--no-scripts"
+
+            -
+                name: "Composer install php-cs-fixer"
+                uses: "ramsey/composer-install@v1"
+                with:
+                    composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
+
+            -
+                name: "Run friendsofphp/php-cs-fixer"
+                run: "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff"
+
+    test:
+        name: "PHP ${{ matrix.php-version }} + @${{ matrix.symfony-version }} ${{ matrix.dependency-versions }} deps"
+
+        runs-on: ubuntu-18.04
+
+        services:
+            mysql:
+                image: mysql:5.7 # Update server_version in phpunit.xml.dist if this changes.
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                    MYSQL_DATABASE: test_maker
+                ports:
+                    - 3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+            mercure:
+                image: dunglas/mercure
+                env:
+                    SERVER_NAME: :1337
+                    MERCURE_PUBLISHER_JWT_KEY: '!ChangeMe!'
+                    MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeMe!'
+                    MERCURE_EXTRA_DIRECTIVES: |
+                        anonymous
+                        cors_origins *
+                ports:
+                    - 1337:1337
+
+        env:
+            SYMFONY_VERSION: ${{ matrix.symfony-version }}
+            MAKER_ALLOW_DEV_DEPS_IN_APP: ${{ matrix.allow-dev-deps-in-apps }}
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version:
+                    - '8.1'
+                symfony-version:
+                    - '5.4.*'
+                    - '5.4.x-dev'
+                    - '6.0.x-dev'
+                    - '6.1.x-dev'
+                    - '6.2.x-dev'
+                dependency-versions: ['highest']
+                allow-dev-deps-in-apps: ['0']
+                include:
+                    # testing lowest PHP version with LTS
+                    - php-version: '8.0.0'
+                      symfony-version: '5.4.*'
+                      dependency-versions: 'lowest'
+                    # testing lowest php version with highest 5.x stable
+                    - php-version: '8.0.0'
+                      symfony-version: '5.4.*'
+                      dependency-versions: 'highest'
+
+        steps:
+            - name: "Checkout code"
+              uses: actions/checkout@v2.3.3
+
+            - name: "Start MySQL"
+              run: |
+                  sudo /etc/init.d/mysql start
+
+            - name: "Verify MySQL connection from host"
+              run: |
+                  mysql --host 127.0.0.1 --port 3306 -uroot -proot -e "SHOW DATABASES;"
+
+            - name: "Setup Database"
+              run: |
+                  mysql --host 127.0.0.1 --port 3306 -uroot -proot -e "CREATE DATABASE IF NOT EXISTS test_maker;"
+
+            - name: "Install PHP with extensions"
+              uses: shivammathur/setup-php@v2
+              with:
+                  coverage: "none"
+                  php-version: ${{ matrix.php-version }}
+                  tools: composer:v2
+
+            - name: "Add PHPUnit matcher"
+              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            - name: "Composer install"
+              uses: "ramsey/composer-install@v1"
+              with:
+                  dependency-versions: "${{ matrix.dependency-versions }}"
+
+            - name: "Composer install php-cs-fixer"
+              uses: "ramsey/composer-install@v1"
+              with:
+                  composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
+
+            - name: "Composer install twigcs"
+              uses: "ramsey/composer-install@v1"
+              with:
+                  composer-options: "--no-scripts --working-dir=tools/twigcs"
+
+            - name: "Install PHPUnit"
+              run: vendor/bin/simple-phpunit install
+
+            - name: "PHPUnit version"
+              run: vendor/bin/simple-phpunit --version
+#
+#            - name: "Run tests"
+#              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -127,7 +127,7 @@ jobs:
               run: php -i
 
             - name: "List Windows Env"
-              run: SET
+              run: "Get-ChildItem Env: | Format-Table -Wrap -AutoSize"
 #
 #            - name: "Run tests"
 #              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -69,6 +69,9 @@ jobs:
 #                      dependency-versions: 'highest'
 
         steps:
+            - name: "Use INPUT for autocrlf in Git Config"
+              run: git config --global core.autocrlf input
+
             - name: "Checkout code"
               uses: actions/checkout@v2.3.3
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ install:
     - composer install --no-interaction --no-progress --ansi --no-scripts --working-dir=tools/twigcs
     - composer install --no-interaction --no-progress --ansi --no-scripts --working-dir=tools/php-cs-fixer
     - vendor/bin/simple-phpunit install
+    - php -i
 
 test_script:
     - cd C:\projects\maker-bundle

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ environment:
 install:
     - choco install sqlite --params "/NoTools"
     - ps: Set-Service wuauserv -StartupType Manual
+    - cinst: sqlite3
     - IF EXIST C:\tools\php (SET PHP=1) # Checks for the PHP install being cached
     - IF %PHP%==0 cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version %php_ver_target%
     - cd C:\tools\php
@@ -61,6 +62,6 @@ install:
     - vendor/bin/simple-phpunit install
     - php -i
 
-test_script:
-    - cd C:\projects\maker-bundle
-    - vendor/bin/simple-phpunit
+#test_script:
+#    - cd C:\projects\maker-bundle
+#    - vendor/bin/simple-phpunit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ environment:
 install:
     - choco install sqlite --params "/NoTools"
     - ps: Set-Service wuauserv -StartupType Manual
-    - cinst: sqlite3
     - IF EXIST C:\tools\php (SET PHP=1) # Checks for the PHP install being cached
     - IF %PHP%==0 cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version %php_ver_target%
     - cd C:\tools\php

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,8 @@ install:
     - composer install --no-interaction --no-progress --ansi --no-scripts --working-dir=tools/php-cs-fixer
     - vendor/bin/simple-phpunit install
     - php -i
+    - git config --global --list --show-origin
 
-test_script:
-    - cd C:\projects\maker-bundle
-    - vendor/bin/simple-phpunit
+#test_script:
+#    - cd C:\projects\maker-bundle
+#    - vendor/bin/simple-phpunit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,6 @@ install:
     - vendor/bin/simple-phpunit install
     - php -i
 
-#test_script:
-#    - cd C:\projects\maker-bundle
-#    - vendor/bin/simple-phpunit
+test_script:
+    - cd C:\projects\maker-bundle
+    - vendor/bin/simple-phpunit

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -232,14 +232,14 @@ final class MakerTestEnvironment
 
         dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath), 'readable' => is_readable($this->cachePath), 'writeable' => is_writable($this->cachePath)], scandir($this->cachePath));
 
-        $flexDir = sprintf('%s\flex_project%s', $this->cachePath, $targetVersion);
+        $flexDir = sprintf('%s\flex_project%s', $this->cachePath, rtrim($targetVersion, '*'));
 
         $this->fs->mkdir($flexDir);
 
         dump(['dir_exists' => is_dir($flexDir), 'readable' => is_readable($flexDir), 'writeable' => is_writable($flexDir)], ['cache_path' => scandir($this->cachePath)], ['flex_dir' => scandir($flexDir)]);
 
         MakerTestProcess::create(
-            sprintf('composer create-project symfony/skeleton%s %s\flex_project%s --prefer-dist -vvv', $versionString, $this->cachePath, $targetVersion),
+            sprintf('composer create-project symfony/skeleton%s %s --prefer-dist -vvv', $versionString, $flexDir),
             $this->cachePath
         )->run();
 

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -233,7 +233,7 @@ final class MakerTestEnvironment
         dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath), 'readable' => is_readable($this->cachePath), 'writeable' => is_writable($this->cachePath)], scandir($this->cachePath));
 
         MakerTestProcess::create(
-            sprintf('composer create-project symfony/skeleton%s flex_project%s --prefer-dist -vvv', $versionString, $targetVersion),
+            sprintf('composer create-project symfony/skeleton%s %s/flex_project%s --prefer-dist -vvv', $versionString, $this->cachePath, $targetVersion),
             $this->cachePath
         )->run();
 

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -230,6 +230,8 @@ final class MakerTestEnvironment
         $targetVersion = $this->getTargetSkeletonVersion();
         $versionString = $targetVersion ? sprintf(':%s', $targetVersion) : '';
 
+        dd($this->cachePath);
+
         MakerTestProcess::create(
             sprintf('composer create-project symfony/skeleton%s flex_project%s --prefer-dist --no-progress', $versionString, $targetVersion),
             $this->cachePath

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -230,7 +230,7 @@ final class MakerTestEnvironment
         $targetVersion = $this->getTargetSkeletonVersion();
         $versionString = $targetVersion ? sprintf(':%s', $targetVersion) : '';
 
-        dd($this->cachePath);
+        dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath)]);
 
         MakerTestProcess::create(
             sprintf('composer create-project symfony/skeleton%s flex_project%s --prefer-dist --no-progress', $versionString, $targetVersion),

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -232,10 +232,18 @@ final class MakerTestEnvironment
 
         dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath), 'readable' => is_readable($this->cachePath), 'writeable' => is_writable($this->cachePath)], scandir($this->cachePath));
 
+        $flexDir = sprintf('%s/flex_project%s', $this->cachePath, $targetVersion);
+
+        $this->fs->mkdir(sprintf('%s/flex_project%s', $this->cachePath, $targetVersion));
+
+        dump(['dir_exists' => is_dir($flexDir), 'readable' => is_readable($flexDir), 'writeable' => is_writable($flexDir)], ['cache_path' => scandir($this->cachePath)], ['flex_dir' => scandir($flexDir)]);
+
         MakerTestProcess::create(
             sprintf('composer create-project symfony/skeleton%s %s/flex_project%s --prefer-dist -vvv', $versionString, $this->cachePath, $targetVersion),
             $this->cachePath
         )->run();
+
+        dump(['cache_path' => scandir($this->cachePath)], ['flex_dir' => scandir($flexDir)]);
 
         $rootPath = str_replace('\\', '\\\\', realpath(__DIR__.'/../..'));
 

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -230,10 +230,10 @@ final class MakerTestEnvironment
         $targetVersion = $this->getTargetSkeletonVersion();
         $versionString = $targetVersion ? sprintf(':%s', $targetVersion) : '';
 
-        dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath)]);
+        dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath), 'readable' => is_readable($this->cachePath), 'writeable' => is_writable($this->cachePath)], scandir($this->cachePath));
 
         MakerTestProcess::create(
-            sprintf('composer create-project symfony/skeleton%s flex_project%s --prefer-dist --no-progress', $versionString, $targetVersion),
+            sprintf('composer create-project symfony/skeleton%s flex_project%s --prefer-dist -vvv', $versionString, $targetVersion),
             $this->cachePath
         )->run();
 

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -232,7 +232,7 @@ final class MakerTestEnvironment
 
         dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath), 'readable' => is_readable($this->cachePath), 'writeable' => is_writable($this->cachePath)], scandir($this->cachePath));
 
-        $flexDir = sprintf('%s\flex_project%s', $this->cachePath, rtrim($targetVersion, '*'));
+        $flexDir = sprintf('%s\flex_project%s', $this->cachePath, '54');
 
         $this->fs->mkdir($flexDir);
 

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -232,14 +232,14 @@ final class MakerTestEnvironment
 
         dump($this->cachePath, ['dir_exists' => is_dir($this->cachePath), 'readable' => is_readable($this->cachePath), 'writeable' => is_writable($this->cachePath)], scandir($this->cachePath));
 
-        $flexDir = sprintf('%s/flex_project%s', $this->cachePath, $targetVersion);
+        $flexDir = sprintf('%s\flex_project%s', $this->cachePath, $targetVersion);
 
-        $this->fs->mkdir(sprintf('%s/flex_project%s', $this->cachePath, $targetVersion));
+        $this->fs->mkdir($flexDir);
 
         dump(['dir_exists' => is_dir($flexDir), 'readable' => is_readable($flexDir), 'writeable' => is_writable($flexDir)], ['cache_path' => scandir($this->cachePath)], ['flex_dir' => scandir($flexDir)]);
 
         MakerTestProcess::create(
-            sprintf('composer create-project symfony/skeleton%s %s/flex_project%s --prefer-dist -vvv', $versionString, $this->cachePath, $targetVersion),
+            sprintf('composer create-project symfony/skeleton%s %s\flex_project%s --prefer-dist -vvv', $versionString, $this->cachePath, $targetVersion),
             $this->cachePath
         )->run();
 


### PR DESCRIPTION
AppVeyor has git's `core.autocrlf` set to `input`. Github Actions windows runner defaults to `true`. This breaks assertions that compare fixture files w/ generated maker output.. 