### PR TITLE
[make:registration-form] render the raw signedUrl in the email template

### DIFF
--- a/src/Resources/skeleton/registration/twig_email.tpl.php
+++ b/src/Resources/skeleton/registration/twig_email.tpl.php
@@ -2,7 +2,7 @@
 
 <p>
     Please confirm your email address by clicking the following link: <br><br>
-    <a href="{{ signedUrl }}">Confirm my Email</a>.
+    <a href="{{ signedUrl|raw }}">Confirm my Email</a>.
     This link will expire in {{ expiresAtMessageKey|trans(expiresAtMessageData, 'VerifyEmailBundle') }}.
 </p>
 

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -135,7 +135,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'jr@rushlow.dev', // from email address
                     'SymfonyCasts', // From Name
                     'n', // no authenticate after
-                    0, // route number to redirect to
+                    'app_anonymous', // route number to redirect to
                 ]);
 
                 $this->assertStringContainsString('Success', $output);
@@ -174,7 +174,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'victor@symfonycasts.com', // from email address
                     'SymfonyCasts', // From Name
                     'n', // no authenticate after
-                    0, // route number to redirect to
+                    'app_anonymous', // route number to redirect to
                 ]);
 
                 $this->assertStringContainsString('Success', $output);

--- a/tests/fixtures/make-registration-form/tests/it_generates_registration_form_with_verification.php
+++ b/tests/fixtures/make-registration-form/tests/it_generates_registration_form_with_verification.php
@@ -19,8 +19,7 @@ class RegistrationFormTest extends WebTestCase
 
         $client->submit($form);
 
-        $messages = $this->getMailerMessages();
-        self::assertCount(1, $messages);
+        self::assertEmailCount(1);
 
         /** @var EntityManager $em */
         $em = self::$kernel->getContainer()
@@ -32,9 +31,15 @@ class RegistrationFormTest extends WebTestCase
 
         self::assertFalse(($query->getSingleResult())->isVerified());
 
-        $context = $messages[0]->getContext();
+        $messageBody = self::getMailerMessage()->getHtmlBody();
 
-        $client->request('GET', $context['signedUrl']);
+        preg_match('/(http.*)(")/', $messageBody, $signedUrl);
+
+        $parsed = parse_url($signedUrl[1]);
+
+        $decodedQueryString = str_replace('amp;', '', $parsed['query']);
+
+        $client->request('GET', sprintf('%s://%s%s?%s', $parsed['scheme'], $parsed['host'], $parsed['path'], $decodedQueryString));
 
         self::assertTrue(($query->getSingleResult())->isVerified());
     }

--- a/tests/fixtures/make-registration-form/tests/it_generates_registration_form_with_verification.php
+++ b/tests/fixtures/make-registration-form/tests/it_generates_registration_form_with_verification.php
@@ -33,13 +33,10 @@ class RegistrationFormTest extends WebTestCase
 
         $messageBody = self::getMailerMessage()->getHtmlBody();
 
+        // Group "1" contains just the signed url from the email
         preg_match('/(http.*)(")/', $messageBody, $signedUrl);
 
-        $parsed = parse_url($signedUrl[1]);
-
-        $decodedQueryString = str_replace('amp;', '', $parsed['query']);
-
-        $client->request('GET', sprintf('%s://%s%s?%s', $parsed['scheme'], $parsed['host'], $parsed['path'], $decodedQueryString));
+        $client->request('GET', $signedUrl[1]);
 
         self::assertTrue(($query->getSingleResult())->isVerified());
     }


### PR DESCRIPTION
# Template:

Twig is escaping the `signedUrl` provided by `VerifyEmailBundle` - we shouldn't do this in the template... 

Before:  (Note the `&amp;` separator in the query string)
```
http://localhost/verify/email?expires=1664884822&amp;id=1&amp;signature=TcUbEcrs7QXcxPdU%2Bb6OZVI%2FkcZ4gGq6JTvubDSG04o%3D&amp;token=g%2BOsXoKFi5iT73QjyezR74Rya1Gy8UtryhEMbmK%2FUB4%3D
```

Now:
```
http://localhost/verify/email?expires=1664884822&id=1&signature=TcUbEcrs7QXcxPdU%2Bb6OZVI%2FkcZ4gGq6JTvubDSG04o%3D&token=g%2BOsXoKFi5iT73QjyezR74Rya1Gy8UtryhEMbmK%2FUB4%3D
```

# Tests:
- Use the actual `app_anonymous` route instead of the profiler routes. (avoids noise when debugging)

- https://github.com/symfony/symfony/pull/47075 removed the `context` from rendered `TemplatedEmail` (allows for better serialization). We were using the `context` to grab the `signedurl` for the test. 

Without the context, we now have to grab the uri from the email body