### PR TITLE
Fix invalid token expiration date

### DIFF
--- a/src/Resources/skeleton/resetPassword/twig_email.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_email.tpl.php
@@ -4,6 +4,6 @@
 
 <a href="{{ url('app_reset_password', {token: resetToken.token}) }}">{{ url('app_reset_password', {token: resetToken.token}) }}</a>
 
-<p>This link will expire in {{ resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle') }}.</p>
+<p>This link will expire at {{ resetToken.expiresAt|format_datetime('none', 'short') }}.</p>
 
 <p>Cheers!</p>


### PR DESCRIPTION
Actually, token expiratino displays «0» in the email because data has changed in the reset password bundle.

This is a small fix to display expiration hour for the link.