### PR TITLE
[tests] use composer to require maker bundle in tests

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -28,10 +28,13 @@ final class MakerTestEnvironment
     private string $flexPath;
     private string $path;
     private MakerTestProcess $runnedMakerProcess;
+    private bool $isWindows;
 
     private function __construct(
         private MakerTestDetails $testDetails,
     ) {
+        $this->isWindows = str_contains(strtolower(\PHP_OS), 'win');
+
         $this->fs = new Filesystem();
         $this->rootPath = realpath(__DIR__.'/../../');
         $cachePath = $this->rootPath.'/tests/tmp/cache';
@@ -124,6 +127,8 @@ final class MakerTestEnvironment
 
     public function prepareDirectory(): void
     {
+        $this->buildMakerRepo();
+
         if (!$this->fs->exists($this->flexPath)) {
             $this->buildFlexSkeleton();
         }
@@ -140,6 +145,11 @@ final class MakerTestEnvironment
                     ]
                 )
                     ->run();
+
+                // In Window's we have to require MakerBundle in each project - git clone doesn't symlink well
+                if ($this->isWindows) {
+                    $this->requireMakerBundle($this->path);
+                }
 
                 // install any missing dependencies
                 $dependencies = $this->determineMissingDependencies();
@@ -231,33 +241,21 @@ final class MakerTestEnvironment
         $targetVersion = $this->getTargetSkeletonVersion();
         $versionString = $targetVersion ? sprintf(':%s', $targetVersion) : '';
 
+        $flexProjectDir = sprintf('flex_project%s', $targetVersion);
+
         MakerTestProcess::create(
-            sprintf('composer create-project symfony/skeleton%s flex_project%s --prefer-dist --no-progress', $versionString, $targetVersion),
+            sprintf('composer create-project symfony/skeleton%s %s --prefer-dist --no-progress', $versionString, $flexProjectDir),
             $this->cachePath
         )->run();
 
         $rootPath = str_replace('\\', '\\\\', realpath(__DIR__.'/../..'));
 
-        // processes any changes needed to the Flex project
-        $replacements = [
-            [
-                'filename' => 'config/bundles.php',
-                'find' => "Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],",
-                'replace' => "Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],\n    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],",
-            ],
-            [
-                // ugly way to autoload Maker & any other vendor libs needed in the command
-                'filename' => 'composer.json',
-                'find' => '"App\\\Tests\\\": "tests/"',
-                'replace' => sprintf(
-                    '"App\\\Tests\\\": "tests/",'."\n".'            "Symfony\\\Bundle\\\MakerBundle\\\": "%s/src/",'."\n".'            "PhpParser\\\": "%s/vendor/nikic/php-parser/lib/PhpParser/"',
-                    // escape \ for Windows
-                    $rootPath,
-                    $rootPath
-                ),
-            ],
-        ];
-        $this->processReplacements($replacements, $this->flexPath);
+        $this->addMakerBundleRepoToComposer(sprintf('%s/%s/composer.json', $this->cachePath, $flexProjectDir));
+
+        // In Linux, git plays well with symlinks. We can add maker to the flex skeleton.
+        if (!$this->isWindows) {
+            $this->requireMakerBundle(sprintf('%s/%s', $this->cachePath, $flexProjectDir));
+        }
 
         if ($_SERVER['MAKER_ALLOW_DEV_DEPS_IN_APP'] ?? false) {
             MakerTestProcess::create('composer config minimum-stability dev', $this->flexPath)->run();
@@ -410,5 +408,51 @@ echo json_encode($missingDependencies);
     private function getTargetSkeletonVersion(): ?string
     {
         return $_SERVER['SYMFONY_VERSION'] ?? '';
+    }
+
+    private function buildMakerRepo(): void
+    {
+        // Copy MakerBundle to a "repo" directory for tests
+        $makerRepoPath = sprintf('%s/maker-repo', $this->cachePath);
+
+        if (!file_exists($makerRepoPath)) {
+            MakerTestProcess::create(sprintf('git clone %s %s', $this->rootPath, $makerRepoPath), $this->cachePath)->run();
+        }
+    }
+
+    private function requireMakerBundle(string $projectDirectory): void
+    {
+        MakerTestProcess::create('composer require --dev symfony/maker-bundle', $projectDirectory)
+            ->run()
+        ;
+
+        $makerRepoSrcPath = sprintf('%s/maker-repo/src', $this->cachePath);
+
+        // DX - So we can test changes without having to commit them locally
+        if (!is_link($makerRepoSrcPath)) {
+            $this->fs->remove($makerRepoSrcPath);
+            $this->fs->symlink(sprintf('%s/src', $this->rootPath), $makerRepoSrcPath);
+        }
+    }
+
+    private function addMakerBundleRepoToComposer(string $composerJsonPath): void
+    {
+        $composerJson = json_decode(
+            file_get_contents($composerJsonPath), true, 512, \JSON_THROW_ON_ERROR);
+
+        // Require-dev is empty and composer complains about this being an array when we encode it again.
+        unset($composerJson['require-dev']);
+
+        $composerJson['repositories']['symfony/maker-bundle'] = [
+            'type' => 'path',
+            'url' => sprintf('%s%smaker-repo', $this->cachePath, \DIRECTORY_SEPARATOR),
+            'options' => [
+                'versions' => [
+                    'symfony/maker-bundle' => '9999.99', // Arbitrary version to avoid stability conflicts
+                ],
+            ],
+        ];
+
+        file_put_contents($composerJsonPath, json_encode($composerJson, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
     }
 }

--- a/src/Test/MakerTestRunner.php
+++ b/src/Test/MakerTestRunner.php
@@ -224,10 +224,18 @@ class MakerTestRunner
      */
     public function addToAutoloader(string $namespace, string $path)
     {
-        $composerJson = json_decode(file_get_contents($this->getPath('composer.json')), true);
+        $composerJson = json_decode(
+            json: file_get_contents($this->getPath('composer.json')),
+            associative: true,
+            flags: \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES
+        );
+
         $composerJson['autoload-dev']['psr-4'][$namespace] = $path;
 
-        $this->filesystem->dumpFile($this->getPath('composer.json'), json_encode($composerJson));
+        $this->filesystem->dumpFile(
+            $this->getPath('composer.json'),
+            json_encode($composerJson, \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR)
+        );
 
         $this->environment->runCommand('composer dump-autoload');
     }

--- a/src/Test/MakerTestRunner.php
+++ b/src/Test/MakerTestRunner.php
@@ -224,11 +224,10 @@ class MakerTestRunner
      */
     public function addToAutoloader(string $namespace, string $path)
     {
-        $this->replaceInFile(
-            'composer.json',
-            '"App\\\Tests\\\": "tests/",',
-            sprintf('"App\\\Tests\\\": "tests/",'."\n".'            "%s": "%s",', $namespace, $path)
-        );
+        $composerJson = json_decode(file_get_contents($this->getPath('composer.json')), true);
+        $composerJson['autoload-dev']['psr-4'][$namespace] = $path;
+
+        $this->filesystem->dumpFile($this->getPath('composer.json'), json_encode($composerJson));
 
         $this->environment->runCommand('composer dump-autoload');
     }

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\MakerInterface;
+use Symfony\Bundle\MakerBundle\Util\TemplateLinter;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class MakerCommandTest extends TestCase
@@ -39,7 +40,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'));
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'), new TemplateLinter());
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);
@@ -52,7 +53,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'));
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'), new TemplateLinter());
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);

