### PR TITLE
[make:authenticator] Core\Security or SecurityBundle\Security - Avoid deprecations in 6.2

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -28,6 +28,7 @@ use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\MakerBundle\Util\YamlManipulationFailedException;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
@@ -42,7 +43,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Security as LegacySecurity;
 use Symfony\Component\Security\Guard\AuthenticatorInterface as GuardAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -273,13 +274,19 @@ final class MakeAuthenticator extends AbstractMaker
         $useStatements->addUseStatement([
             RedirectResponse::class,
             UrlGeneratorInterface::class,
-            Security::class,
             AbstractLoginFormAuthenticator::class,
             CsrfTokenBadge::class,
             UserBadge::class,
             PasswordCredentials::class,
             TargetPathTrait::class,
         ]);
+
+        // @legacy - Can be removed when Symfony 5.4 support is dropped
+        if (class_exists(Security::class)) {
+            $useStatements->addUseStatement(Security::class);
+        } else {
+            $useStatements->addUseStatement(LegacySecurity::class);
+        }
 
         $userClassNameDetails = $this->generator->createClassNameDetails(
             '\\'.$userClass,


### PR DESCRIPTION
When using make:authenticator on a Symfony 6.2 project the generated code is deprecated.

In the generated code, `use Symfony\Component\Security\Core\Security;` should be replace by  `use Symfony\Bundle\SecurityBundle\Security;`.

However, in order to respect the compatibility with 5.4 I used a workaround.
