### PR TITLE
[reset-password] use higher level "options" in ChangePasswordFormType.tpl.php

### DIFF
--- a/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
@@ -11,8 +11,12 @@ class <?= $class_name ?> extends AbstractType
         $builder
             ->add('plainPassword', RepeatedType::class, [
                 'type' => PasswordType::class,
+                'options' => [
+                    'attr' => [
+                        'autocomplete' => 'new-password',
+                    ],
+                ],
                 'first_options' => [
-                    'attr' => ['autocomplete' => 'new-password'],
                     'constraints' => [
                         new NotBlank([
                             'message' => 'Please enter a password',
@@ -27,7 +31,6 @@ class <?= $class_name ?> extends AbstractType
                     'label' => 'New password',
                 ],
                 'second_options' => [
-                    'attr' => ['autocomplete' => 'new-password'],
                     'label' => 'Repeat Password',
                 ],
                 'invalid_message' => 'The password fields must match.',


### PR DESCRIPTION
I add [options ](https://symfony.com/doc/current/reference/forms/types/repeated.html#options) instead of writing to first_options and second_options.