--- a/tests/Command/MakerCommandTest.php
+++ b/tests/Command/MakerCommandTest.php
@@ -18,7 +18,6 @@ use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\MakerInterface;
-use Symfony\Bundle\MakerBundle\Util\TemplateLinter;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class MakerCommandTest extends TestCase
@@ -40,7 +39,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'), new TemplateLinter());
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'App'));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);
@@ -53,7 +52,7 @@ class MakerCommandTest extends TestCase
 
         $fileManager = $this->createMock(FileManager::class);
 
-        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'), new TemplateLinter());
+        $command = new MakerCommand($maker, $fileManager, new Generator($fileManager, 'Unknown'));
         // needed because it's normally set by the Application
         $command->setName('make:foo');
         $tester = new CommandTester($command);

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -637,7 +637,7 @@ class MakeEntityTest extends MakerTestCase
         );
 
         $runner->addToAutoloader(
-            'Some\Vendor\\',
+            'Some\\Vendor\\',
             'vendor/some-vendor/src'
         );
     }

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -637,7 +637,7 @@ class MakeEntityTest extends MakerTestCase
         );
 
         $runner->addToAutoloader(
-            'Some\\\Vendor\\\\',
+            'Some\Vendor\\',
             'vendor/some-vendor/src'
         );
     }


### PR DESCRIPTION
Instead of copying MakerBundle to the flex skeleton and fiddling with autoloader to force things to work. Let's:
- add MakerBundle as a "path" repository to the skeletons `composer.json`
- `composer require --dev symfony/maker-bundle`
- Symlink Maker's `src/` to the skeleton's `vendor/symfony/maker-bundle/src` directory so we can test changes locally without having to create a commit.

Caveats:
- In Windows, `git clone` and symlinks are problematic. I experienced problems creating a symlink in the skeleton then attempting to clone the skeleton for individual maker tests. Workaround: `composer require --dev symfony/maker-bundle` + create the symlink each time we generate a "project" from the `flex_skeleton` 

- Windows AppVeyor test times have a ~4 min increase across the whole suite. This will likely be reduced when we move Windows CI to GitHub Actions. 

Side note: We're doing this so we can `php-cs-fixer` in each maker run w/o having to screw with the autoloader for `symfony/process`