### PR TITLE
Update MakeAuthenticator.php

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -193,8 +193,8 @@ final class MakeAuthenticator extends AbstractMaker
 
             if ($input->getArgument('support-remember-me')) {
                 $supportRememberMeValues = [
-                    'Activate when the user checks a box' => self::REMEMBER_ME_TYPE_CHECKBOX,
-                    'Always activate remember me' => self::REMEMBER_ME_TYPE_ALWAYS,
+                    'Activate when the user checks a box' => false,
+                    'Always activate remember me' => true,
                 ];
                 $command->addArgument('always-remember-me', InputArgument::REQUIRED);
 

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -193,8 +193,8 @@ final class MakeAuthenticator extends AbstractMaker
 
             if ($input->getArgument('support-remember-me')) {
                 $supportRememberMeValues = [
-                    'Activate when the user checks a box' => false,
-                    'Always activate remember me' => true,
+                    'Activate when the user checks a box' => FALSE,
+                    'Always activate remember me' => TRUE,
                 ];
                 $command->addArgument('always-remember-me', InputArgument::REQUIRED);
 


### PR DESCRIPTION
During a Symfony training @Tiriel discovered an issue with the MakerBundle & Auth.
When choosing "remember me" and "checkbox" for the always remember me, MakerBundle always generates a "always_remember_me: true" in security.yaml instead of a commented part as written in documentation.

Disclaimer: sorry it's my first PR, feel free to explain if I'm wrong .