### PR TITLE
Use TwigComponent HTML syntax

### DIFF
--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -42,7 +42,7 @@ final class MakeTwigComponent extends AbstractMaker
     {
         $command
             ->setDescription(self::getCommandDescription())
-            ->addArgument('name', InputArgument::OPTIONAL, 'The name of your twig component (ie <fg=yellow>NotificationComponent</>)')
+            ->addArgument('name', InputArgument::OPTIONAL, 'The name of your twig component (ie <fg=yellow>Notification</>)')
             ->addOption('live', null, InputOption::VALUE_NONE, 'Whether to create a live twig component (requires <fg=yellow>symfony/ux-live-component</>)')
         ;
     }
@@ -84,7 +84,7 @@ final class MakeTwigComponent extends AbstractMaker
 
         $this->writeSuccessMessage($io);
         $io->newLine();
-        $io->writeln(" To render the component, use {{ component('{$shortName}') }}.");
+        $io->writeln(" To render the component, use <fg=yellow><twig:{$shortName} /></>.");
         $io->newLine();
     }
 

--- a/src/Resources/skeleton/twig/Component.tpl.php
+++ b/src/Resources/skeleton/twig/Component.tpl.php
@@ -4,7 +4,7 @@ namespace <?= $namespace; ?>;
 
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
-#[AsTwigComponent()]
+#[AsTwigComponent]
 final class <?= $class_name."\n" ?>
 {
 }

--- a/src/Resources/skeleton/twig/LiveComponent.tpl.php
+++ b/src/Resources/skeleton/twig/LiveComponent.tpl.php
@@ -5,7 +5,7 @@ namespace <?= $namespace; ?>;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent()]
+#[AsLiveComponent]
 final class <?= $class_name."\n" ?>
 {
     use DefaultActionTrait;

--- a/tests/Maker/MakeTwigComponentTest.php
+++ b/tests/Maker/MakeTwigComponentTest.php
@@ -27,7 +27,7 @@ class MakeTwigComponentTest extends MakerTestCase
 
                 $this->assertStringContainsString('src/Twig/Components/Alert.php', $output);
                 $this->assertStringContainsString('templates/components/Alert.html.twig', $output);
-                $this->assertStringContainsString("To render the component, use {{ component('Alert') }}.", $output);
+                $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_twig_component.php',
@@ -46,7 +46,7 @@ class MakeTwigComponentTest extends MakerTestCase
 
                 $this->assertStringContainsString('src/Twig/Components/FormInput.php', $output);
                 $this->assertStringContainsString('templates/components/FormInput.html.twig', $output);
-                $this->assertStringContainsString("To render the component, use {{ component('FormInput') }}.", $output);
+                $this->assertStringContainsString('To render the component, use <twig:FormInput />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_twig_component.php',
@@ -65,7 +65,7 @@ class MakeTwigComponentTest extends MakerTestCase
 
                 $this->assertStringContainsString('src/Twig/Components/Alert.php', $output);
                 $this->assertStringContainsString('templates/components/Alert.html.twig', $output);
-                $this->assertStringContainsString("To render the component, use {{ component('Alert') }}.", $output);
+                $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_live_component.php',
@@ -84,7 +84,7 @@ class MakeTwigComponentTest extends MakerTestCase
 
                 $this->assertStringContainsString('src/Twig/Components/FormInput.php', $output);
                 $this->assertStringContainsString('templates/components/FormInput.html.twig', $output);
-                $this->assertStringContainsString("To render the component, use {{ component('FormInput') }}.", $output);
+                $this->assertStringContainsString('To render the component, use <twig:FormInput />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_live_component.php',

--- a/tests/fixtures/make-twig-component/tests/it_generates_live_component.php
+++ b/tests/fixtures/make-twig-component/tests/it_generates_live_component.php
@@ -8,7 +8,7 @@ class GeneratedTwigComponentTest extends KernelTestCase
 {
     public function testController()
     {
-        $output = self::getContainer()->get('twig')->createTemplate("{{ component('{name}') }}")->render();
+        $output = self::getContainer()->get('twig')->createTemplate("<twig:{name} />")->render();
 
         $this->assertStringContainsString('<div data-controller="live"', $output);
         $this->assertStringContainsString('data-live-name-value="', $output);

--- a/tests/fixtures/make-twig-component/tests/it_generates_twig_component.php
+++ b/tests/fixtures/make-twig-component/tests/it_generates_twig_component.php
@@ -8,7 +8,7 @@ class GeneratedTwigComponentTest extends KernelTestCase
 {
     public function testController()
     {
-        $output = self::getContainer()->get('twig')->createTemplate("{{ component('{name}') }}")->render();
+        $output = self::getContainer()->get('twig')->createTemplate("<twig:{name} />")->render();
 
         $this->assertSame("<div>\n    <!-- component html -->\n</div>\n", $output);
     }


### PR DESCRIPTION
 Use the new default HTML syntax 

( `<twig:Alert />` instead of  `{{ component('Alert') }}` )

cc @weaverryan 