### PR TITLE
[make:migration] Add link to new migration files

### DIFF
--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Util\CliOutputHelper;
+use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -34,8 +35,10 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
 {
     private Application $application;
 
-    public function __construct(private string $projectDir)
-    {
+    public function __construct(
+        private string $projectDir,
+        private ?MakerFileLinkFormatter $makerFileLinkFormatter = null,
+    ) {
     }
 
     public static function getCommandName(): string
@@ -116,13 +119,15 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
             return;
         }
 
+        $absolutePath = $this->getGeneratedMigrationFilename($migrationOutput);
+        $relativePath = str_replace($this->projectDir.'/', '', $absolutePath);
+
+        $io->comment('<fg=blue>created</>: '.($this->makerFileLinkFormatter?->makeLinkedPath($absolutePath, $relativePath) ?? $relativePath));
+
         $this->writeSuccessMessage($io);
 
-        $migrationName = $this->getGeneratedMigrationFilename($migrationOutput);
-
         $io->text([
-            sprintf('Next: Review the new migration <info>%s</info>', $migrationName),
-            sprintf('Then: Run the migration with <info>%s doctrine:migrations:migrate</info>', CliOutputHelper::getCommandPrefix()),
+            sprintf('Review the new migration then run it with <info>%s doctrine:migrations:migrate</info>', CliOutputHelper::getCommandPrefix()),
             'See <fg=yellow>https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html</>',
         ]);
     }
@@ -148,12 +153,12 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
 
     private function getGeneratedMigrationFilename(string $migrationOutput): string
     {
-        preg_match('#"(.*?)"#', $migrationOutput, $matches);
+        preg_match('#"<info>(.*?)</info>"#', $migrationOutput, $matches);
 
-        if (!isset($matches[0])) {
+        if (!isset($matches[1])) {
             throw new \Exception('Your migration generated successfully, but an error occurred printing the summary of what occurred.');
         }
 
-        return str_replace($this->projectDir.'/', '', $matches[0]);
+        return $matches[1];
     }
 }

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -133,6 +133,7 @@
 
             <service id="maker.maker.make_migration" class="Symfony\Bundle\MakerBundle\Maker\MakeMigration">
                 <argument>%kernel.project_dir%</argument>
+                <argument type="service" id="maker.file_link_formatter" />
                 <tag name="maker.command" />
             </service>
 

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -62,7 +62,7 @@ class MakeMigrationTest extends MakerTestCase
                 // see that the exact filename is in the output
                 $iterator = $finder->getIterator();
                 $iterator->rewind();
-                $this->assertStringContainsString(sprintf('"%s/%s"', $migrationsDirectoryPath, $iterator->current()->getFilename()), $output);
+                $this->assertStringContainsString(sprintf('%s/%s', $migrationsDirectoryPath, $iterator->current()->getFilename()), $output);
             }),
         ];
 


### PR DESCRIPTION
Makes the output of make:migration more consistent with other commands.

Before:
![image](https://user-images.githubusercontent.com/243674/207104941-0d932c31-f038-4a48-a912-b61fecbdcb60.png)

After:
![image](https://user-images.githubusercontent.com/243674/207104859-a96765ea-6a25-4995-8020-5dfa06da42db.png)
