### PR TITLE
Fix methodName as string when adding method

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -1026,7 +1026,7 @@ final class ClassSourceManipulator
     private function addMethod(Node\Stmt\ClassMethod $methodNode): void
     {
         $classNode = $this->getClassNode();
-        $methodName = $methodNode->name;
+        $methodName = (string) $methodNode->name;
         $existingIndex = null;
         if ($this->methodExists($methodName)) {
             if (!$this->overwrite) {


### PR DESCRIPTION
`$method->name` is an instance of `PhpParser\Node\Identifier` and must be cast to string for the following operations.  Related error:

````
[TypeError]
  Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator::methodExists(): Argument #1 ($methodName) must be of type string, PhpParser\Node\Identifier given, called in /project/vendor/symfony/maker-bundle/src/Util/ClassSourceManipulator.php on line 1036
```