### PR TITLE
[make:registration-form] Print registration form errors

### DIFF
--- a/src/Resources/skeleton/registration/twig_template.tpl.php
+++ b/src/Resources/skeleton/registration/twig_template.tpl.php
@@ -9,6 +9,8 @@
 <?php endif; ?>
     <h1>Register</h1>
 
+    {{ form_errors(registrationForm) }}
+
     {{ form_start(registrationForm) }}
         {{ form_row(registrationForm.<?= $username_field ?>) }}
         {{ form_row(registrationForm.plainPassword, {


### PR DESCRIPTION
Errors messages are not displayed on registration form. This PR add the required things in TWIG template to display errors when availables.