### PR TITLE
feat: add make:form-extension command

### DIFF
--- a/src/Maker/MakeFormExtension.php
+++ b/src/Maker/MakeFormExtension.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use ReflectionClass;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Form\AbstractTypeExtension;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ * @author Bechir Ba <bechiirr71@gmail.com>
+ */
+class MakeFormExtension extends AbstractMaker
+{
+    public function __construct(private array $types = [])
+    {
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:form-extension';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new form extension class';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->addArgument('name', InputArgument::OPTIONAL, 'Choose a name for your form extension class (e.g. <fg=yellow>ImageTypeExtension</>)')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeFormExtension.txt'))
+        ;
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command)
+    {
+        $command->addArgument('extended_type', InputArgument::OPTIONAL, 'The class name of the extended form type (e.g. <fg=yellow>FileType</>)');
+
+        $question = new Question(sprintf(' <fg=green>%s</>', $command->getDefinition()->getArgument('extended_type')->getDescription()));
+
+        $question->setAutocompleterValues($this->types);
+        $question->setValidator(function ($extendedType) {
+            Validator::notBlank($extendedType);
+
+            if (!isset($this->types[$extendedType])) {
+                Validator::classExists($extendedType);
+            }
+
+            return $extendedType;
+        });
+
+        $extendedType = $io->askQuestion($question);
+        if (!isset($this->types[$extendedType])) {
+            $this->types[$extendedType] = $extendedType;
+            $extendedType = (new ReflectionClass($extendedType))->getShortName();
+        }
+        $input->setArgument('extended_type', $extendedType);
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $classNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'Form\\Extension\\',
+            'TypeExtension'
+        );
+
+        $useStatements = new UseStatementGenerator([
+            AbstractTypeExtension::class,
+            $this->types[$input->getArgument('extended_type')],
+        ]);
+
+        $generator->generateClass(
+            $classNameDetails->getFullName(),
+            'form/TypeExtension.tpl.php',
+            [
+                'use_statements' => $useStatements,
+                'extended_type' => $input->getArgument('extended_type'),
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+        $io->text([
+            'Next: Open your new form extension class and start customizing it.',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/form/create_form_type_extension.html</>',
+        ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies->addClassDependency(
+            AbstractTypeExtension::class,
+            'form'
+        );
+    }
+}

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -61,6 +61,11 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_form_extension" class="Symfony\Bundle\MakerBundle\Maker\MakeFormExtension">
+                <argument type="collection" />
+                <tag name="maker.command" />
+            </service>
+
             <service id="maker.maker.make_functional_test" class="Symfony\Bundle\MakerBundle\Maker\MakeFunctionalTest">
                 <tag name="maker.command" />
             </service>

--- a/src/Resources/help/MakeFormExtension.txt
+++ b/src/Resources/help/MakeFormExtension.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> generates a new form extension class.
+
+<info>php %command.full_name% ImageTypeExtension</info>
+
+If the argument is missing, the command will ask for the form class interactively.

--- a/src/Resources/skeleton/form/TypeExtension.tpl.php
+++ b/src/Resources/skeleton/form/TypeExtension.tpl.php
@@ -1,0 +1,18 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace ?>;
+
+<?= $use_statements ?>
+
+class <?= $class_name ?> extends AbstractTypeExtension
+{
+    /**
+     * Returns an array of extended types.
+     */
+    public static function getExtendedTypes(): iterable
+    {
+        return [
+            <?= $extended_type ?>::class,
+        ];
+    }
+}

--- a/tests/Maker/MakeFormExtensionTest.php
+++ b/tests/Maker/MakeFormExtensionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeFormExtension;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+
+class MakeFormExtensionTest extends MakerTestCase
+{
+    protected function getMakerClass(): string
+    {
+        return MakeFormExtension::class;
+    }
+
+    public function getTestDetails()
+    {
+        yield 'it_makes_form_extension' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // form extension name
+                        'Media',
+                        DateType::class,
+                    ]
+                );
+
+                $data = file_get_contents($runner->getPath('src/Form/Extension/MediaTypeExtension.php'));
+                $this->assertStringContainsString(sprintf('use %s;', DateType::class), $data);
+                $this->assertStringContainsString('DateType::class', $data);
+            }),
+        ];
+    }
+}


### PR DESCRIPTION
Hello!

This PR is related to #78 

I juste based my work the @yceruto's PR #85 (closed)

The `getExtendedTypes` method return now array but I ask only one extended type. It is also possible to iteratively ask for an other extended type until the user press `enter`, but I don't know if it's really matters (and it seems to be a lot of work)

What do you think about it?

Edit: I added test but I don't know if the failing tests are related to my code.