### PR TITLE
[make:registration-form] use route attributes for test routes

### DIFF
--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -34,22 +34,9 @@ class MakeRegistrationFormTest extends MakerTestCase
                 );
 
                 if (60000 > $runner->getSymfonyVersion()) {
-                    /*
-                     * @Legacy - Drop when Symfony 6.0 is LTS
-                     *
-                     * This is a round about way to handle empty yaml files and YamlSourceManipulator.
-                     * Prior to Symfony 6.0, the routes.yaml was empty w/ a comment line. YSM
-                     * requires a top level array structure to manipulate them.
-                     */
-                    $runner->writeFile('config/routes.yaml', 'app_homepage:');
+                    // @legacy - In 5.4 tests, we need to tell Symfony to look for the route attributes in `src/Controller`
+                    $runner->copy('router-annotations.yaml', 'config/routes/annotations.yaml');
                 }
-
-                $runner->modifyYamlFile('config/routes.yaml', function (array $yaml) {
-                    $yaml['app_homepage'] = ['path' => '/', 'controller' => 'App\Controller\TestingController::homepage'];
-                    $yaml['app_anonymous'] = ['path' => '/anonymous', 'controller' => 'App\Controller\TestingController::anonymous'];
-
-                    return $yaml;
-                });
             })
         ;
     }

--- a/tests/fixtures/make-registration-form/standard_setup/src/Controller/TestingController.php
+++ b/tests/fixtures/make-registration-form/standard_setup/src/Controller/TestingController.php
@@ -4,9 +4,11 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 class TestingController extends AbstractController
 {
+    #[Route(path: '/', name: 'app_homepage')]
     public function homepage()
     {
         $this->denyAccessUnlessGranted('ROLE_USER');
@@ -14,6 +16,7 @@ class TestingController extends AbstractController
         return new Response('Page Success');
     }
 
+    #[Route(path: '/anonymous', name: 'app_anonymous')]
     public function anonymous()
     {
         return new Response('Page Success');


### PR DESCRIPTION
IIRC we used a `yaml` router config in tests to avoid recipe changes / `doctrine/annotations` problems - this should no longer be a problem as we don't support annotations in maker. So let's be a bit more realistic in our tests and just use route attributes...