### PR TITLE
Add make listener command

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -194,6 +194,7 @@ class FileManager
         }
 
         $finalPath = implode('/', $finalParts);
+
         // Normalize: // => /
         // Normalize: /./ => /
         return str_replace(['//', '/./'], '/', $finalPath);

--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\EventRegistry;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class MakeListener extends AbstractMaker
+{
+    public function __construct(private EventRegistry $eventRegistry)
+    {
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:listener';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new event listener class';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->addArgument('name', InputArgument::OPTIONAL, 'Choose a class name for your event listener (e.g. <fg=yellow>ExceptionListener</>)')
+            ->addArgument('event', InputArgument::OPTIONAL, 'What event do you want to listen to?')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeListener.txt'))
+        ;
+
+        $inputConfig->setArgumentAsNonInteractive('event');
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        if (!$input->getArgument('event')) {
+            $events = $this->eventRegistry->getAllActiveEvents();
+
+            $io->writeln(' <fg=green>Suggested Events:</>');
+            $io->listing($this->eventRegistry->listActiveEvents($events));
+            $question = new Question(sprintf(' <fg=green>%s</>', $command->getDefinition()->getArgument('event')->getDescription()));
+            $question->setAutocompleterValues($events);
+            $question->setValidator([Validator::class, 'notBlank']);
+            $event = $io->askQuestion($question);
+            $input->setArgument('event', $event);
+        }
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $subscriberClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'EventListener\\',
+            'Listener'
+        );
+
+        $event = $input->getArgument('event');
+        $eventFullClassName = $this->eventRegistry->getEventClassName($event);
+        $eventClassName = $eventFullClassName ? Str::getShortClassName($eventFullClassName) : null;
+
+        $useStatements = new UseStatementGenerator([
+            AsEventListener::class,
+        ]);
+
+        // Determine if we use a KernelEvents::CONSTANT or custom event name
+        if (null !== ($eventConstant = $this->getEventConstant($event))) {
+            $useStatements->addUseStatement(KernelEvents::class);
+            $eventName = $eventConstant;
+        } else {
+            $eventName = class_exists($event) ? sprintf('%s::class', $eventClassName) : sprintf('\'%s\'', $event);
+        }
+
+        if (null !== $eventFullClassName) {
+            $useStatements->addUseStatement($eventFullClassName);
+        }
+
+        $generator->generateClass(
+            $subscriberClassNameDetails->getFullName(),
+            'event/Listener.tpl.php',
+            [
+                'use_statements' => $useStatements,
+                'event' => $eventName,
+                'event_arg' => $eventClassName ? sprintf('%s $event', $eventClassName) : '$event',
+                'method_name' => class_exists($event) ? Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next: Open your new listener class and start customizing it.',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-listener</>',
+        ]);
+    }
+
+    private function getEventConstant(string $event): ?string
+    {
+        $constants = (new \ReflectionClass(KernelEvents::class))->getConstants();
+
+        if (false !== ($name = array_search($event, $constants, true))) {
+            return sprintf('KernelEvents::%s', $name);
+        }
+
+        return null;
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+    }
+}

--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -70,7 +70,7 @@ final class MakeListener extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
-        $subscriberClassNameDetails = $generator->createClassNameDetails(
+        $ListenerClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
             'EventListener\\',
             'Listener'
@@ -97,7 +97,7 @@ final class MakeListener extends AbstractMaker
         }
 
         $generator->generateClass(
-            $subscriberClassNameDetails->getFullName(),
+            $ListenerClassNameDetails->getFullName(),
             'event/Listener.tpl.php',
             [
                 'use_statements' => $useStatements,

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -65,6 +65,11 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_listener" class="Symfony\Bundle\MakerBundle\Maker\MakeListener">
+                <tag name="maker.command" />
+                <argument type="service" id="maker.event_registry" />
+            </service>
+
             <service id="maker.maker.make_message" class="Symfony\Bundle\MakerBundle\Maker\MakeMessage">
                 <argument type="service" id="maker.file_manager" />
                 <tag name="maker.command" />

--- a/src/Resources/help/MakeListener.txt
+++ b/src/Resources/help/MakeListener.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new event listener class.
+
+<info>php %command.full_name% ExceptionListener</info>
+
+If the argument is missing, the command will ask for the class name interactively.

--- a/src/Resources/skeleton/event/Listener.tpl.php
+++ b/src/Resources/skeleton/event/Listener.tpl.php
@@ -1,0 +1,15 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace; ?>;
+
+<?= $use_statements; ?>
+
+final class <?= $class_name ?>
+{
+
+    #[AsEventListener(event: <?= $event ?>)]
+    public function <?= $method_name ?>(<?= $event_arg ?>): void
+    {
+        // ...
+    }
+}

--- a/tests/Maker/MakeListenerTest.php
+++ b/tests/Maker/MakeListenerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeListener;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+
+class MakeListenerTest extends MakerTestCase
+{
+    protected function getMakerClass(): string
+    {
+        return MakeListener::class;
+    }
+
+    public function getTestDetails(): \Generator
+    {
+        yield 'it_makes_listener_for_known_event' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'FooBar',
+                        // event name
+                        'kernel.request',
+                    ]
+                );
+
+                self::assertStringContainsString(
+                    'KernelEvents::REQUEST',
+                    file_get_contents($runner->getPath('src/EventListener/FooBarListener.php'))
+                );
+
+                self::assertStringContainsString(
+                    'onKernelRequest',
+                    file_get_contents($runner->getPath('src/EventListener/FooBarListener.php'))
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_custom_event_class' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'FooBar',
+                        // event name
+                        \Symfony\Bundle\MakerBundle\Generator::class,
+                    ]
+                );
+
+                self::assertStringContainsString(
+                    'Generator::class',
+                    file_get_contents($runner->getPath('src/EventListener/FooBarListener.php'))
+                );
+
+                self::assertStringContainsString(
+                    'onGenerator',
+                    file_get_contents($runner->getPath('src/EventListener/FooBarListener.php'))
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_unknown_event_class' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'FooBar',
+                        // event name
+                        'foo.unknown_event',
+                    ]
+                );
+
+                self::assertStringContainsString(
+                    '\'foo.unknown_event\'',
+                    file_get_contents($runner->getPath('src/EventListener/FooBarListener.php'))
+                );
+
+                self::assertStringContainsString(
+                    'onFooUnknownEvent',
+                    file_get_contents($runner->getPath('src/EventListener/FooBarListener.php'))
+                );
+            }),
+        ];
+    }
+}


### PR DESCRIPTION
Related to #1301 I worked on this class to make a listener class by command.

Because it's  almost the same as  [src/Maker/MakeSubscriber.php](https://github.com/symfony/maker-bundle/blob/main/src/Maker/MakeSubscriber.php) would it be more consistent to have both made by only one command and finally created depending on a question step as "Class type (enter ? to see all types) [Subsriber]:" ?

Or is it better to separate like this?