### PR TITLE
Twig extension: create with a runtime class

### DIFF
--- a/src/Resources/help/MakeTwigExtension.txt
+++ b/src/Resources/help/MakeTwigExtension.txt
@@ -1,4 +1,4 @@
-The <info>%command.name%</info> command generates a new twig extension class.
+The <info>%command.name%</info> command generates a new twig extension with its runtime class.
 
 <info>php %command.full_name% AppExtension</info>
 

--- a/src/Resources/skeleton/twig/Extension.tpl.php
+++ b/src/Resources/skeleton/twig/Extension.tpl.php
@@ -12,19 +12,14 @@ class <?= $class_name ?> extends AbstractExtension
             // If your filter generates SAFE HTML, you should add a third
             // parameter: ['is_safe' => ['html']]
             // Reference: https://twig.symfony.com/doc/3.x/advanced.html#automatic-escaping
-            new TwigFilter('filter_name', [$this, 'doSomething']),
+            new TwigFilter('filter_name', [<?= $runtime_class_name ?>::class, 'doSomething']),
         ];
     }
 
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('function_name', [$this, 'doSomething']),
+            new TwigFunction('function_name', [<?= $runtime_class_name ?>::class, 'doSomething']),
         ];
-    }
-
-    public function doSomething($value)
-    {
-        // ...
     }
 }

--- a/src/Resources/skeleton/twig/Runtime.tpl.php
+++ b/src/Resources/skeleton/twig/Runtime.tpl.php
@@ -1,0 +1,18 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace; ?>;
+
+<?= $use_statements ?>
+
+class <?= $class_name ?> implements RuntimeExtensionInterface
+{
+    public function __construct()
+    {
+        // Inject dependencies if needed
+    }
+
+    public function doSomething($value)
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
This PR introduce a way to generate a twig runtime linked to the twig extension via the `make:twig-extension` command

Fixes https://github.com/symfony/maker-bundle/issues/1222

For now I did not touch the test, just want to gather early feedbacks :)