### PR TITLE
[make:crud] Make sensio/framework-extra-bundle an optional dependency

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -17,6 +17,7 @@ use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -317,9 +318,11 @@ final class MakeCrud extends AbstractMaker
             'security-csrf'
         );
 
+        // @legacy - Remove dependency when support for Symfony <6.2 is dropped
         $dependencies->addClassDependency(
             ParamConverter::class,
-            'annotations'
+            'annotations',
+            !class_exists(EntityValueResolver::class) // sensio/framework-extra-bundle dependency is not required when using symfony 6.2+
         );
     }
 }


### PR DESCRIPTION
The `sensio/framework-extra-bundle` is abandoned and replaced by built-in feature of symfony components. So this dependency is not required when using symfony 6.2+.

I've tested the crud maker on a new symfony 6.2 project without the framework-extra-bundle and the controller typehints work correctly

See: https://symfony.com/blog/new-in-symfony-6-2-built-in-cache-security-template-and-doctrine-attributes