### PR TITLE
[make:migration] Format the generated migration sql by passing `--formatted` to the command

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -194,6 +194,7 @@ class FileManager
         }
 
         $finalPath = implode('/', $finalParts);
+
         // Normalize: // => /
         // Normalize: /./ => /
         return str_replace(['//', '/./'], '/', $finalPath);

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -70,6 +70,9 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
                 ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection name')
             ;
         }
+
+        $command
+            ->addOption('formatted', null, InputOption::VALUE_NONE, 'Format the generated SQL');
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
@@ -87,6 +90,10 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
             $options[] = '--shard='.$input->getOption('shard');
         }
         // end 2.x support
+
+        if ($input->hasOption('formatted') && null !== $input->getOption('formatted')) {
+            $options[] = '--formatted';
+        }
 
         $generateMigrationCommand = $this->application->find('doctrine:migrations:diff');
         $generateMigrationCommandInput = new ArgvInput($options);

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -91,7 +91,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         }
         // end 2.x support
 
-        if ($input->hasOption('formatted') && null !== $input->getOption('formatted')) {
+        if ($input->getOption('formatted')) {
             $options[] = '--formatted';
         }
 

--- a/src/Resources/help/MakeMigration.txt
+++ b/src/Resources/help/MakeMigration.txt
@@ -1,3 +1,7 @@
 The <info>%command.name%</info> command generates a new migration:
 
 <info>php %command.full_name%</info>
+
+You can also generate a formatted migration with this option:
+
+<info>php %command.full_name% --formatted</info>

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -132,7 +132,7 @@ class MakeMigrationTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generate_a_formatted_migration' => [$this->createMakeMigrationTest()
+        yield 'it_generates_a_formatted_migration' => [$this->createMakeMigrationTest()
             ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runConsole('make:migration', [], '--formatted');

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -131,5 +131,16 @@ class MakeMigrationTest extends MakerTestCase
                 $this->assertStringNotContainsString('Success', $output);
             }),
         ];
+
+        yield 'it_generate_a_formatted_migration' => [$this->createMakeMigrationTest()
+            ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runConsole('make:migration', [], '--formatted');
+
+                $output = $runner->runMaker([/* no input */]);
+
+                $this->assertStringContainsString('Success', $output);
+            }),
+        ];
     }
 }


### PR DESCRIPTION
Hi,

Related to this #1336 I tried to work on this PR.

Now you can run `make:migration --formatted` to get a formatted SQL migration file.