### PR TITLE
Fix crash on user class without properties

### DIFF
--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -89,6 +89,17 @@ final class InteractiveSecurityHelper
             return 'username';
         }
 
+        $classProperties = $this->getClassProperties($userClass);
+
+        return $io->choice(
+            sprintf('Which field on your <fg=yellow>%s</> class will people enter when logging in?', $userClass),
+            $classProperties,
+            property_exists($userClass, 'username') ? 'username' : (property_exists($userClass, 'email') ? 'email' : null)
+        );
+    }
+
+    private function getClassProperties(string $userClass): array
+    {
         $classProperties = [];
         $reflectionClass = new \ReflectionClass($userClass);
         foreach ($reflectionClass->getProperties() as $property) {
@@ -99,11 +110,7 @@ final class InteractiveSecurityHelper
             throw new \LogicException(sprintf('No properties were found in "%s" entity', $userClass));
         }
 
-        return $io->choice(
-            sprintf('Which field on your <fg=yellow>%s</> class will people enter when logging in?', $userClass),
-            $classProperties,
-            property_exists($userClass, 'username') ? 'username' : (property_exists($userClass, 'email') ? 'email' : null)
-        );
+        return $classProperties;
     }
 
     public function guessEmailField(SymfonyStyle $io, string $userClass): string
@@ -112,11 +119,7 @@ final class InteractiveSecurityHelper
             return 'email';
         }
 
-        $classProperties = [];
-        $reflectionClass = new \ReflectionClass($userClass);
-        foreach ($reflectionClass->getProperties() as $property) {
-            $classProperties[] = $property->name;
-        }
+        $classProperties = $this->getClassProperties($userClass);
 
         return $io->choice(
             sprintf('Which field on your <fg=yellow>%s</> class holds the email address?', $userClass),
@@ -130,11 +133,7 @@ final class InteractiveSecurityHelper
             return 'password';
         }
 
-        $classProperties = [];
-        $reflectionClass = new \ReflectionClass($userClass);
-        foreach ($reflectionClass->getProperties() as $property) {
-            $classProperties[] = $property->name;
-        }
+        $classProperties = $this->getClassProperties($userClass);
 
         return $io->choice(
             sprintf('Which field on your <fg=yellow>%s</> class holds the encoded password?', $userClass),


### PR DESCRIPTION
End builder properly when no user class properties as choices are available.

---

I had this User class

```php
class EmptyUser implements UserInterface
{
    public function getRoles(): array
    {
        return [];
    }

    public function eraseCredentials()
    {
        // TODO: Implement eraseCredentials() method.
    }

    public function getUserIdentifier(): string
    {
        return '';
    }

}
```

and `make:reset-password` ended with generic critical error

```
 What is the User entity that should be used with the "forgotten password" feature? (e.g. App\Entity\User) []:
 > \Gamecon\Symfony\Entity\EmptyUser

[critical] Error thrown while running command "make:reset-password". Message: "Choice question must have at least 1 choice available."

In ChoiceQuestion.php line 36:
                                                          
  Choice question must have at least 1 choice available.                                                        
```

Reason is a missing check that given user class has some properties, used later as choices.