### PR TITLE
[make:authenticator] Add missing RememberMeBadge

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -49,6 +49,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
@@ -276,6 +277,7 @@ final class MakeAuthenticator extends AbstractMaker
             UrlGeneratorInterface::class,
             AbstractLoginFormAuthenticator::class,
             CsrfTokenBadge::class,
+            RememberMeBadge::class,
             UserBadge::class,
             PasswordCredentials::class,
             TargetPathTrait::class,

--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -23,9 +23,10 @@ class <?= $class_name; ?> extends AbstractLoginFormAuthenticator
         return new Passport(
             new UserBadge($<?= $username_field_var ?>),
             new PasswordCredentials($request->request->get('password', '')),
-            [
+            array_filter([
                 new CsrfTokenBadge('authenticate', $request->request->get('_csrf_token')),
-            ]
+                (bool) $request->request->get('_remember_me') ? new RememberMeBadge() : null,
+            ])
         );
     }
 


### PR DESCRIPTION
Hi,

I see that RememberMeBadge is missing on LoginForm guard that is generated with `make:authenticator`. It can be usefull to add badge if checkbox is uncommented and checked.