### PR TITLE
[WCM] Deleting `save` and `remove` methods from repositories

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -163,6 +163,7 @@ final class MakeCrud extends AbstractMaker
             Request::class,
             Response::class,
             Route::class,
+            EntityManagerInterface::class,
         ]);
 
         $generator->generateController(

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -163,8 +163,11 @@ final class MakeCrud extends AbstractMaker
             Request::class,
             Response::class,
             Route::class,
-            EntityManagerInterface::class,
         ]);
+
+        if (EntityManagerInterface::class !== $repositoryClassName) {
+            $useStatements->addUseStatement(EntityManagerInterface::class);
+        }
 
         $generator->generateController(
             $controllerClassDetails->getFullName(),
@@ -257,6 +260,10 @@ final class MakeCrud extends AbstractMaker
 
             if ($usesEntityManager) {
                 $useStatements->addUseStatement(EntityRepository::class);
+            }
+
+            if (EntityManagerInterface::class !== $repositoryClassName) {
+                $useStatements->addUseStatement(EntityManagerInterface::class);
             }
 
             $generator->generateFile(

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -29,30 +29,18 @@ class <?= $class_name ?> extends AbstractController
 <?php endif ?>
 
 <?= $generator->generateRouteForControllerMethod('/new', sprintf('%s_new', $route_name), ['GET', 'POST']) ?>
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-    public function new(Request $request, <?= $repository_class_name ?> $<?= $repository_var ?>): Response
-<?php } else { ?>
     public function new(Request $request, EntityManagerInterface $entityManager): Response
-<?php } ?>
     {
         $<?= $entity_var_singular ?> = new <?= $entity_class_name ?>();
         $form = $this->createForm(<?= $form_class_name ?>::class, $<?= $entity_var_singular ?>);
         $form->handleRequest($request);
 
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-        if ($form->isSubmitted() && $form->isValid()) {
-            $<?= $repository_var ?>->save($<?= $entity_var_singular ?>, true);
-
-            return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
-        }
-<?php } else { ?>
         if ($form->isSubmitted() && $form->isValid()) {
             $entityManager->persist($<?= $entity_var_singular ?>);
             $entityManager->flush();
 
             return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
         }
-<?php } ?>
 
 <?php if ($use_render_form) { ?>
         return $this->renderForm('<?= $templates_path ?>/new.html.twig', [
@@ -76,28 +64,16 @@ class <?= $class_name ?> extends AbstractController
     }
 
 <?= $generator->generateRouteForControllerMethod(sprintf('/{%s}/edit', $entity_identifier), sprintf('%s_edit', $route_name), ['GET', 'POST']) ?>
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-    public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, <?= $repository_class_name ?> $<?= $repository_var ?>): Response
-<?php } else { ?>
     public function edit(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, EntityManagerInterface $entityManager): Response
-<?php } ?>
     {
         $form = $this->createForm(<?= $form_class_name ?>::class, $<?= $entity_var_singular ?>);
         $form->handleRequest($request);
 
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-        if ($form->isSubmitted() && $form->isValid()) {
-            $<?= $repository_var ?>->save($<?= $entity_var_singular ?>, true);
-
-            return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
-        }
-<?php } else { ?>
         if ($form->isSubmitted() && $form->isValid()) {
             $entityManager->flush();
 
             return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
         }
-<?php } ?>
 
 <?php if ($use_render_form) { ?>
         return $this->renderForm('<?= $templates_path ?>/edit.html.twig', [
@@ -113,22 +89,12 @@ class <?= $class_name ?> extends AbstractController
     }
 
 <?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_delete', $route_name), ['POST']) ?>
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-    public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, <?= $repository_class_name ?> $<?= $repository_var ?>): Response
-<?php } else { ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, EntityManagerInterface $entityManager): Response
-<?php } ?>
     {
-<?php if (isset($repository_full_class_name) && $generator->repositoryHasSaveAndRemoveMethods($repository_full_class_name)) { ?>
-        if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->request->get('_token'))) {
-            $<?= $repository_var ?>->remove($<?= $entity_var_singular ?>, true);
-        }
-<?php } else { ?>
         if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->request->get('_token'))) {
             $entityManager->remove($<?= $entity_var_singular ?>);
             $entityManager->flush();
         }
-<?php } ?>
 
         return $this->redirectToRoute('<?= $route_name ?>_index', [], Response::HTTP_SEE_OTHER);
     }

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -62,7 +62,8 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $fixture->set<?= ucfirst($form_field); ?>('My Title');
 <?php endforeach; ?>
 
