### PR TITLE
Ignore use statement generator duplicates

### DIFF
--- a/src/Util/UseStatementGenerator.php
+++ b/src/Util/UseStatementGenerator.php
@@ -45,7 +45,11 @@ final class UseStatementGenerator implements \Stringable
                 $class = $aliasClass;
             }
 
-            $transformed[$key] = str_replace('\\', ' ', $class);
+            $transformedClass = str_replace('\\', ' ', $class);
+            // Let's not add the class again if it already exists.
+            if (!\in_array($transformedClass, $transformed, true)) {
+                $transformed[$key] = $transformedClass;
+            }
         }
 
         asort($transformed);

--- a/tests/Util/UseStatementGeneratorTest.php
+++ b/tests/Util/UseStatementGeneratorTest.php
@@ -90,4 +90,20 @@ class UseStatementGeneratorTest extends TestCase
             EOT;
         self::assertSame($expected, (string) $unsorted);
     }
+
+    public function testUseStatementsWithDuplicates(): void
+    {
+        $unsorted = new UseStatementGenerator([
+            \Symfony\UX\Turbo\Attribute\Broadcast::class,
+            \ApiPlatform\Core\Annotation\ApiResource::class,
+            \ApiPlatform\Core\Annotation\ApiResource::class,
+        ]);
+
+        $expected = <<< 'EOT'
+            use ApiPlatform\Core\Annotation\ApiResource;
+            use Symfony\UX\Turbo\Attribute\Broadcast;
+
+            EOT;
+        self::assertSame($expected, (string) $unsorted);
+    }
 }


### PR DESCRIPTION
Follow https://github.com/symfony/maker-bundle/pull/1328#discussion_r1242695471

Following weaverryan's idea I've improved `UseStatementGenerator` in this PR to ignore duplicates.