### PR TITLE
[git-released] v1.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## [v1.49.0](https://github.com/symfony/maker-bundle/releases/tag/v1.49.0)
 
-*May 23rd, 2023*
+*June 7th, 2023*
 
 ### Feature
 
+- [#1321](https://github.com/symfony/maker-bundle/pull/1321) - Changing make:stimulus-controller to require StimulusBundle - *@weaverryan*
 - [#1309](https://github.com/symfony/maker-bundle/pull/1309) - Apply `get_class_to_class_keyword` PHP-CS-Fixer rule - *@seb-jean*
 - [#1276](https://github.com/symfony/maker-bundle/pull/1276) - [make:migration] Change message when required package for migration doesn't exist. - *@bdaler*
 - [#1261](https://github.com/symfony/maker-bundle/pull/1261) - [make:registration-form] use UniqueEntity attribute instead of annotation - *@jrushlow*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [v1.49.0](https://github.com/symfony/maker-bundle/releases/tag/v1.49.0)
+
+*May 23rd, 2023*
+
+### Feature
+
+- [#1309](https://github.com/symfony/maker-bundle/pull/1309) - Apply `get_class_to_class_keyword` PHP-CS-Fixer rule - *@seb-jean*
+- [#1276](https://github.com/symfony/maker-bundle/pull/1276) - [make:migration] Change message when required package for migration doesn't exist. - *@bdaler*
+- [#1261](https://github.com/symfony/maker-bundle/pull/1261) - [make:registration-form] use UniqueEntity attribute instead of annotation - *@jrushlow*
+- [#1253](https://github.com/symfony/maker-bundle/pull/1253) - [make:migration] Add link to new migration files - *@nicolas-grekas*
+- [#1251](https://github.com/symfony/maker-bundle/pull/1251) - [make:*] use php-cs-fixer to style/lint all generated php templates - *@jrushlow*
+- [#1244](https://github.com/symfony/maker-bundle/pull/1244) - [make:security:form-login] new maker to use built in FormLogin - *@jrushlow*
+- [#1242](https://github.com/symfony/maker-bundle/pull/1242) - [make:*] use static return type instead of self for setters - *@jrushlow*
+- [#1239](https://github.com/symfony/maker-bundle/pull/1239) - Improve error messages to show PHP & XML configurations are not supported - *@ThomasLandauer*
+- [#1238](https://github.com/symfony/maker-bundle/pull/1238) - [make:*] improve output messages for Symfony CLI users - *@jrushlow*
+- [#1237](https://github.com/symfony/maker-bundle/pull/1237) - [make:registration-form] Print registration form errors - *@comxd*
+### Bug
+
+- [#1307](https://github.com/symfony/maker-bundle/pull/1307) - [make:twig-component] handle upstream changes to how live components are rendered - *@jrushlow*
+- [#1270](https://github.com/symfony/maker-bundle/pull/1270) - [make:authenticator] Core\Security or SecurityBundle\Security - Avoid deprecations in 6.2 - *@nacorp*
+- [#1265](https://github.com/symfony/maker-bundle/pull/1265) - [make:crud] Make sensio/framework-extra-bundle an optional dependency - *@acrobat*
+- [#1264](https://github.com/symfony/maker-bundle/pull/1264) - [make:controller] doctrine/annotations is not needed - *@jrushlow*
+- [#1262](https://github.com/symfony/maker-bundle/pull/1262) - [make:reset-password] doctrine/annotations are not needed - *@jrushlow*
+
 ## [v1.48.0](https://github.com/symfony/maker-bundle/releases/tag/v1.48.0)
 
 *November 14th, 2022*


### PR DESCRIPTION
# Changelog

## [v1.49.0](https://github.com/symfony/maker-bundle/releases/tag/v1.49.0)

*Jun 7th, 2023*

### Feature

- [#1321](https://github.com/symfony/maker-bundle/pull/1321) - Changing make:stimulus-controller to require StimulusBundle - *@weaverryan*
- [#1309](https://github.com/symfony/maker-bundle/pull/1309) - Apply `get_class_to_class_keyword` PHP-CS-Fixer rule - *@seb-jean*
- [#1276](https://github.com/symfony/maker-bundle/pull/1276) - [make:migration] Change message when required package for migration doesn't exist. - *@bdaler*
- [#1261](https://github.com/symfony/maker-bundle/pull/1261) - [make:registration-form] use UniqueEntity attribute instead of annotation - *@jrushlow*
- [#1253](https://github.com/symfony/maker-bundle/pull/1253) - [make:migration] Add link to new migration files - *@nicolas-grekas*
- [#1251](https://github.com/symfony/maker-bundle/pull/1251) - [make:*] use php-cs-fixer to style/lint all generated php templates - *@jrushlow*
- [#1244](https://github.com/symfony/maker-bundle/pull/1244) - [make:security:form-login] new maker to use built in FormLogin - *@jrushlow*
- [#1242](https://github.com/symfony/maker-bundle/pull/1242) - [make:*] use static return type instead of self for setters - *@jrushlow*
- [#1239](https://github.com/symfony/maker-bundle/pull/1239) - Improve error messages to show PHP & XML configurations are not supported - *@ThomasLandauer*
- [#1238](https://github.com/symfony/maker-bundle/pull/1238) - [make:*] improve output messages for Symfony CLI users - *@jrushlow*
- [#1237](https://github.com/symfony/maker-bundle/pull/1237) - [make:registration-form] Print registration form errors - *@comxd*
### Bug

- [#1307](https://github.com/symfony/maker-bundle/pull/1307) - [make:twig-component] handle upstream changes to how live components are rendered - *@jrushlow*
- [#1270](https://github.com/symfony/maker-bundle/pull/1270) - [make:authenticator] Core\Security or SecurityBundle\Security - Avoid deprecations in 6.2 - *@nacorp*
- [#1265](https://github.com/symfony/maker-bundle/pull/1265) - [make:crud] Make sensio/framework-extra-bundle an optional dependency - *@acrobat*
- [#1264](https://github.com/symfony/maker-bundle/pull/1264) - [make:controller] doctrine/annotations is not needed - *@jrushlow*
- [#1262](https://github.com/symfony/maker-bundle/pull/1262) - [make:reset-password] doctrine/annotations are not needed - *@jrushlow*


_Generated by Git Released_