-        $this->repository->save($fixture, true);
+        $this->manager->persist($fixture);
+        $this->manager->flush();
 
         $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
 
@@ -108,7 +109,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $fixture->set<?= ucfirst($form_field); ?>('Value');
 <?php endforeach; ?>
 
-        $$this->manager->remove($fixture);
+        $this->manager->remove($fixture);
         $this->manager->flush();
 
         $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));

--- a/src/Resources/skeleton/crud/test/Test.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.tpl.php
@@ -10,6 +10,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
     private KernelBrowser $client;
     private <?= "$repository_class_name " ?>$repository;
     private string $path = '<?= $route_path; ?>/';
+    private EntityManagerInterface $manager;
 
     protected function setUp(): void
     {
@@ -17,7 +18,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $this->repository = static::getContainer()->get('doctrine')->getRepository(<?= $entity_class_name; ?>::class);
 
         foreach ($this->repository->findAll() as $object) {
-            $this->repository->remove($object, true);
+            $this->manager->remove($object);
         }
     }
 
@@ -60,7 +61,8 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $fixture->set<?= ucfirst($form_field); ?>('My Title');
 <?php endforeach; ?>
 
-        $this->repository->save($fixture, true);
+        $this->manager->persist($fixture);
+        $this->manager->flush();
 
         $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));
 
@@ -78,7 +80,8 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $fixture->set<?= ucfirst($form_field); ?>('My Title');
 <?php endforeach; ?>
 
-        $this->repository->save($fixture, true);
+        $this->manager->persist($fixture);
+        $this->manager->flush();
 
         $this->client->request('GET', sprintf('%s%s/edit', $this->path, $fixture->getId()));
 
@@ -108,7 +111,8 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $fixture->set<?= ucfirst($form_field); ?>('My Title');
 <?php endforeach; ?>
 
-        $this->repository->save($fixture, true);
+        $this->manager->persist($fixture);
+        $this->manager->flush();
 
         self::assertSame($originalNumObjectsInRepository + 1, count($this->repository->findAll()));
 

--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -18,26 +18,6 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
     {
         parent::__construct($registry, <?= $entity_class_name; ?>::class);
     }
-
-    public function save(<?= $entity_class_name ?> $entity, bool $flush = false): void
-    {
-        $entityManager = $this->getEntityManager();
-        $entityManager->persist($entity);
-
-        if ($flush) {
-            $entityManager->flush();
-        }
-    }
-
-    public function remove(<?= $entity_class_name ?> $entity, bool $flush = false): void
-    {
-        $entityManager = $this->getEntityManager();
-        $entityManager->remove($entity);
-
-        if ($flush) {
-            $entityManager->flush();
-        }
-    }
 <?php if ($include_example_comments): // When adding a new method without existing default comments, the blank line is automatically added.?>
 
 <?php endif; ?>
@@ -52,8 +32,8 @@ class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgr
         }
 
         $user->setPassword($newHashedPassword);
-
-        $this->save($user, true);
+        $this->getEntityManager()->persist($user);
+        $this->getEntityManager()->flush();
     }
 
 <?php endif ?>

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -43,14 +43,4 @@ final class TemplateComponentGenerator
     {
         return sprintf('%s ', $classNameDetails->getShortName());
     }
-
-    /**
-     * @throws \ReflectionException
-     */
-    public function repositoryHasSaveAndRemoveMethods(string $repositoryFullClassName): bool
-    {
-        $reflectedComponents = new \ReflectionClass($repositoryFullClassName);
-
-        return $reflectedComponents->hasMethod('save') && $reflectedComponents->hasMethod('remove');
-    }
 }

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
@@ -21,26 +21,6 @@ class UserRepository extends ServiceEntityRepository
         parent::__construct($registry, UserXml::class);
     }
 
-    public function save(UserXml $entity, bool $flush = false): void
-    {
-        $entityManager = $this->getEntityManager();
-        $entityManager->persist($entity);
-
-        if ($flush) {
-            $entityManager->flush();
-        }
-    }
-
-    public function remove(UserXml $entity, bool $flush = false): void
-    {
-        $entityManager = $this->getEntityManager();
-        $entityManager->remove($entity);
-
-        if ($flush) {
-            $entityManager->flush();
-        }
-    }
-
 //    /**
 //     * @return UserXml[] Returns an array of UserXml objects
 //     */

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
@@ -21,26 +21,6 @@ class XOtherRepository extends ServiceEntityRepository
         parent::__construct($registry, XOther::class);
     }
 
