### PR TITLE
Add conditional @implements tag to Doctrine repository template

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -6,6 +6,7 @@ namespace <?= $namespace; ?>;
 
 /**
  * @extends ServiceEntityRepository<<?= $entity_class_name; ?>>
+<?= $with_password_upgrade ? "* @implements PasswordUpgraderInterface<$entity_class_name>\n" : "" ?>
  *
  * @method <?= $entity_class_name; ?>|null find($id, $lockMode = null, $lockVersion = null)
  * @method <?= $entity_class_name; ?>|null findOneBy(array $criteria, array $orderBy = null)


### PR DESCRIPTION
Adding the @implements phpdoc tag on generated Doctrine repository classes will help IDE and prevent tools like phpstan from generating errors.

@implements is only added if `$with_password_upgrade` is set to true, avoiding useless phpdocs.

![Immagine 2023-07-06 120413](https://github.com/symfony/maker-bundle/assets/1532616/9e9c1b08-4f60-4a8b-862d-0f32cff2920b)

Similar to #1088
