### PR TITLE
[make:twig-extension] Change folder for Twig Extension

### DIFF
--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -51,7 +51,7 @@ final class MakeTwigExtension extends AbstractMaker
     {
         $extensionClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Twig\\',
+            'Twig\\Extension',
             'Extension'
         );
 

--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -51,7 +51,7 @@ final class MakeTwigExtension extends AbstractMaker
     {
         $extensionClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Twig\\Extension',
+            'Twig\\Extension\\',
             'Extension'
         );
 


### PR DESCRIPTION
I think it would be interesting to put the Twig Extensions in a `src/Twig/Extension` folder rather than `src/Twig`. The idea is to do like the Twig Components.