### PR TITLE
[make:listener] Add global command for listener and subscriber

### DIFF
--- a/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
+++ b/src/DependencyInjection/CompilerPass/MakeCommandRegistrationPass.php
@@ -63,6 +63,14 @@ class MakeCommandRegistrationPass implements CompilerPassInterface
                 }
             }
 
+            /*
+             * @deprecated remove this block when removing make:subscriber
+             */
+            if (method_exists($class, 'getCommandAlias')) {
+                $alias = $class::getCommandAlias();
+                $commandDefinition->addTag('console.command', ['command' => $alias, 'description' => 'Deprecated alias of "make:listener"']);
+            }
+
             $container->setDefinition(sprintf('maker.auto_command.%s', Str::asTwigVariable($class::getCommandName())), $commandDefinition);
         }
     }

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\MakerBundle\DependencyInjection\CompilerPass\MakeCommandRegis
 use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -26,27 +25,11 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class MakerExtension extends Extension
 {
-    /**
-     * @deprecated remove this block when removing make:unit-test and make:functional-test
-     */
-    private const TEST_MAKER_DEPRECATION_MESSAGE = 'The "%service_id%" service is deprecated, use "maker.maker.make_test" instead.';
-
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('makers.xml');
-
-        /**
-         * @deprecated remove this block when removing make:unit-test and make:functional-test
-         */
-        $deprecParams = method_exists(Definition::class, 'getDeprecation') ? ['symfony/maker-bundle', '1.29', self::TEST_MAKER_DEPRECATION_MESSAGE] : [true, self::TEST_MAKER_DEPRECATION_MESSAGE];
-        $container
-            ->getDefinition('maker.maker.make_unit_test')
-            ->setDeprecated(...$deprecParams);
-        $container
-            ->getDefinition('maker.maker.make_functional_test')
-            ->setDeprecated(...$deprecParams);
 
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\EventRegistry;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ * @author Ryan Weaver <weaverryan@gmail.com>
+ * @author Steven Renaux <steven.renaux8000@gmail.com>
+ */
+final class MakeListener extends AbstractMaker
+{
+    private const ALL_TYPES = ['Listener', 'Subscriber'];
+    private bool $isSubscriber = false;
+
+    public function __construct(private readonly EventRegistry $eventRegistry)
+    {
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:listener';
+    }
+
+    /**
+     * @deprecated remove this method when removing make:subscriber
+     */
+    public static function getCommandAlias(): string
+    {
+        return 'make:subscriber';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Creates a new event subscriber class or a new event listener class';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->addArgument('name', InputArgument::OPTIONAL, 'Choose a class name for your event listener or subscriber (e.g. <fg=yellow>ExceptionListener</> or <fg=yellow>ExceptionSubscriber</>)')
+            ->addArgument('event', InputArgument::OPTIONAL, 'What event do you want to listen to?')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeListener.txt'))
+        ;
+
+        $inputConfig->setArgumentAsNonInteractive('event');
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        /* @deprecated remove the following block when removing make:subscriber */
+        $this->handleDeprecatedMakerCommands($input, $io);
+
+        $io->writeln('');
+
+        $name = $input->getArgument('name');
+
+        if (!str_ends_with($name, 'Subscriber') && !str_ends_with($name, 'Listener')) {
+            $question = new ChoiceQuestion('Do you want to generate an event listener or subscriber?', self::ALL_TYPES, 0);
+            $classToGenerate = $io->askQuestion($question);
+
+            $input->setArgument('name', $name.$classToGenerate);
+        }
+
+        if (str_ends_with($input->getArgument('name'), 'Subscriber')) {
+            $this->isSubscriber = true;
+        }
+
+        if (!$input->getArgument('event')) {
+            $events = $this->eventRegistry->getAllActiveEvents();
+
+            $io->writeln(' <fg=green>Suggested Events:</>');
+            $io->listing($this->eventRegistry->listActiveEvents($events));
+            $question = new Question(sprintf(' <fg=green>%s</>', $command->getDefinition()->getArgument('event')->getDescription()));
+            $question->setAutocompleterValues($events);
+            $question->setValidator([Validator::class, 'notBlank']);
+            $event = $io->askQuestion($question);
+            $input->setArgument('event', $event);
+        }
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        if ($this->isSubscriber) {
+            $useStatements = new UseStatementGenerator([
+                EventSubscriberInterface::class,
+            ]);
+        } else {
+            $useStatements = new UseStatementGenerator([
+                AsEventListener::class,
+            ]);
+        }
+
+        $event = $input->getArgument('event');
+        $eventFullClassName = $this->eventRegistry->getEventClassName($event);
+        $eventClassName = $eventFullClassName ? Str::getShortClassName($eventFullClassName) : null;
+
+        if (null !== ($eventConstant = $this->getEventConstant($event))) {
+            $useStatements->addUseStatement(KernelEvents::class);
+            $eventName = $eventConstant;
+        } else {
+            $eventName = class_exists($event) ? sprintf('%s::class', $eventClassName) : sprintf('\'%s\'', $event);
+        }
+
+        if (null !== $eventFullClassName) {
+            $useStatements->addUseStatement($eventFullClassName);
+        }
+
+        if ($this->isSubscriber) {
+            $this->generateSubscriberClass($input, $io, $generator, $useStatements, $event, $eventName, $eventClassName);
+        } else {
+            $this->generateListenerClass($input, $io, $generator, $useStatements, $event, $eventName, $eventClassName);
+        }
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+    }
+
+    private function getEventConstant(string $event): ?string
+    {
+        $constants = (new \ReflectionClass(KernelEvents::class))->getConstants();
+
+        if (false !== ($name = array_search($event, $constants, true))) {
+            return sprintf('KernelEvents::%s', $name);
+        }
+
+        return null;
+    }
+
+    private function generateSubscriberClass(InputInterface $input, ConsoleStyle $io, Generator $generator, UseStatementGenerator $useStatements, string $event, string $eventName, ?string $eventClassName): void
+    {
+        $subscriberClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'EventSubscriber\\',
+            'Subscriber'
+        );
+
+        $generator->generateClass(
+            $subscriberClassNameDetails->getFullName(),
+            'event/Subscriber.tpl.php',
+            [
+                'use_statements' => $useStatements,
+                'event' => $eventName,
+                'event_arg' => $eventClassName ? sprintf('%s $event', $eventClassName) : '$event',
+                'method_name' => class_exists($event) ? Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next: Open your new subscriber class and start customizing it.',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber</>',
+        ]);
+    }
+
+    private function generateListenerClass(InputInterface $input, ConsoleStyle $io, Generator $generator, UseStatementGenerator $useStatements, string $event, string $eventName, ?string $eventClassName): void
+    {
+        $listenerClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'EventListener\\',
+            'Listener'
+        );
+
+        $generator->generateClass(
+            $listenerClassNameDetails->getFullName(),
+            'event/Listener.tpl.php',
+            [
+                'use_statements' => $useStatements,
+                'event' => $eventName,
+                'event_arg' => $eventClassName ? sprintf('%s $event', $eventClassName) : '$event',
+                'method_name' => class_exists($event) ? Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next: Open your new listener class and start customizing it.',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-listener</>',
+        ]);
+    }
+
+    /**
+     * @deprecated
+     */
+    private function handleDeprecatedMakerCommands(InputInterface $input, ConsoleStyle $io): void
+    {
+        $currentCommand = $input->getFirstArgument();
+        $name = $input->getArgument('name');
+
+        if ('make:subscriber' === $currentCommand) {
+            if (!str_ends_with($name, 'Subscriber')) {
+                $input->setArgument('name', $name.'Subscriber');
+            }
+
+            $io->warning('The "make:subscriber" command is deprecated, use "make:listener" instead.');
+        }
+    }
+}

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -26,7 +26,11 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+trigger_deprecation('symfony/maker-bundle', '1.51', 'The "%s" class is deprecated, use "%s" instead.', MakeSubscriber::class, MakeListener::class);
+
 /**
+ * @deprecated since MakerBundle 1.51, use Symfony\Bundle\MakerBundle\Maker\MakeListener instead.
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Ryan Weaver <weaverryan@gmail.com>
  */

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -63,6 +63,12 @@
 
             <service id="maker.maker.make_functional_test" class="Symfony\Bundle\MakerBundle\Maker\MakeFunctionalTest">
                 <tag name="maker.command" />
