### PR TITLE
Revert `flush()` to `edit` action

### DIFF
--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -76,28 +76,16 @@ class <?= $class_name ?> extends AbstractController
     }
 
 <?= $generator->generateRouteForControllerMethod(sprintf('/{%s}/edit', $entity_identifier), sprintf('%s_edit', $route_name), ['GET', 'POST']) ?>
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-    public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, <?= $repository_class_name ?> $<?= $repository_var ?>): Response
-<?php } else { ?>
     public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, EntityManagerInterface $entityManager): Response
-<?php } ?>
     {
         $form = $this->createForm(<?= $form_class_name ?>::class, $<?= $entity_var_singular ?>);
         $form->handleRequest($request);
 
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-        if ($form->isSubmitted() && $form->isValid()) {
-            $<?= $repository_var ?>->save($<?= $entity_var_singular ?>, true);
-
-            return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
-        }
-<?php } else { ?>
         if ($form->isSubmitted() && $form->isValid()) {
             $entityManager->flush();
 
             return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
         }
-<?php } ?>
 
 <?php if ($use_render_form) { ?>
         return $this->renderForm('<?= $templates_path ?>/edit.html.twig', [

--- a/src/Resources/skeleton/security/UserProvider.tpl.php
+++ b/src/Resources/skeleton/security/UserProvider.tpl.php
@@ -46,7 +46,7 @@ class <?= $class_name ?> implements UserProviderInterface, PasswordUpgraderInter
     public function refreshUser(UserInterface $user): UserInterface
     {
         if (!$user instanceof <?= $user_short_name ?>) {
-            throw new UnsupportedUserException(sprintf('Invalid user class "%s".', get_class($user)));
+            throw new UnsupportedUserException(sprintf('Invalid user class "%s".', $user::class));
         }
 
         // Return a User object after making sure its data is "fresh".


### PR DESCRIPTION
We don't need to use the repository's `save()` action for edit.
This action does a `persist()` and a `flush()`.
We just need to do a `flush()` for edit.