### PR TITLE
[make:migration] Change message when required package for migration doesn't exist.

### DIFF
--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -147,7 +147,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
     {
         $dependencies->addClassDependency(
             DoctrineMigrationsBundle::class,
-            'migrations'
+            'doctrine/doctrine-migrations-bundle'
         );
     }
 


### PR DESCRIPTION
Related to issue #1274
- Change message when required package for migration doesn't exist.