### PR TITLE
 Add cascade annotation option support in ClassSourceManipulator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=8.0",
+        "doctrine/annotations": "2.0.x-dev",
         "doctrine/inflector": "^2.0",
         "nikic/php-parser": "^4.11",
         "symfony/config": "^5.4.7|^6.0",
@@ -24,10 +25,12 @@
         "symfony/finder": "^5.4.3|^6.0",
         "symfony/framework-bundle": "^5.4.7|^6.0",
         "symfony/http-kernel": "^5.4.7|^6.0",
-        "symfony/process": "^5.4.7|^6.0"
+        "symfony/process": "^5.4.7|^6.0",
+        "symfony/security-bundle": "^5.4.7|^6.0"
     },
     "require-dev": {
         "composer/semver": "^3.0",
+        "dbrekelmans/bdi": "dev-main",
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/orm": "^2.10.0",
         "symfony/http-client": "^5.4.7|^6.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="TEST_DATABASE_DSN" value="mysql://root:root@127.0.0.1:3306/test_maker?serverVersion=5.7" />
+        <env name="TEST_DATABASE_DSN" value="mysql://root:root@mariadb:3306/test_maker?serverVersion=5.7" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 

--- a/src/Doctrine/BaseRelation.php
+++ b/src/Doctrine/BaseRelation.php
@@ -28,6 +28,7 @@ abstract class BaseRelation
         private bool $isOwning = false,
         private bool $orphanRemoval = false,
         private bool $isNullable = false,
+        private array $cascade = []
     ) {
     }
 
@@ -84,5 +85,10 @@ abstract class BaseRelation
     public function isNullable(): bool
     {
         return $this->isNullable;
+    }
+
+    public function getCascade(): array
+    {
+        return $this->cascade;
     }
 }

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -464,6 +464,10 @@ final class ClassSourceManipulator
             $annotationOptions['targetEntity'] = new ClassNameValue($typeHint, $relation->getTargetClassName());
         }
 
+        if ($cascade = $relation->getCascade()) {
+            $annotationOptions['cascade'] = $cascade;
+        }
+
         if ($relation instanceof RelationOneToOne) {
             $annotationOptions['cascade'] = ['persist', 'remove'];
         }
@@ -548,6 +552,10 @@ final class ClassSourceManipulator
 
         if ($relation->getOrphanRemoval()) {
             $annotationOptions['orphanRemoval'] = true;
+        }
+
+        if ($cascade = $relation->getCascade()) {
+            $annotationOptions['cascade'] = $cascade;
         }
 
         $attributes = [

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -404,6 +404,20 @@ class ClassSourceManipulatorTest extends TestCase
                 isNullable: true,
             ),
         ];
+
+        yield 'many_to_one_cascade_persist' => [
+            'User_simple.php',
+            'User_simple_cascade_persist.php',
+            new RelationManyToOne(
+                propertyName: 'category',
+                targetClassName: \App\Entity\Category::class,
+                targetPropertyName: 'foods',
+                mapInverseRelation: false,
+                isOwning: true,
+                isNullable: true,
+                cascade: ['persist'],
+            ),
+        ];
     }
 
     /**
@@ -461,6 +475,17 @@ class ClassSourceManipulatorTest extends TestCase
                 targetClassName: \App\Entity\UserAvatarPhoto::class,
                 targetPropertyName: 'user',
                 orphanRemoval: true,
+            ),
+        ];
+
+        yield 'one_to_many_cascade_persist' => [
+            'User_simple.php',
+            'User_simple_cascade_persist.php',
+            new RelationOneToMany(
+                propertyName: 'avatarPhotos',
+                targetClassName: \App\Entity\UserAvatarPhoto::class,
+                targetPropertyName: 'user',
+                cascade: ['persist'],
             ),
         ];
 
@@ -522,6 +547,19 @@ class ClassSourceManipulatorTest extends TestCase
                 targetPropertyName: 'foods',
                 mapInverseRelation: false,
                 isOwning: true,
+            ),
+        ];
+
+        yield 'many_to_many_cascade_persist' => [
+            'User_simple.php',
+            'User_simple_cascade_persist.php',
+            new RelationManyToMany(
+                propertyName: 'recipes',
+                targetClassName: \App\Entity\Recipe::class,
+                targetPropertyName: 'foods',
+                mapInverseRelation: false,
+                isOwning: true,
+                cascade: ['persist'],
             ),
         ];
     }
@@ -641,6 +679,19 @@ class ClassSourceManipulatorTest extends TestCase
                 targetPropertyName: 'user',
                 isOwning: true,
                 isNullable: true,
+            ),
+        ];
+
+        yield 'one_to_one_cascade_persist_only' => [
+            'User_simple.php',
+            'User_simple_owning.php', // Same because ['persist', 'remove'] is forced
+            new RelationOneToOne(
+                propertyName: 'userProfile',
+                targetClassName: \App\Entity\UserProfile::class,
+                targetPropertyName: 'user',
+                isOwning: true,
+                isNullable: true,
+                cascade: ['persist'],
             ),
         ];
     }

--- a/tests/Util/fixtures/add_many_to_many_relation/User_simple_cascade_persist.php
+++ b/tests/Util/fixtures/add_many_to_many_relation/User_simple_cascade_persist.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\ManyToMany(targetEntity: Recipe::class, cascade: ['persist'])]
+    private Collection $recipes;
+
+    public function __construct()
+    {
+        $this->recipes = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Collection<int, Recipe>
+     */
+    public function getRecipes(): Collection
+    {
+        return $this->recipes;
+    }
+
+    public function addRecipe(Recipe $recipe): static
+    {
+        if (!$this->recipes->contains($recipe)) {
+            $this->recipes->add($recipe);
+        }
+
+        return $this;
+    }
+
+    public function removeRecipe(Recipe $recipe): static
+    {
+        $this->recipes->removeElement($recipe);
+
+        return $this;
+    }
+}

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_cascade_persist.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_cascade_persist.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(cascade: ['persist'])]
+    private ?Category $category = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCategory(): ?Category
+    {
+        return $this->category;
+    }
+
+    public function setCategory(?Category $category): static
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+}

--- a/tests/Util/fixtures/add_one_to_many_relation/User_simple_cascade_persist.php
+++ b/tests/Util/fixtures/add_one_to_many_relation/User_simple_cascade_persist.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserAvatarPhoto::class, cascade: ['persist'])]
+    private Collection $avatarPhotos;
+
+    public function __construct()
+    {
+        $this->avatarPhotos = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Collection<int, UserAvatarPhoto>
+     */
+    public function getAvatarPhotos(): Collection
+    {
+        return $this->avatarPhotos;
+    }
+
+    public function addAvatarPhoto(UserAvatarPhoto $avatarPhoto): static
+    {
+        if (!$this->avatarPhotos->contains($avatarPhoto)) {
+            $this->avatarPhotos->add($avatarPhoto);
+            $avatarPhoto->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removeAvatarPhoto(UserAvatarPhoto $avatarPhoto): static
+    {
+        if ($this->avatarPhotos->removeElement($avatarPhoto)) {
+            // set the owning side to null (unless already changed)
+            if ($avatarPhoto->getUser() === $this) {
+                $avatarPhoto->setUser(null);
+            }
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Allow adding the cascade annotation option for OneToMany, ManyToOne and ManyToMany relation in ClassSourceManipulator.
The OneToOne remains forced to ['persist', 'remove']

Related issue : https://github.com/symfony/maker-bundle/issues/1316