+                <deprecated package="symfony/maker-bundle" version="1.29">The "%service_id%" service is deprecated, use "maker.maker.make_test" instead.</deprecated>
+            </service>
+
+            <service id="maker.maker.make_listener" class="Symfony\Bundle\MakerBundle\Maker\MakeListener">
+                <tag name="maker.command" />
+                <argument type="service" id="maker.event_registry" />
             </service>
 
             <service id="maker.maker.make_message" class="Symfony\Bundle\MakerBundle\Maker\MakeMessage">
@@ -100,6 +106,7 @@
             <service id="maker.maker.make_subscriber" class="Symfony\Bundle\MakerBundle\Maker\MakeSubscriber">
                 <tag name="maker.command" />
                 <argument type="service" id="maker.event_registry" />
+                <deprecated package="symfony/maker-bundle" version="1.51">The "%service_id%" service is deprecated, use "maker.maker.make_listener" instead.</deprecated>
             </service>
 
             <service id="maker.maker.make_twig_extension" class="Symfony\Bundle\MakerBundle\Maker\MakeTwigExtension">
@@ -112,6 +119,7 @@
 
             <service id="maker.maker.make_unit_test" class="Symfony\Bundle\MakerBundle\Maker\MakeUnitTest">
                 <tag name="maker.command" />
