### PR TITLE
Fill PasswordUpgraderInterface template in repository

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -6,6 +6,7 @@ namespace <?= $namespace; ?>;
 
 /**
  * @extends ServiceEntityRepository<<?= $entity_class_name; ?>>
+<?= $with_password_upgrade ? " * @extends PasswordUpgraderInterface<{$entity_class_name}>\n" : "" ?>
  *
  * @method <?= $entity_class_name; ?>|null find($id, $lockMode = null, $lockVersion = null)
  * @method <?= $entity_class_name; ?>|null findOneBy(array $criteria, array $orderBy = null)


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/48750 cc @nicolas-grekas.

But if the template is only introduced in 6.3, adding the annotation for someone on a previous Symfony version will generate a useless annotation. So what is the maker-strategy to deal with this situation ?