### PR TITLE
Add entity data to `make:crud` form template

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -199,7 +199,10 @@ final class MakeCrud extends AbstractMaker
                 'entity_twig_var_singular' => $entityTwigVarSingular,
                 'entity_identifier' => $entityDoctrineDetails->getIdentifier(),
             ],
-            '_form' => [],
+            '_form' => [
+                'entity_twig_var_singular' => $entityTwigVarSingular,
+                'entity_fields' => $entityDoctrineDetails->getDisplayFields(),
+            ],
             'edit' => [
                 'entity_class_name' => $entityClassDetails->getShortName(),
                 'entity_twig_var_singular' => $entityTwigVarSingular,


### PR DESCRIPTION
Those two fields added to the return array can allow us to override the _form.html.php template when making make:crud.