### PR TITLE
[make:registration] Make router optional in MakeRegistrationForm constructor

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -85,8 +85,8 @@ final class MakeRegistrationForm extends AbstractMaker
     public function __construct(
         private FileManager $fileManager,
         private FormTypeRenderer $formTypeRenderer,
-        private RouterInterface $router,
         private DoctrineHelper $doctrineHelper,
+        private ?RouterInterface $router = null,
     ) {
     }
 
@@ -110,6 +110,10 @@ final class MakeRegistrationForm extends AbstractMaker
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
         $interactiveSecurityHelper = new InteractiveSecurityHelper();
+
+        if (null === $this->router) {
+            throw new RuntimeCommandException('Router have been explicitely disabled in your configuration. This command needs to use the router.');
+        }
 
         if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
             throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. This command needs that file to accurately build your registration form.');

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -77,8 +77,8 @@
             <service id="maker.maker.make_registration_form" class="Symfony\Bundle\MakerBundle\Maker\MakeRegistrationForm">
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.renderer.form_type_renderer" />
-                <argument type="service" id="router" />
                 <argument type="service" id="maker.doctrine_helper" />
+                <argument type="service" id="router" on-invalid="ignore" />
                 <tag name="maker.command" />
             </service>
 


### PR DESCRIPTION
In a console application, I have the following configuration:
```yaml
framework:
  router: false
```

As the `MakeRegistrationForm` class need a `RouterInterface` to be constructed, I get the following error: `Symfony\Bundle\MakerBundle\Maker\MakeRegistrationForm::__construct(): Argument #3 ($router) must be of type Symfony\Component\Routing\RouterInterface, null given`

This PR aim to remove this dependency.