### PR TITLE
[make:crud] use save instead of add repository methods

### DIFF
--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -29,7 +29,7 @@ class <?= $class_name ?> extends AbstractController
 <?php endif ?>
 
 <?= $generator->generateRouteForControllerMethod('/new', sprintf('%s_new', $route_name), ['GET', 'POST']) ?>
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasAddRemoveMethods($repository_full_class_name)) { ?>
+<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
     public function new(Request $request, <?= $repository_class_name ?> $<?= $repository_var ?>): Response
 <?php } else { ?>
     public function new(Request $request, EntityManagerInterface $entityManager): Response
@@ -39,9 +39,9 @@ class <?= $class_name ?> extends AbstractController
         $form = $this->createForm(<?= $form_class_name ?>::class, $<?= $entity_var_singular ?>);
         $form->handleRequest($request);
 
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasAddRemoveMethods($repository_full_class_name)) { ?>
+<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
         if ($form->isSubmitted() && $form->isValid()) {
-            $<?= $repository_var ?>->add($<?= $entity_var_singular ?>, true);
+            $<?= $repository_var ?>->save($<?= $entity_var_singular ?>, true);
 
             return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
         }
@@ -76,7 +76,7 @@ class <?= $class_name ?> extends AbstractController
     }
 
 <?= $generator->generateRouteForControllerMethod(sprintf('/{%s}/edit', $entity_identifier), sprintf('%s_edit', $route_name), ['GET', 'POST']) ?>
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasAddRemoveMethods($repository_full_class_name)) { ?>
+<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
     public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, <?= $repository_class_name ?> $<?= $repository_var ?>): Response
 <?php } else { ?>
     public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, EntityManagerInterface $entityManager): Response
@@ -85,7 +85,7 @@ class <?= $class_name ?> extends AbstractController
         $form = $this->createForm(<?= $form_class_name ?>::class, $<?= $entity_var_singular ?>);
         $form->handleRequest($request);
 
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasAddRemoveMethods($repository_full_class_name)) { ?>
+<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
         if ($form->isSubmitted() && $form->isValid()) {
             $<?= $repository_var ?>->add($<?= $entity_var_singular ?>, true);
 
@@ -113,13 +113,13 @@ class <?= $class_name ?> extends AbstractController
     }
 
 <?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_delete', $route_name), ['POST']) ?>
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasAddRemoveMethods($repository_full_class_name)) { ?>
+<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, <?= $repository_class_name ?> $<?= $repository_var ?>): Response
 <?php } else { ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, EntityManagerInterface $entityManager): Response
 <?php } ?>
     {
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasAddRemoveMethods($repository_full_class_name)) { ?>
+<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
         if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->request->get('_token'))) {
             $<?= $repository_var ?>->remove($<?= $entity_var_singular ?>, true);
         }

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -87,7 +87,7 @@ class <?= $class_name ?> extends AbstractController
 
 <?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
         if ($form->isSubmitted() && $form->isValid()) {
-            $<?= $repository_var ?>->add($<?= $entity_var_singular ?>, true);
+            $<?= $repository_var ?>->save($<?= $entity_var_singular ?>, true);
 
             return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
         }

--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -19,7 +19,7 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
         parent::__construct($registry, <?= $entity_class_name; ?>::class);
     }
 
-    public function add(<?= $entity_class_name ?> $entity, bool $flush = false): void
+    public function save(<?= $entity_class_name ?> $entity, bool $flush = false): void
     {
         $this->getEntityManager()->persist($entity);
 

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -50,10 +50,10 @@ final class TemplateComponentGenerator
     /**
      * @throws ReflectionException
      */
-    public function repositoryHasAddRemoveMethods(string $repositoryFullClassName): bool
+    public function repositoryHasSaveAndRemoveMethods(string $repositoryFullClassName): bool
     {
         $reflectedComponents = new ReflectionClass($repositoryFullClassName);
 
-        return $reflectedComponents->hasMethod('add') && $reflectedComponents->hasMethod('remove');
+        return $reflectedComponents->hasMethod('save') && $reflectedComponents->hasMethod('remove');
     }
 }

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
@@ -21,7 +21,7 @@ class UserRepository extends ServiceEntityRepository
         parent::__construct($registry, UserXml::class);
     }
 
-    public function add(UserXml $entity, bool $flush = false): void
+    public function save(UserXml $entity, bool $flush = false): void
     {
         $this->getEntityManager()->persist($entity);
 

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
@@ -21,7 +21,7 @@ class XOtherRepository extends ServiceEntityRepository
         parent::__construct($registry, XOther::class);
     }
 
-    public function add(XOther $entity, bool $flush = false): void
+    public function save(XOther $entity, bool $flush = false): void
     {
         $this->getEntityManager()->persist($entity);
 

--- a/tests/fixtures/make-crud/SweetFoodRepository.php
+++ b/tests/fixtures/make-crud/SweetFoodRepository.php
@@ -21,7 +21,7 @@ class SweetFoodRepository extends ServiceEntityRepository
         parent::__construct($registry, SweetFood::class);
     }
 
-    public function add(SweetFood $entity, bool $flush = false): void
+    public function save(SweetFood $entity, bool $flush = false): void
     {
         ($em = $this->getEntityManager())->persist($entity);
 

--- a/tests/fixtures/make-crud/expected/WithCustomRepository.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepository.php
@@ -29,7 +29,7 @@ class SweetFoodController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $sweetFoodRepository->add($sweetFood, true);
+            $sweetFoodRepository->save($sweetFood, true);
 
             return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
         }
@@ -55,7 +55,7 @@ class SweetFoodController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $sweetFoodRepository->add($sweetFood, true);
+            $sweetFoodRepository->save($sweetFood, true);
 
             return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
         }


### PR DESCRIPTION
Instead of using an `add()` method in the repository, it's been renamed to `save()`. Logic behind the change is to not confuse with "add()" and item to a collection - we're "save()"ing an entity to persistence. 

Original work done by @bdaler in #1169 
fixes #1138 
fixes #788 