### PR TITLE
Add tests for `SecurityConfigUpdater`

### DIFF
--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -32,23 +32,22 @@ final class SecurityConfigUpdater
 
     public function updateForFormLogin(string $yamlSource, string $firewallToUpdate, string $loginPath, string $checkPath): string
     {
-        $this->manipulator = new YamlSourceManipulator($yamlSource);
-
-        if (null !== $this->ysmLogger) {
-            $this->manipulator->setLogger($this->ysmLogger);
-        }
-
-        $this->normalizeSecurityYamlFile();
-
-        $newData = $this->manipulator->getData();
+        $newData = $this->createYamlSourceManipulator($yamlSource);
 
         $newData['security']['firewalls'][$firewallToUpdate]['form_login']['login_path'] = $loginPath;
         $newData['security']['firewalls'][$firewallToUpdate]['form_login']['check_path'] = $checkPath;
         $newData['security']['firewalls'][$firewallToUpdate]['form_login']['enable_csrf'] = true;
 
-        $this->manipulator->setData($newData);
+        return $this->getYamlContentsFromData($newData);
+    }
 
-        return $this->manipulator->getContents();
+    public function updateForJsonLogin(string $yamlSource, string $firewallToUpdate, string $checkPath): string
+    {
+        $data = $this->createYamlSourceManipulator($yamlSource);
+
+        $data['security']['firewalls'][$firewallToUpdate]['json_login']['check_path'] = $checkPath;
+
+        return $this->getYamlContentsFromData($data);
     }
 
     /**
@@ -149,7 +148,7 @@ final class SecurityConfigUpdater
         $this->manipulator->setData($securityData);
     }
 
-    private function createYamlSourceManipulator(string $yamlSource): void
+    private function createYamlSourceManipulator(string $yamlSource): array
     {
         $this->manipulator = new YamlSourceManipulator($yamlSource);
 
@@ -158,6 +157,15 @@ final class SecurityConfigUpdater
         }
 
         $this->normalizeSecurityYamlFile();
+
+        return $this->manipulator->getData();
+    }
+
+    private function getYamlContentsFromData(array $yamlData): string
+    {
+        $this->manipulator->setData($yamlData);
+
+        return $this->manipulator->getContents();
     }
 
     private function normalizeSecurityYamlFile(): void

--- a/tests/Security/yaml_fixtures/expected_form_login/form_login.yaml
+++ b/tests/Security/yaml_fixtures/expected_form_login/form_login.yaml
@@ -1,0 +1,8 @@
+security:
+    enable_authenticator_manager: true
+    firewalls:
+        main:
+            form_login:
+                login_path: a_login_path
+                check_path: a_check_path
+                enable_csrf: true

--- a/tests/Security/yaml_fixtures/expected_json_login/json_login.yaml
+++ b/tests/Security/yaml_fixtures/expected_json_login/json_login.yaml
@@ -1,0 +1,6 @@
+security:
+    enable_authenticator_manager: true
+    firewalls:
+        main:
+            json_login:
+                check_path: a_check_path

--- a/tests/Security/yaml_fixtures/expected_logout/logout.yaml
+++ b/tests/Security/yaml_fixtures/expected_logout/logout.yaml
@@ -1,0 +1,17 @@
+security:
+    enable_authenticator_manager: true
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            lazy: true
+            logout:
+                path: app_logout
+                # where to redirect after logout
+                # target: app_any_route


### PR DESCRIPTION
Adds missing tests for the `formLogin` & `logout` updaters. Adds a new updater for `jsonLogin` to be used in `make:security:json-login` #1246 