### PR TITLE
[CS] Update command descriptions (minor)

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -84,7 +84,7 @@ final class MakeAuthenticator extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a Guard authenticator of different flavors';
+        return 'Create a Guard authenticator of different flavors';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -44,7 +44,7 @@ final class MakeCommand extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new console command class';
+        return 'Create a new console command class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -52,7 +52,7 @@ final class MakeController extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new controller class';
+        return 'Create a new controller class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -61,7 +61,7 @@ final class MakeCrud extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates CRUD for Doctrine entity class';
+        return 'Create CRUD for Doctrine entity class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeDockerDatabase.php
+++ b/src/Maker/MakeDockerDatabase.php
@@ -59,7 +59,7 @@ final class MakeDockerDatabase extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Adds a database container to your docker-compose.yaml file';
+        return 'Add a database container to your docker-compose.yaml file';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -90,7 +90,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
     public static function getCommandDescription(): string
     {
-        return 'Creates or updates a Doctrine entity class, and optionally an API Platform resource';
+        return 'Create or update a Doctrine entity class, and optionally an API Platform resource';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeFixtures.php
+++ b/src/Maker/MakeFixtures.php
@@ -36,7 +36,7 @@ final class MakeFixtures extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new class to load Doctrine fixtures';
+        return 'Create a new class to load Doctrine fixtures';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConf)

--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -45,7 +45,7 @@ final class MakeForm extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new form class';
+        return 'Create a new form class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeFunctionalTest.php
+++ b/src/Maker/MakeFunctionalTest.php
@@ -43,7 +43,7 @@ class MakeFunctionalTest extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new functional test class';
+        return 'Create a new functional test class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -43,7 +43,7 @@ final class MakeMessage extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new message and handler';
+        return 'Create a new message and handler';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeMessengerMiddleware.php
+++ b/src/Maker/MakeMessengerMiddleware.php
@@ -38,7 +38,7 @@ final class MakeMessengerMiddleware extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new messenger middleware';
+        return 'Create a new messenger middleware';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -48,7 +48,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new migration based on database changes';
+        return 'Create a new migration based on database changes';
     }
 
     public function setApplication(Application $application)

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -95,7 +95,7 @@ final class MakeRegistrationForm extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new registration form system';
+        return 'Create a new registration form system';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConf): void

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -35,7 +35,7 @@ final class MakeSerializerEncoder extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new serializer encoder class';
+        return 'Create a new serializer encoder class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeSerializerNormalizer.php
+++ b/src/Maker/MakeSerializerNormalizer.php
@@ -36,7 +36,7 @@ final class MakeSerializerNormalizer extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new serializer normalizer class';
+        return 'Create a new serializer normalizer class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -37,7 +37,7 @@ final class MakeStimulusController extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new Stimulus controller';
+        return 'Create a new Stimulus controller';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -43,7 +43,7 @@ final class MakeSubscriber extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new event subscriber class';
+        return 'Create a new event subscriber class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeTest.php
+++ b/src/Maker/MakeTest.php
@@ -65,7 +65,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new test class';
+        return 'Create a new test class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -35,7 +35,7 @@ final class MakeTwigComponent extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a twig (or live) component';
+        return 'Create a twig (or live) component';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -37,7 +37,7 @@ final class MakeTwigExtension extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new Twig extension with its runtime class';
+        return 'Create a new Twig extension with its runtime class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeUnitTest.php
+++ b/src/Maker/MakeUnitTest.php
@@ -38,7 +38,7 @@ final class MakeUnitTest extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new unit test class';
+        return 'Create a new unit test class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -64,7 +64,7 @@ final class MakeUser extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new security user class';
+        return 'Create a new security user class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -34,7 +34,7 @@ final class MakeValidator extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new validator and constraint class';
+        return 'Create a new validator and constraint class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConf)

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -33,7 +33,7 @@ final class MakeVoter extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Creates a new security voter class';
+        return 'Create a new security voter class';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void


### PR DESCRIPTION
Update command descriptions to enforce Symfony code conventions ([imperative mood](https://symfony.com/doc/current/contributing/code/conventions.html#naming-commands-and-options)) 

Not sure if MakerBundle follow Symfony codebase code conventions..  but as this bundle is used in the official documentation and many tutorials, it may be more coherent for the user

See: https://symfony.com/doc/current/contributing/code/conventions.html#naming-commands-and-options
