### PR TITLE
Fix(Doctrine Repository template)/Avoid potential double call in save method

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -21,19 +21,21 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
 
     public function save(<?= $entity_class_name ?> $entity, bool $flush = false): void
     {
-        $this->getEntityManager()->persist($entity);
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist($entity);
 
         if ($flush) {
-            $this->getEntityManager()->flush();
+            $entityManager->flush();
         }
     }
 
     public function remove(<?= $entity_class_name ?> $entity, bool $flush = false): void
     {
-        $this->getEntityManager()->remove($entity);
+        $entityManager = $this->getEntityManager();
+        $entityManager->remove($entity);
 
         if ($flush) {
-            $this->getEntityManager()->flush();
+            $entityManager->flush();
         }
     }
 <?php if ($include_example_comments): // When adding a new method without existing default comments, the blank line is automatically added.?>

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
@@ -23,19 +23,21 @@ class UserRepository extends ServiceEntityRepository
 
     public function save(UserXml $entity, bool $flush = false): void
     {
-        $this->getEntityManager()->persist($entity);
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist($entity);
 
         if ($flush) {
-            $this->getEntityManager()->flush();
+            $entityManager->flush();
         }
     }
 
     public function remove(UserXml $entity, bool $flush = false): void
     {
-        $this->getEntityManager()->remove($entity);
+        $entityManager = $this->getEntityManager();
+        $entityManager->remove($entity);
 
         if ($flush) {
-            $this->getEntityManager()->flush();
+            $entityManager->flush();
         }
     }
 

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
@@ -23,19 +23,21 @@ class XOtherRepository extends ServiceEntityRepository
 
     public function save(XOther $entity, bool $flush = false): void
     {
-        $this->getEntityManager()->persist($entity);
+        $entityManager = $this->getEntityManager();
+        $entityManager->persist($entity);
 
         if ($flush) {
-            $this->getEntityManager()->flush();
+            $entityManager->flush();
         }
     }
 
     public function remove(XOther $entity, bool $flush = false): void
     {
-        $this->getEntityManager()->remove($entity);
+        $entityManager = $this->getEntityManager();
+        $entityManager->remove($entity);
 
         if ($flush) {
-            $this->getEntityManager()->flush();
+            $entityManager->flush();
         }
     }
 


### PR DESCRIPTION
Store the entity manager in a variable rather than calling getEntityManager() twice in case of persist + flush 