### PR TITLE
Better security rules

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -53,6 +53,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotCompromisedPassword;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -292,6 +293,7 @@ class MakeResetPassword extends AbstractMaker
             OptionsResolver::class,
             Length::class,
             NotBlank::class,
+            NotCompromisedPassword::class,
         ]);
 
         $generator->generateClass(

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -56,6 +56,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotCompromisedPassword;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
@@ -117,6 +118,7 @@ class MakeResetPassword extends AbstractMaker
         $dependencies->addClassDependency(MailerInterface::class, 'symfony/mailer');
         $dependencies->addClassDependency(Form::class, 'symfony/form');
         $dependencies->addClassDependency(Validation::class, 'symfony/validator');
+        $dependencies->addClassDependency(HttpClientInterface::class, 'symfony/http-client');
         $dependencies->addClassDependency(SecurityBundle::class, 'security-bundle');
         $dependencies->addClassDependency(AppVariable::class, 'twig');
 

--- a/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
@@ -29,7 +29,9 @@ class <?= $class_name ?> extends AbstractType
                             'max' => 64,
                             'maxMessage' => 'Your password cannot be longer than {{ limit }} characters',
                         ]),
-                        new NotCompromisedPassword(),
+                        new NotCompromisedPassword([
+                            'skipOnError' => true,
+                        ]),
                     ],
                     'label' => 'New password',
                 ],

--- a/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
@@ -22,11 +22,14 @@ class <?= $class_name ?> extends AbstractType
                             'message' => 'Please enter a password',
                         ]),
                         new Length([
-                            'min' => 6,
+                            // min and max lengths recommended as per the OWASP Cheat Sheet and the hashing function limitations
+                            // see https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls
+                            'min' => 8,
                             'minMessage' => 'Your password should be at least {{ limit }} characters',
-                            // max length allowed by Symfony for security reasons
-                            'max' => 4096,
+                            'max' => 64,
+                            'maxMessage' => 'Your password cannot be longer than {{ limit }} characters',
                         ]),
+                        new NotCompromisedPassword(),
                     ],
                     'label' => 'New password',
                 ],


### PR DESCRIPTION
Hi,

I recently prepared and organised workshops during the SymfonyLive Paris 2023 and noted that a few things could be enhanced in the `make:auth` command templates.

* As the `NotCompromisedPassword` constraint exists, we could leverage on it and then deny compromised password when a password is reset. `skipOnError` is set to true meaning that we continue the process if the API cannot be reached or returns a HTTP error status code.

* The OWASP recommends a minimum of 8 characters and a maximum of 64 (see [the cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls)).
I propose to stick of these values and especially the maximum length for the follwing main reasons:
    * There is no reason for using so long passwords.
    * `bcrypt`, which is the default hasing function at the time of writing, allows only inputs of 72 bytes