### PR TITLE
[make:serializer:normalizer] Inject a NormalizerInterface instead of an ObjectNormalizer

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -194,6 +194,7 @@ class FileManager
         }
 
         $finalPath = implode('/', $finalParts);
+
         // Normalize: // => /
         // Normalize: /./ => /
         return str_replace(['//', '/./'], '/', $finalPath);

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -94,6 +94,7 @@
             </service>
 
             <service id="maker.maker.make_serializer_normalizer" class="Symfony\Bundle\MakerBundle\Maker\MakeSerializerNormalizer">
+                <argument type="service" id="maker.file_manager" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -6,7 +6,7 @@ namespace <?= $namespace; ?>;
 
 class <?= $class_name ?> implements NormalizerInterface, CacheableSupportsMethodInterface
 {
-    public function __construct(private ObjectNormalizer $normalizer)
+    public function __construct(private NormalizerInterface $objectNormalizer)
     {
     }
 


### PR DESCRIPTION
Related to https://github.com/symfony/maker-bundle/issues/1252

This PR aims to do not rely anymore on constructor argument injection and use `NormalizerAwareInterface`/`NormalizerAwareTrait` instead.

Moreover, this allows to not inject explicitly the `ObjectNormalizer` anymore which can be considered as a bad practice as it is a concrete implementation of the `NormalizerInterface`.