### PR TITLE
[make:entity] better repo methods

### DIFF
--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -35,7 +35,7 @@ final class EntityClassGenerator
     ) {
     }
 
-    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true, bool $broadcast = false): string
+    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true, bool $broadcast = false, bool $useLegacyRepoMethods = false): string
     {
         $repoClassDetails = $this->generator->createClassNameDetails(
             $entityClassDetails->getRelativeName(),
@@ -77,14 +77,15 @@ final class EntityClassGenerator
                 $repoClassDetails->getFullName(),
                 $entityClassDetails->getFullName(),
                 $withPasswordUpgrade,
-                true
+                true,
+                $useLegacyRepoMethods
             );
         }
 
         return $entityPath;
     }
 
-    public function generateRepositoryClass(string $repositoryClass, string $entityClass, bool $withPasswordUpgrade, bool $includeExampleComments = true): void
+    public function generateRepositoryClass(string $repositoryClass, string $entityClass, bool $withPasswordUpgrade, bool $includeExampleComments = true, bool $useLegacyMethods = false): void
     {
         $shortEntityClass = Str::getShortClassName($entityClass);
         $entityAlias = strtolower($shortEntityClass[0]);
@@ -121,6 +122,7 @@ final class EntityClassGenerator
                 'with_password_upgrade' => $withPasswordUpgrade,
                 'password_upgrade_user_interface' => $interfaceClassNameDetails,
                 'include_example_comments' => $includeExampleComments,
+                'use_legacy_methods' => $useLegacyMethods,
             ]
         );
     }

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -103,6 +103,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             ->addOption('broadcast', 'b', InputOption::VALUE_NONE, 'Add the ability to broadcast entity updates using Symfony UX Turbo?')
             ->addOption('regenerate', null, InputOption::VALUE_NONE, 'Instead of adding new fields, simply generate the methods (e.g. getter/setter) for existing fields')
             ->addOption('overwrite', null, InputOption::VALUE_NONE, 'Overwrite any existing getter/setter methods')
+            ->addOption('legacy-methods', null, InputOption::VALUE_NONE, 'Generate repository with legacy <fg=yellow>save()</> and <fg=yellow>remove()</> methods.')
             ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeEntity.txt'))
         ;
 

--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -19,6 +19,7 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
         parent::__construct($registry, <?= $entity_class_name; ?>::class);
     }
 
+<?php if ($use_legacy_methods): ?>
     public function save(<?= $entity_class_name ?> $entity, bool $flush = false): void
     {
         $this->getEntityManager()->persist($entity);
@@ -36,6 +37,34 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
             $this->getEntityManager()->flush();
         }
     }
+<?php else: ?>
+    public function persist(<?= $entity_class_name ?> $entity): void
+    {
+        $this->_em->persist($entity);
+    }
+
+    public function persistAndFlush(<?= $entity_class_name ?> $entity): void
+    {
+        $this->persist($entity);
+        $this->flush();
+    }
+
+    public function flush(): void
+    {
+        $this->_em->flush();
+    }
+
+    public function remove(<?= $entity_class_name ?> $entity): void
+    {
+        $this->_em->remove($entity);
+    }
+
+    public function removeAndFlush(<?= $entity_class_name ?> $entity): void
+    {
+        $this->remove($entity);
+        $this->flush();
+    }
+<?php endif; ?>
 <?php if ($include_example_comments): // When adding a new method without existing default comments, the blank line is automatically added.?>
 
 <?php endif; ?>


### PR DESCRIPTION
- repositories are generated with `persist(...)`, `persistAndFlush(...)`, `remove(...)`, `removeAndFlush(...)` & `flush()` methods.

- legacy `save(...)` & `remove(...)` methods _may_ be generated instead by passing the `--legacy-methods` option to `make:entity`

The legacy option is used to provide consistency in projects that already have repositories with the `save()` && `remove()` methods. However, we strongly encourage projects not to use `--legacy-methods` as it is deprecated and will be removed in a future version of MakerBundle.

The legacy option is _not_ available with `make:user` or `make:reset-password` to improve code base maintainability.