### PR TITLE
Add `--standalone` to `make:controller`

### DIFF
--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -3,22 +3,45 @@
 namespace <?= $namespace; ?>;
 
 <?= $use_statements; ?>
+<?php if ($is_standalone) { ?>
 
-class <?= $class_name; ?> extends AbstractController
+#[AsController]
+<?php } ?>
+class <?= $class_name; ?><?= !$is_standalone ? ' extends AbstractController': '' ?>
 {
+<?php if ($is_standalone && $with_template) { ?>
+    public function __construct(
+        private Environment $twig,
+    ) {
+    }
+
+<?php } ?>
 <?= $generator->generateRouteForControllerMethod($route_path, $route_name); ?>
     public function <?= $method_name ?>(): <?php if ($with_template) { ?>Response<?php } else { ?>JsonResponse<?php } ?>
 
     {
 <?php if ($with_template) { ?>
+        <?php if ($is_standalone) { ?>
+        return new Response($this->twig->render('<?= $template_name ?>', [
+            'controller_name' => '<?= $class_name ?>',
+        ]));
+        <?php } else { ?>
         return $this->render('<?= $template_name ?>', [
             'controller_name' => '<?= $class_name ?>',
         ]);
+        <?php } ?>
 <?php } else { ?>
+        <?php if ($is_standalone) { ?>
+        return new JsonResponse([
+            'message' => 'Welcome to your new controller!',
+            'path' => '<?= $relative_path; ?>',
+        ]);
+        <?php } else { ?>
         return $this->json([
             'message' => 'Welcome to your new controller!',
             'path' => '<?= $relative_path; ?>',
         ]);
+        <?php } ?>
 <?php } ?>
     }
 }

--- a/tests/Maker/MakeControllerTest.php
+++ b/tests/Maker/MakeControllerTest.php
@@ -143,6 +143,31 @@ class MakeControllerTest extends MakerTestCase
                 $this->assertStringContainsString('templates/admin/foo_invokable.html.twig', $output);
             }),
         ];
+
+        yield 'it_generates_a_controller_standalone' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([
+                    // controller class name
+                    'FooStandalone',
+                ], '--standalone');
+
+                $this->assertStringContainsString('src/Controller/FooStandaloneController.php', $output);
+                $this->runControllerTest($runner, 'it_generates_a_standalone_controller.php');
+            }),
+        ];
+
+        yield 'it_generates_a_controller_standalone_with_twig' => [$this->createMakerTest()
+            ->addExtraDependencies('twig')
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([
+                    // controller class name
+                    'FooStandaloneTwig',
+                ], '--standalone');
+
+                $this->assertStringContainsString('src/Controller/FooStandaloneTwigController.php', $output);
+                $this->runControllerTest($runner, 'it_generates_a_standalone_controller_with_twig.php');
+            }),
+        ];
     }
 
     private function runControllerTest(MakerTestRunner $runner, string $filename): void

--- a/tests/fixtures/make-controller/tests/it_generates_a_standalone_controller.php
+++ b/tests/fixtures/make-controller/tests/it_generates_a_standalone_controller.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class GeneratedControllerTest extends WebTestCase
+{
+    public function testController()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/foo/standalone');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('application/json', $client->getResponse()->headers->get('Content-Type'));
+        $this->assertSame('{"message":"Welcome to your new controller!","path":"src\/Controller\/FooStandaloneController.php"}', $client->getResponse()->getContent());
+    }
+
+    public function testControllerInheritance()
+    {
+        $controller = $this->getContainer()->get('App\Controller\FooStandaloneController');
+        $this->assertNotInstanceOf('Symfony\Bundle\FrameworkBundle\Controller\AbstractController', $controller);
+    }
+}

--- a/tests/fixtures/make-controller/tests/it_generates_a_standalone_controller_with_twig.php
+++ b/tests/fixtures/make-controller/tests/it_generates_a_standalone_controller_with_twig.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class GeneratedControllerTest extends WebTestCase
+{
+    public function testController()
+    {
+        $client = self::createClient();
+        $client->request('GET', '/foo/standalone/twig');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('<!DOCTYPE html>', $client->getResponse()->getContent());
+        $this->assertStringContainsString('Hello FooStandaloneTwigController', $client->getResponse()->getContent());
+    }
+
+    public function testControllerInheritance()
+    {
+        $controller = $this->getContainer()->get('App\Controller\FooStandaloneTwigController');
+        $this->assertNotInstanceOf('Symfony\Bundle\FrameworkBundle\Controller\AbstractController', $controller);
+    }
+}


### PR DESCRIPTION
Allows to create controllers without base class [as described in the documentation](https://symfony.com/doc/current/controller/service.html).

[See output examples](https://gist.github.com/adrienlucas/5f832d2aef49012572f6924d5538d611).

PS : Not sure about the `standalone` wording tho, the word itself doesn't appear in the said documentation. Actually I only want it to be an affirmative word, not `--without-base` or something, but I did not find any better alternative.