+                <deprecated package="symfony/maker-bundle" version="1.29">The "%service_id%" service is deprecated, use "maker.maker.make_test" instead.</deprecated>
             </service>
 
             <service id="maker.maker.make_validator" class="Symfony\Bundle\MakerBundle\Maker\MakeValidator">

--- a/src/Resources/help/MakeListener.txt
+++ b/src/Resources/help/MakeListener.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new event subscriber class or a new event listener class.
+
+<info>php %command.full_name% ExceptionListener</info>
+
+If the argument is missing, the command will ask for the class name interactively.

--- a/src/Resources/skeleton/event/Listener.tpl.php
+++ b/src/Resources/skeleton/event/Listener.tpl.php
@@ -1,0 +1,14 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace; ?>;
+
+<?= $use_statements; ?>
+
+final class <?= $class_name."\n" ?>
+{
+    #[AsEventListener(event: <?= $event ?>)]
+    public function <?= $method_name ?>(<?= $event_arg ?>): void
+    {
+        // ...
+    }
+}

--- a/tests/Maker/MakeListenerTest.php
+++ b/tests/Maker/MakeListenerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeListener;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+
+class MakeListenerTest extends MakerTestCase
+{
+    private const EXPECTED_SUBSCRIBER_PATH = __DIR__.'/../../tests/fixtures/make-listener/tests/EventSubscriber/';
+    private const EXPECTED_LISTENER_PATH = __DIR__.'/../../tests/fixtures/make-listener/tests/EventListener/';
+
+    public function getTestDetails(): \Generator
+    {
+        yield 'it_make_subscriber_without_conventional_name' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'foo',
+                        // event class type
+                        'Subscriber',
+                        // event name
+                        'kernel.request',
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_SUBSCRIBER_PATH.'FooSubscriber.php',
+                    $runner->getPath('src/EventSubscriber/FooSubscriber.php')
+                );
+            }),
+        ];
+
+        yield 'it_make_listener_without_conventional_name' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'foo',
+                        // event class type
+                        'Listener',
+                        // event name
+                        'kernel.request',
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'FooListener.php',
+                    $runner->getPath('src/EventListener/FooListener.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_subscriber_for_known_event' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // subscriber name
+                        'FooBarSubscriber',
+                        // event name
+                        'kernel.request',
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_SUBSCRIBER_PATH.'FooBarSubscriber.php',
+                    $runner->getPath('src/EventSubscriber/FooBarSubscriber.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_subscriber_for_custom_event_class' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // subscriber name
+                        'CustomSubscriber',
+                        // event name
+                        \Symfony\Bundle\MakerBundle\Generator::class,
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_SUBSCRIBER_PATH.'CustomSubscriber.php',
+                    $runner->getPath('src/EventSubscriber/CustomSubscriber.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_subscriber_for_unknown_event_class' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // subscriber name
+                        'UnknownSubscriber',
+                        // event name
+                        'foo.unknown_event',
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_SUBSCRIBER_PATH.'UnknownSubscriber.php',
+                    $runner->getPath('src/EventSubscriber/UnknownSubscriber.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_known_event' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'FooBarListener',
+                        // event name
+                        'kernel.request',
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'FooBarListener.php',
+                    $runner->getPath('src/EventListener/FooBarListener.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_custom_event_class' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'CustomListener',
+                        // event name
+                        \Symfony\Bundle\MakerBundle\Generator::class,
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'CustomListener.php',
+                    $runner->getPath('src/EventListener/CustomListener.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_unknown_event_class' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'UnknownListener',
+                        // event name
+                        'foo.unknown_event',
+                    ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'UnknownListener.php',
+                    $runner->getPath('src/EventListener/UnknownListener.php')
+                );
+            }),
+        ];
+    }
+
+    protected function getMakerClass(): string
+    {
+        return MakeListener::class;
+    }
+}

