### PR TITLE
:wastebasket: render and renderForm

### DIFF
--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -55,7 +55,7 @@ class <?= $class_name ?> extends AbstractController
 <?php } ?>
 
 <?php if ($use_render_form) { ?>
-        return $this->renderForm('<?= $templates_path ?>/new.html.twig', [
+        return $this->render('<?= $templates_path ?>/new.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form,
         ]);
@@ -100,7 +100,7 @@ class <?= $class_name ?> extends AbstractController
 <?php } ?>
 
 <?php if ($use_render_form) { ?>
-        return $this->renderForm('<?= $templates_path ?>/edit.html.twig', [
+        return $this->render('<?= $templates_path ?>/edit.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
             'form' => $form,
         ]);


### PR DESCRIPTION
Use render instead of renderForm in controller template.
RenderForm is deprecated : https://github.com/symfony/symfony/commit/7edbdf8b11e9bcd976c42085d94cc8778abb6de5