### PR TITLE
Allow to add JoinTable and InverseJoinColunm ORM attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=8.0",
+        "doctrine/annotations": "2.0.x-dev",
         "doctrine/inflector": "^2.0",
         "nikic/php-parser": "^4.11",
         "symfony/config": "^5.4.7|^6.0",
@@ -24,10 +25,12 @@
         "symfony/finder": "^5.4.3|^6.0",
         "symfony/framework-bundle": "^5.4.7|^6.0",
         "symfony/http-kernel": "^5.4.7|^6.0",
-        "symfony/process": "^5.4.7|^6.0"
+        "symfony/process": "^5.4.7|^6.0",
+        "symfony/security-bundle": "^5.4.7|^6.0"
     },
     "require-dev": {
         "composer/semver": "^3.0",
+        "dbrekelmans/bdi": "dev-main",
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/orm": "^2.10.0",
         "symfony/http-client": "^5.4.7|^6.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="TEST_DATABASE_DSN" value="mysql://root:root@127.0.0.1:3306/test_maker?serverVersion=5.7" />
+        <env name="TEST_DATABASE_DSN" value="mysql://root:root@mariadb:3306/test_maker?serverVersion=5.7" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 

--- a/src/Doctrine/BaseRelation.php
+++ b/src/Doctrine/BaseRelation.php
@@ -28,6 +28,7 @@ abstract class BaseRelation
         private bool $isOwning = false,
         private bool $orphanRemoval = false,
         private bool $isNullable = false,
+        private array $additionnalAttributes = []
     ) {
     }
 
@@ -84,5 +85,10 @@ abstract class BaseRelation
     public function isNullable(): bool
     {
         return $this->isNullable;
+    }
+
+    public function getAdditionnalAttributes(): array
+    {
+        return $this->additionnalAttributes;
     }
 }

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -13,6 +13,12 @@ namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\InverseJoinColumn;
+use Doctrine\ORM\Mapping\JoinTable;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use PhpParser\Builder\Param;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToMany;
@@ -524,6 +530,34 @@ class ClassSourceManipulatorTest extends TestCase
                 isOwning: true,
             ),
         ];
