### PR TITLE
[make:entity] don't set array field default value for nullable column

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -110,7 +110,7 @@ final class ClassSourceManipulator
         $attributes[] = $this->buildAttributeNode(Column::class, $columnOptions, 'ORM');
 
         $defaultValue = null;
-        if ('array' === $typeHint) {
+        if ('array' === $typeHint && !$nullable) {
             $defaultValue = new Node\Expr\Array_([], ['kind' => Node\Expr\Array_::KIND_SHORT]);
         } elseif ($typeHint && '\\' === $typeHint[0] && false !== strpos($typeHint, '\\', 1)) {
             $typeHint = $this->addUseStatementIfNecessary(substr($typeHint, 1));


### PR DESCRIPTION
Setting a default value will lead to a wrong (not nullable) return value of the getter method.

Also setting a default value on a nullable field somehow cancels out the intention of nullable (except for setting it explicitly).

I'm not sure if this should be treated as a bc break. but since no existing properties are overwritten i think it should be fine.