### PR TITLE
fix missing blank space in Repository.tpl.php

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -6,7 +6,7 @@ namespace <?= $namespace; ?>;
 
 /**
  * @extends ServiceEntityRepository<<?= $entity_class_name; ?>>
-<?= $with_password_upgrade ? "* @implements PasswordUpgraderInterface<$entity_class_name>\n" : "" ?>
+<?= $with_password_upgrade ? " * @implements PasswordUpgraderInterface<$entity_class_name>\n" : "" ?>
  *
  * @method <?= $entity_class_name; ?>|null find($id, $lockMode = null, $lockVersion = null)
  * @method <?= $entity_class_name; ?>|null findOneBy(array $criteria, array $orderBy = null)


### PR DESCRIPTION
Added extra space character to keep the code style consistent.

Without this space, the new UserRepository is generated like this:
![image](https://github.com/symfony/maker-bundle/assets/41155673/679496be-f4c4-4b40-a64a-c384ce34f172)