+
+        yield 'many_to_many_join_table' => [
+            'User_simple.php',
+            'User_simple_join_table.php',
+            new RelationManyToMany(
+                propertyName: 'recipes',
+                targetClassName: \App\Entity\Recipe::class,
+                mapInverseRelation: false,
+                isOwning: true,
+                additionnalAttributes: [
+                    JoinTable::class => ['name' => 'users_have_recipes'],
+                ]
+            ),
+        ];
+
+        yield 'many_to_many_inverse_join_column' => [
+            'User_simple.php',
+            'User_simple_inverse_join_column.php',
+            new RelationManyToMany(
+                propertyName: 'recipes',
+                targetClassName: \App\Entity\Recipe::class,
+                mapInverseRelation: false,
+                isOwning: true,
+                additionnalAttributes: [
+                    InverseJoinColumn::class => ['name' => 'user_id', 'referencedColumnName' => 'id'],
+                ]
+            ),
+        ];
     }
 
     /**
@@ -642,6 +676,80 @@ class ClassSourceManipulatorTest extends TestCase
                 isOwning: true,
                 isNullable: true,
             ),
+        ];
+    }
+
+    /**
+     * @dataProvider getCantHaveAnnotationTests
+     */
+    public function testCantHaveAnnotation(string $relation, string $mappingAttribute, string $method): void
+    {
+        $source = file_get_contents(__DIR__.'/fixtures/source/User_simple.php');
+        $manipulator = new ClassSourceManipulator($source, false);
+
+        $relation = new $relation(
+            propertyName: 'category',
+            targetClassName: \App\Entity\Category::class,
+            mapInverseRelation: false,
+            isOwning: true,
+            additionnalAttributes: [
+                $mappingAttribute => [],
+            ]
+        );
+
+        $this->expectException(\LogicException::class);
+
+        $manipulator->$method($relation);
+    }
+
+    public function getCantHaveAnnotationTests(): \Generator
+    {
+        yield 'many_to_one_join_table' => [
+            RelationManyToOne::class,
+            JoinTable::class,
+            'addManyToOneRelation',
+        ];
+
+        yield 'one_to_one_join_table' => [
+            RelationOneToOne::class,
+            JoinTable::class,
+            'addOneToOneRelation',
+        ];
+
+        yield 'one_to_many_join_table' => [
+            RelationOneToMany::class,
+            JoinTable::class,
+            'addOneToManyRelation',
+        ];
+
+        yield 'one_to_many_inverse_join_column' => [
+            RelationOneToMany::class,
+            InverseJoinColumn::class,
+            'addOneToManyRelation',
+        ];
+
+        yield 'many_to_many_additionnal_attribute' => [
+            RelationManyToMany::class,
+            ManyToMany::class,
+            'addManyToManyRelation',
+        ];
+
+        yield 'many_to_one_additionnal_attribute' => [
+            RelationManyToOne::class,
+            ManyToOne::class,
+            'addManyToOneRelation',
+        ];
+
+        yield 'one_to_many_additionnal_attribute' => [
+            RelationOneToMany::class,
+            OneToMany::class,
+            'addOneToManyRelation',
+        ];
+
+        yield 'one_to_one_additionnal_attribute' => [
+            RelationOneToOne::class,
+            OneToOne::class,
+            'addOneToOneRelation',
         ];
     }
 

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse_join_column.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_inverse_join_column.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\ManyToMany(targetEntity: Recipe::class)]
+    #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id')]
+    private Collection $recipes;
+
+    public function __construct()
+    {
+        $this->recipes = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Collection<int, Recipe>
+     */
+    public function getRecipes(): Collection
+    {
+        return $this->recipes;
+    }
+
+    public function addRecipe(Recipe $recipe): static
+    {
+        if (!$this->recipes->contains($recipe)) {
+            $this->recipes->add($recipe);
+        }
+
+        return $this;
+    }
+
+    public function removeRecipe(Recipe $recipe): static
+    {
+        $this->recipes->removeElement($recipe);
+
+        return $this;
+    }
+}

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_join_table.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_join_table.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\ManyToMany(targetEntity: Recipe::class)]
+    #[ORM\JoinTable(name: 'users_have_recipes')]
+    private Collection $recipes;
+
+    public function __construct()
+    {
+        $this->recipes = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Collection<int, Recipe>
+     */
+    public function getRecipes(): Collection
+    {
+        return $this->recipes;
+    }
+
+    public function addRecipe(Recipe $recipe): static
+    {
+        if (!$this->recipes->contains($recipe)) {
+            $this->recipes->add($recipe);
+        }
+
+        return $this;
+    }
+
+    public function removeRecipe(Recipe $recipe): static
+    {
+        $this->recipes->removeElement($recipe);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Proposition : Allow to add *JoinTable* attribute on *ManyToMany* relations and *InverseJoinColumn* attribute on *ManyToMany*, *ManyToOne* and *OneToOne* relations

Points of attention :

Point 1 : Other attributes can be added. It may be preferable to only allow a whitelist with *JoinTable* and *InverseJoinColumn* instead.

Point 2 : It's not be possible to override attributes added added by the manipulator, for example, the *JoinColumn* on *ManyToOne* and *OneToOne* for non-nullable owning relation. Maybe it should be more permissive.

Point 3 : the attributes array becomes indexed by string (the mapping class) to not allow the same attribute multiple time, it's set back to numerical indexes before the *addProperty* as before. Maybe it should be more permissive if some mapping attributes may appear multiple time on the same class attribute ?

Point 4 : test only cover my initial need : adding *JoinTable* and *InverseJoinColumn* on *ManyToMany* relation, not *InverseJoinColumn* on *ManyToOne* and *OneToOne*. But tests cover that *JoinTable* can't be used on others relations than *ManyToMany* and that *InverseJoinColumn* can't be used on *OneToMany*. Tests also cover that a relation mapping can't be added as additionnal attribute on itself (for example, adding *ManyToMany* additionnal attribute on a *RelationManyToMany*)

Related issue : https://github.com/symfony/maker-bundle/issues/1316