### PR TITLE
[make:registration-form] avoid using internal method get from Request

### DIFF
--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -78,7 +78,7 @@ class <?= $class_name; ?> extends AbstractController
 <?php if (!$verify_email_anonymously): ?>
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY');
 <?php else: ?>
-        $id = $request->get('id');
+        $id = $request->query->get('id');
 
         if (null === $id) {
             return $this->redirectToRoute('app_register');


### PR DESCRIPTION
When launching the `make:registration-controller`, there is a `$request->get('id')` in the generated controller.

Replace `$request->get('id')` with `$request->query->get('id')` in the RegistrationController template to avoid using the Symfony internal method.

