### PR TITLE
bump phpunit-bridge version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/orm": "^2.10.0",
         "symfony/http-client": "^5.4.7|^6.0",
-        "symfony/phpunit-bridge": "^5.4.7|^6.0",
+        "symfony/phpunit-bridge": "^5.4.17|^6.0",
         "symfony/polyfill-php80": "^1.16.0",
         "symfony/security-core": "^5.4.7|^6.0",
         "symfony/yaml": "^5.4.3|^6.0",


### PR DESCRIPTION
`v5.4.17` of `phpunit-bridge` fixed compatibility with `doctrine/annotations:^2.0`.
https://github.com/symfony/symfony/pull/48718/files#diff-7b61897762550adef47d038e61dbb44e9759b80179c8c7674fc2300c207fe751

Without the version bump to at least `5.4.17` - CI fails against `5.4.*` w/ `--prefer-lowest` dependencies. `phpunit-bridge:^5.4.7` is the lowest, but not compatible w/ MakerBundle as `doctrine/annotations` isn't needed.

Fixes:
```
PHP Fatal error:  Uncaught Error: Call to undefined method Doctrine\Common\Annotations\AnnotationRegistry::registerLoader() 
in /home/runner/work/maker-bundle/maker-bundle/vendor/symfony/phpunit-bridge/bootstrap.php:34
```
in several tests.
