### PR TITLE
[make:controller] doctrine/annotations is not needed

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
-use Doctrine\Common\Annotations\Annotation;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
@@ -27,7 +26,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -115,15 +113,6 @@ final class MakeController extends AbstractMaker
 
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
-        // @legacy - Remove method when support for Symfony 5.4 is dropped
-        if (null !== $this->phpCompatUtil && 60000 <= Kernel::VERSION_ID) {
-            return;
-        }
-
-        $dependencies->addClassDependency(
-            Annotation::class,
-            'doctrine/annotations'
-        );
     }
 
     private function isTwigInstalled(): bool

--- a/tests/Maker/MakeAuthenticatorTest.php
+++ b/tests/Maker/MakeAuthenticatorTest.php
@@ -284,7 +284,7 @@ class MakeAuthenticatorTest extends MakerTestCase
 
         // @legacy - In 5.4 tests, we need to tell Symfony to look for route attributes in `src/Controller`
         if ('60000' > $runner->getSymfonyVersion()) {
-            $runner->copy('make-auth/annotations.yaml', 'config/routes/annotations.yaml');
+            $runner->copy('router-annotations.yaml', 'config/routes/annotations.yaml');
         }
 
         // plaintext password: needed for entities, simplifies overall

--- a/tests/fixtures/make-auth/annotations.yaml
+++ b/tests/fixtures/make-auth/annotations.yaml
@@ -1,7 +1,0 @@
-controllers:
-    resource: ../../src/Controller/
-    type: annotation
-
-kernel:
-    resource: ../../src/Kernel.php
-    type: annotation

--- a/tests/fixtures/router-annotations.yaml
+++ b/tests/fixtures/router-annotations.yaml
@@ -1,0 +1,10 @@
+# @legacy - Can be removed when Symfony 5.4 is no longer supported
+# This is needed for controller attributes as we do not install / require
+# doctrine/annotations...
+controllers:
+    resource: ../../src/Controller/
+    type: annotation
+
+kernel:
+    resource: ../../src/Kernel.php
+    type: annotation


### PR DESCRIPTION
Attribute support for `make:controller` was added in https://github.com/symfony/maker-bundle/pull/725. 
PHP 7 support was dropped in https://github.com/symfony/maker-bundle/pull/1122

Attributes are always used when using PHP 8...