### PR TITLE
[make:voter] Set type for subject in Voter template

### DIFF
--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -11,7 +11,7 @@ class <?= $class_name ?> extends Voter
     public const EDIT = 'POST_EDIT';
     public const VIEW = 'POST_VIEW';
 
-    protected function supports(string $attribute, $subject): bool
+    protected function supports(string $attribute, mixed $subject): bool
     {
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
@@ -19,7 +19,7 @@ class <?= $class_name ?> extends Voter
             && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;
     }
 
-    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access


### PR DESCRIPTION
Setting type for $subject in Voter template so phpstan issue can be covered by default

```
 ------ ----------------------------------------------------------------- 
  15     Method App\Security\Voter\TenantVoter::supports() has parameter  
         $subject with no type specified.                                 
 ------ ----------------------------------------------------------------- 
```