--- a/tests/Maker/MakeSubscriberTest.php
+++ b/tests/Maker/MakeSubscriberTest.php
@@ -15,6 +15,9 @@ use Symfony\Bundle\MakerBundle\Maker\MakeSubscriber;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 
+/**
+ * @group legacy
+ */
 class MakeSubscriberTest extends MakerTestCase
 {
     protected function getMakerClass(): string

--- a/tests/fixtures/make-listener/tests/EventListener/CustomListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/CustomListener.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+final class CustomListener
+{
+    #[AsEventListener(event: Generator::class)]
+    public function onGenerator(Generator $event): void
+    {
+        // ...
+    }
+}

--- a/tests/fixtures/make-listener/tests/EventListener/FooBarListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/FooBarListener.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class FooBarListener
+{
+    #[AsEventListener(event: KernelEvents::REQUEST)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        // ...
+    }
+}

--- a/tests/fixtures/make-listener/tests/EventListener/FooListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/FooListener.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class FooListener
+{
+    #[AsEventListener(event: KernelEvents::REQUEST)]
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        // ...
+    }
+}

--- a/tests/fixtures/make-listener/tests/EventListener/UnknownListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/UnknownListener.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+final class UnknownListener
+{
+    #[AsEventListener(event: 'foo.unknown_event')]
+    public function onFooUnknownEvent($event): void
+    {
+        // ...
+    }
+}

--- a/tests/fixtures/make-listener/tests/EventSubscriber/CustomSubscriber.php
+++ b/tests/fixtures/make-listener/tests/EventSubscriber/CustomSubscriber.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CustomSubscriber implements EventSubscriberInterface
+{
+    public function onGenerator(Generator $event): void
+    {
+        // ...
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Generator::class => 'onGenerator',
+        ];
+    }
+}

--- a/tests/fixtures/make-listener/tests/EventSubscriber/FooBarSubscriber.php
+++ b/tests/fixtures/make-listener/tests/EventSubscriber/FooBarSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class FooBarSubscriber implements EventSubscriberInterface
+{
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        // ...
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+}

--- a/tests/fixtures/make-listener/tests/EventSubscriber/FooSubscriber.php
+++ b/tests/fixtures/make-listener/tests/EventSubscriber/FooSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class FooSubscriber implements EventSubscriberInterface
+{
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        // ...
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+}

--- a/tests/fixtures/make-listener/tests/EventSubscriber/UnknownSubscriber.php
+++ b/tests/fixtures/make-listener/tests/EventSubscriber/UnknownSubscriber.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class UnknownSubscriber implements EventSubscriberInterface
+{
+    public function onFooUnknownEvent($event): void
+    {
+        // ...
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'foo.unknown_event' => 'onFooUnknownEvent',
+        ];
+    }
+}


### PR DESCRIPTION
Related to #1301 I also suggest to add a global maker for both, Listener and Subscriber.

I worked with the based class `MakeSubscriber` and updated it to make this solution.

In the terminal you can run `make:event` and a question will be displayed like that to know which event class you want to create.

```
$ php bin/console make:event FooBar kernel.request


 What event class to generate(enter ? to see all types) [Subscriber]:
 > ?

Event Types Class
  * Subscriber
  * Listener

 What event class to generate(enter ? to see all types) [Subscriber]:
 > 
```

And if you write well what you want as `FooBarSubscriber` or `FooBarListener` and the event to listen, your file will be generated as Listener or Subscriber.

```php
namespace App\EventListener;

use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
use Symfony\Component\HttpKernel\Event\RequestEvent;
use Symfony\Component\HttpKernel\KernelEvents;

final class FooBarListener
{
    #[AsEventListener(event: KernelEvents::REQUEST)]
    public function onKernelRequest(RequestEvent $event): void
    {
        // ...
    }
}
```