### PR TITLE
[make:crud] render or renderForm - Avoid deprecations in 6.2

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -70,7 +70,8 @@ final class MakeCrud extends AbstractMaker
     {
         $command
             ->addArgument('entity-class', InputArgument::OPTIONAL, sprintf('The class name of the entity to create CRUD (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
-            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCrud.txt'));
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCrud.txt'))
+        ;
 
         $inputConfig->setArgumentAsNonInteractive('entity-class');
     }

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -70,8 +70,7 @@ final class MakeCrud extends AbstractMaker
     {
         $command
             ->addArgument('entity-class', InputArgument::OPTIONAL, sprintf('The class name of the entity to create CRUD (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
-            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCrud.txt'))
-        ;
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeCrud.txt'));
 
         $inputConfig->setArgumentAsNonInteractive('entity-class');
     }
@@ -168,20 +167,20 @@ final class MakeCrud extends AbstractMaker
             $controllerClassDetails->getFullName(),
             'crud/controller/Controller.tpl.php',
             array_merge([
-                    'use_statements' => $useStatements,
-                    'entity_class_name' => $entityClassDetails->getShortName(),
-                    'form_class_name' => $formClassDetails->getShortName(),
-                    'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
-                    'route_name' => $routeName,
-                    'templates_path' => $templatesPath,
-                    'entity_var_plural' => $entityVarPlural,
-                    'entity_twig_var_plural' => $entityTwigVarPlural,
-                    'entity_var_singular' => $entityVarSingular,
-                    'entity_twig_var_singular' => $entityTwigVarSingular,
-                    'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
-                    // @legacy - Remove when support for Symfony <6 is dropped - hack to determine version
-                    'use_render_form' =>  method_exists(AbstractController::class, 'getDoctrine'),
-                ],
+                'use_statements' => $useStatements,
+                'entity_class_name' => $entityClassDetails->getShortName(),
+                'form_class_name' => $formClassDetails->getShortName(),
+                'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
+                'route_name' => $routeName,
+                'templates_path' => $templatesPath,
+                'entity_var_plural' => $entityVarPlural,
+                'entity_twig_var_plural' => $entityTwigVarPlural,
+                'entity_var_singular' => $entityVarSingular,
+                'entity_twig_var_singular' => $entityTwigVarSingular,
+                'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
+                // @legacy - Remove when support for Symfony <6 is dropped - hack to determine version
+                'use_render_form' => method_exists(AbstractController::class, 'getDoctrine'),
+            ],
                 $repositoryVars
             )
         );

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -167,20 +167,20 @@ final class MakeCrud extends AbstractMaker
             $controllerClassDetails->getFullName(),
             'crud/controller/Controller.tpl.php',
             array_merge([
-                'use_statements' => $useStatements,
-                'entity_class_name' => $entityClassDetails->getShortName(),
-                'form_class_name' => $formClassDetails->getShortName(),
-                'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
-                'route_name' => $routeName,
-                'templates_path' => $templatesPath,
-                'entity_var_plural' => $entityVarPlural,
-                'entity_twig_var_plural' => $entityTwigVarPlural,
-                'entity_var_singular' => $entityVarSingular,
-                'entity_twig_var_singular' => $entityTwigVarSingular,
-                'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
-                // @legacy - Remove when support for Symfony <6 is dropped - hack to determine version
-                'use_render_form' => method_exists(AbstractController::class, 'getDoctrine'),
-            ],
+                    'use_statements' => $useStatements,
+                    'entity_class_name' => $entityClassDetails->getShortName(),
+                    'form_class_name' => $formClassDetails->getShortName(),
+                    'route_path' => Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix()),
+                    'route_name' => $routeName,
+                    'templates_path' => $templatesPath,
+                    'entity_var_plural' => $entityVarPlural,
+                    'entity_twig_var_plural' => $entityTwigVarPlural,
+                    'entity_var_singular' => $entityVarSingular,
+                    'entity_twig_var_singular' => $entityTwigVarSingular,
+                    'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
+                    // @legacy - Remove when support for Symfony <6 is dropped - hack to determine version
+                    'use_render_form' => method_exists(AbstractController::class, 'getDoctrine'),
+                ],
                 $repositoryVars
             )
         );

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -181,7 +181,7 @@ final class MakeCrud extends AbstractMaker
                     'entity_twig_var_singular' => $entityTwigVarSingular,
                     'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
                     // @legacy - Remove when support for Symfony <6 is dropped
-                    'use_render_form' => Kernel::VERSION_ID < 60000,
+                    'use_render_form' => Kernel::VERSION_ID < 62000,
                 ],
                 $repositoryVars
             )

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -179,7 +179,8 @@ final class MakeCrud extends AbstractMaker
                     'entity_var_singular' => $entityVarSingular,
                     'entity_twig_var_singular' => $entityTwigVarSingular,
                     'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
-                    'use_render_form' => method_exists(AbstractController::class, 'renderForm'),
+                    // @legacy - Remove when support for Symfony <6 is dropped - hack to determine version
+                    'use_render_form' =>  method_exists(AbstractController::class, 'getDoctrine'),
                 ],
                 $repositoryVars
             )

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -38,6 +38,7 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\Validator\Validation;
@@ -179,8 +180,8 @@ final class MakeCrud extends AbstractMaker
                     'entity_var_singular' => $entityVarSingular,
                     'entity_twig_var_singular' => $entityTwigVarSingular,
                     'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
-                    // @legacy - Remove when support for Symfony <6 is dropped - hack to determine version
-                    'use_render_form' => method_exists(AbstractController::class, 'getDoctrine'),
+                    // @legacy - Remove when support for Symfony <6 is dropped
+                    'use_render_form' => Kernel::VERSION_ID < 60000,
                 ],
                 $repositoryVars
             )

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -62,7 +62,7 @@ class <?= $class_name ?> extends AbstractController
 <?php } else { ?>
         return $this->render('<?= $templates_path ?>/new.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
 <?php } ?>
     }
@@ -107,7 +107,7 @@ class <?= $class_name ?> extends AbstractController
 <?php } else { ?>
         return $this->render('<?= $templates_path ?>/edit.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
 <?php } ?>
     }


### PR DESCRIPTION
The old `use_render_form` is always true, in both Symfony 5.4 and 6.2 so we always end un with a `$this->renderForm() ` that has been deprecated in 6.2.

This (ugly, but nevertheless working) hack tests if `getDoctrine` exists in AbstractController allows us to determine Symfony's version and if we should generate a `$this->render()` or a `$this->renderForm()`.