### PR TITLE
Create empty-ready construct on command generate

### DIFF
--- a/src/Resources/skeleton/command/Command.tpl.php
+++ b/src/Resources/skeleton/command/Command.tpl.php
@@ -10,6 +10,11 @@ namespace <?= $namespace; ?>;
 )]
 class <?= $class_name; ?> extends Command
 {
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this


### PR DESCRIPTION
I understand that this was not put on purpose, but I believe that it would be useful for most people, because when generating a lot of commands, in 99% of cases I have to manually write this generic code to be able to do dependency injection