-    public function save(XOther $entity, bool $flush = false): void
-    {
-        $entityManager = $this->getEntityManager();
-        $entityManager->persist($entity);
-
-        if ($flush) {
-            $entityManager->flush();
-        }
-    }
-
-    public function remove(XOther $entity, bool $flush = false): void
-    {
-        $entityManager = $this->getEntityManager();
-        $entityManager->remove($entity);
-
-        if ($flush) {
-            $entityManager->flush();
-        }
-    }
-
 //    /**
 //     * @return XOther[] Returns an array of XOther objects
 //     */

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 use Symfony\Bundle\MakerBundle\Maker\MakeCrud;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Yaml\Yaml;
 
 class MakeCrudTest extends MakerTestCase
 {

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\MakerBundle\Maker\MakeCrud;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\HttpKernel\Kernel;
 
 class MakeCrudTest extends MakerTestCase
 {
@@ -177,7 +178,7 @@ class MakeCrudTest extends MakerTestCase
                 $this->runCrudTest($runner, 'it_generates_basic_crud.php');
 
                 self::assertFileEquals(
-                    sprintf('%s/fixtures/%s', \dirname(__DIR__), 'make-crud/expected/WithCustomRepository.php'),
+                    sprintf('%s/fixtures/make-crud/expected/WithCustomRepository%s.php', \dirname(__DIR__), Kernel::VERSION_ID < 60200 ? 'Legacy' : ''),
                     $runner->getPath('src/Controller/SweetFoodController.php')
                 );
             }),

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -176,9 +176,8 @@ class MakeCrudTest extends MakerTestCase
                 $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
 
                 $this->runCrudTest($runner, 'it_generates_basic_crud.php');
-
                 self::assertFileEquals(
-                    sprintf('%s/fixtures/make-crud/expected/WithCustomRepository%s.php', \dirname(__DIR__), Kernel::VERSION_ID < 60200 ? 'Legacy' : ''),
+                    sprintf('%s/fixtures/make-crud/expected/WithCustomRepository%s.php', \dirname(__DIR__), $runner->getSymfonyVersion() < 60200 ? 'Legacy' : ''),
                     $runner->getPath('src/Controller/SweetFoodController.php')
                 );
             }),

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 use Symfony\Bundle\MakerBundle\Maker\MakeCrud;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Yaml\Yaml;
 
 class MakeCrudTest extends MakerTestCase

--- a/tests/fixtures/make-crud/SweetFoodRepository.php
+++ b/tests/fixtures/make-crud/SweetFoodRepository.php
@@ -20,22 +20,4 @@ class SweetFoodRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, SweetFood::class);
     }
-
-    public function save(SweetFood $entity, bool $flush = false): void
-    {
-        ($em = $this->getEntityManager())->persist($entity);
-
-        if ($flush) {
-            $em->flush();
-        }
-    }
-
-    public function remove(SweetFood $entity, bool $flush = false): void
-    {
-        ($em = $this->getEntityManager())->remove($entity);
-
-        if ($flush) {
-            $em->flush();
-        }
-    }
 }

--- a/tests/fixtures/make-crud/expected/WithCustomRepository.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepository.php
@@ -36,7 +36,7 @@ class SweetFoodController extends AbstractController
             return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
         }
 
-        return $this->renderForm('sweet_food/new.html.twig', [
+        return $this->render('sweet_food/new.html.twig', [
             'sweet_food' => $sweetFood,
             'form' => $form,
         ]);
@@ -62,7 +62,7 @@ class SweetFoodController extends AbstractController
             return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
         }
 
-        return $this->renderForm('sweet_food/edit.html.twig', [
+        return $this->render('sweet_food/edit.html.twig', [
             'sweet_food' => $sweetFood,
             'form' => $form,
         ]);

--- a/tests/fixtures/make-crud/expected/WithCustomRepository.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepository.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\SweetFood;
 use App\Form\SweetFoodType;
 use App\Repository\SweetFoodRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,14 +23,15 @@ class SweetFoodController extends AbstractController
     }
 
     #[Route('/new', name: 'app_sweet_food_new', methods: ['GET', 'POST'])]
-    public function new(Request $request, SweetFoodRepository $sweetFoodRepository): Response
+    public function new(Request $request, EntityManagerInterface $entityManager): Response
     {
         $sweetFood = new SweetFood();
         $form = $this->createForm(SweetFoodType::class, $sweetFood);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $sweetFoodRepository->save($sweetFood, true);
+            $entityManager->persist($sweetFood);
+            $entityManager->flush();
 
             return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
         }
@@ -49,13 +51,13 @@ class SweetFoodController extends AbstractController
     }
 
     #[Route('/{id}/edit', name: 'app_sweet_food_edit', methods: ['GET', 'POST'])]
-    public function edit(Request $request, SweetFood $sweetFood, SweetFoodRepository $sweetFoodRepository): Response
+    public function edit(Request $request, SweetFood $sweetFood, EntityManagerInterface $entityManager): Response
     {
         $form = $this->createForm(SweetFoodType::class, $sweetFood);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $sweetFoodRepository->save($sweetFood, true);
+            $entityManager->flush();
 
             return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
         }
@@ -67,10 +69,11 @@ class SweetFoodController extends AbstractController
     }
 
     #[Route('/{id}', name: 'app_sweet_food_delete', methods: ['POST'])]
