### PR TITLE
MakeEntity: Removing parentheses in field types overview

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -486,9 +486,9 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
                 $line = sprintf('  * <comment>%s</comment>', $mainType);
 
                 if (\is_string($subTypes) && $subTypes) {
-                    $line .= sprintf(' (%s)', $subTypes);
+                    $line .= sprintf(' or %s', $subTypes);
                 } elseif (\is_array($subTypes) && !empty($subTypes)) {
-                    $line .= sprintf(' (or %s)', implode(', ', array_map(
+                    $line .= sprintf(' or %s', implode(' or ', array_map(
                         static fn ($subType) => sprintf('<comment>%s</comment>', $subType), $subTypes))
                     );
 


### PR DESCRIPTION
Reason: In `date (or date_immutable)`, the second option looks inferior/exotic. So I changed it to look more equal: `date or date_immutable`