### PR TITLE
[make:user] add the void return type to eraseCredentials()

### DIFF
--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -304,7 +304,7 @@ final class UserClassBuilder
         // add eraseCredentials: always empty
         $builder = $manipulator->createMethodBuilder(
             'eraseCredentials',
-            null,
+            'void',
             false,
             ['@see UserInterface']
         );

--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -90,7 +90,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -85,7 +85,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -85,7 +85,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
@@ -63,7 +63,7 @@ class User implements UserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
@@ -75,7 +75,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/UserModelWithPassword.php
+++ b/tests/Security/fixtures/expected/UserModelWithPassword.php
@@ -70,7 +70,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/UserModelWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserModelWithoutPassword.php
@@ -49,7 +49,7 @@ class User implements UserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithEmailAsIdentifier.php
@@ -109,7 +109,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithPassword.php
@@ -104,7 +104,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -104,7 +104,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserEntityWithoutPassword.php
@@ -91,7 +91,7 @@ class User implements UserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithEmailAsIdentifier.php
@@ -94,7 +94,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithPassword.php
@@ -89,7 +89,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;

--- a/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithoutPassword.php
+++ b/tests/Security/fixtures/expected/legacy_5_user_class/UserModelWithoutPassword.php
@@ -77,7 +77,7 @@ class User implements UserInterface
     /**
      * @see UserInterface
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
         // If you store any temporary, sensitive data on the user, clear it here
         // $this->plainPassword = null;


### PR DESCRIPTION
In 6.3 tests - handle:
```
Method "Symfony\Component\Security\Core\User\UserInterface::eraseCredentials()" might add "void" 
as a native return type declaration in the future. Do the same in implementation "App\Entity\User" now
 to avoid errors or add an explicit @return annotation to suppress this message.
```