-    public function delete(Request $request, SweetFood $sweetFood, SweetFoodRepository $sweetFoodRepository): Response
+    public function delete(Request $request, SweetFood $sweetFood, EntityManagerInterface $entityManager): Response
     {
         if ($this->isCsrfTokenValid('delete'.$sweetFood->getId(), $request->request->get('_token'))) {
-            $sweetFoodRepository->remove($sweetFood, true);
+            $entityManager->remove($sweetFood);
+            $entityManager->flush();
         }
 
         return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);

--- a/tests/fixtures/make-crud/expected/WithCustomRepositoryLegacy.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepositoryLegacy.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\SweetFood;
+use App\Form\SweetFoodType;
+use App\Repository\SweetFoodRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/sweet/food')]
+class SweetFoodController extends AbstractController
+{
+    #[Route('/', name: 'app_sweet_food_index', methods: ['GET'])]
+    public function index(SweetFoodRepository $sweetFoodRepository): Response
+    {
+        return $this->renderForm('sweet_food/index.html.twig', [
+            'sweet_foods' => $sweetFoodRepository->findAll(),
+        ]);
+    }
+
+    #[Route('/new', name: 'app_sweet_food_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $sweetFood = new SweetFood();
+        $form = $this->createForm(SweetFoodType::class, $sweetFood);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $entityManager->persist($sweetFood);
+            $entityManager->flush();
+
+            return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->renderForm('sweet_food/new.html.twig', [
+            'sweet_food' => $sweetFood,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_sweet_food_show', methods: ['GET'])]
+    public function show(SweetFood $sweetFood): Response
+    {
+        return $this->renderForm('sweet_food/show.html.twig', [
+            'sweet_food' => $sweetFood,
+        ]);
+    }
+
+    #[Route('/{id}/edit', name: 'app_sweet_food_edit', methods: ['GET', 'POST'])]
+    public function edit(Request $request, SweetFood $sweetFood, EntityManagerInterface $entityManager): Response
+    {
+        $form = $this->createForm(SweetFoodType::class, $sweetFood);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $entityManager->flush();
+
+            return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
+        }
+
+        return $this->renderForm('sweet_food/edit.html.twig', [
+            'sweet_food' => $sweetFood,
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/{id}', name: 'app_sweet_food_delete', methods: ['POST'])]
+    public function delete(Request $request, SweetFood $sweetFood, EntityManagerInterface $entityManager): Response
+    {
+        if ($this->isCsrfTokenValid('delete'.$sweetFood->getId(), $request->request->get('_token'))) {
+            $entityManager->remove($sweetFood);
+            $entityManager->flush();
+        }
+
+        return $this->redirectToRoute('app_sweet_food_index', [], Response::HTTP_SEE_OTHER);
+    }
+}

--- a/tests/fixtures/make-crud/expected/WithCustomRepositoryLegacy.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepositoryLegacy.php
@@ -17,7 +17,7 @@ class SweetFoodController extends AbstractController
     #[Route('/', name: 'app_sweet_food_index', methods: ['GET'])]
     public function index(SweetFoodRepository $sweetFoodRepository): Response
     {
-        return $this->renderForm('sweet_food/index.html.twig', [
+        return $this->render('sweet_food/index.html.twig', [
             'sweet_foods' => $sweetFoodRepository->findAll(),
         ]);
     }
@@ -45,7 +45,7 @@ class SweetFoodController extends AbstractController
     #[Route('/{id}', name: 'app_sweet_food_show', methods: ['GET'])]
     public function show(SweetFood $sweetFood): Response
     {
-        return $this->renderForm('sweet_food/show.html.twig', [
+        return $this->render('sweet_food/show.html.twig', [
             'sweet_food' => $sweetFood,
         ]);
     }


### PR DESCRIPTION
Fix #1327

In this PR I've removed the `save` and `remove` methods from the repositories, for the reasons explained here #1327.

( The add method has been renamed to save, here #1204 )

Reviews welcome!