### PR TITLE
Improve error messages to show PHP & XML configurations are not supported

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -93,7 +93,7 @@ final class MakeAuthenticator extends AbstractMaker
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
         if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
-            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. This command requires that file to exist so that it can be updated.');
+            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. PHP & XML configuration formats are currently not supported.');
         }
         $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));
         $securityData = $manipulator->getData();

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -116,7 +116,7 @@ final class MakeRegistrationForm extends AbstractMaker
         }
 
         if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
-            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. This command needs that file to accurately build your registration form.');
+            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. PHP & XML configuration formats are currently not supported.');
         }
 
         $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -137,7 +137,7 @@ class MakeResetPassword extends AbstractMaker
         $interactiveSecurityHelper = new InteractiveSecurityHelper();
 
         if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
-            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. This command needs that file to accurately build the reset password form.');
+            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. PHP & XML configuration formats are currently not supported.');
         }
 
         $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));


### PR DESCRIPTION
Closes #1231
As suggested in https://github.com/symfony/maker-bundle/issues/1231#issuecomment-1321891623