### PR TITLE
Entity Validator is accepting absolute namespaces

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -216,7 +216,7 @@ final class Validator
             self::classExists($className, sprintf('Entity "%s" doesn\'t exist; please enter an existing one or create a new one.', $className));
         }
 
-        if (!\in_array($className, $entities)) {
+        if (!\in_array($className, $entities) && !\in_array(ltrim($className, '\\'), $entities)) {
             throw new RuntimeCommandException(sprintf('Entity "%s" doesn\'t exist; please enter an existing one or create a new one.', $className));
         }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -94,4 +94,26 @@ class ValidatorTest extends TestCase
         $this->expectExceptionMessage(sprintf('"%sController" is not a UTF-8-encoded string.', \chr(0xA6)));
         Validator::validateClassName(mb_convert_encoding('ŚController', 'ISO-8859-2', 'UTF-8'));
     }
+
+    public function testRegisteredEntitiesExists()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('There are no registered entities; please create an entity before using this command.');
+        Validator::entityExists('App\Entity\Class', []);
+    }
+
+    public function testEntityExists()
+    {
+        $className = self::class;
+        $this->assertSame($className, Validator::entityExists($className, [$className]));
+        $this->assertSame('\\'.$className, Validator::entityExists('\\'.$className, [$className]));
+    }
+
+    public function testEntityDoesNotExist()
+    {
+        $className = '\\'.self::class;
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage(sprintf('Entity "%s" doesn\'t exist; please enter an existing one or create a new one.', $className));
+        Validator::entityExists($className, ['Full\Entity\DummyEntity']);
+    }
 }


### PR DESCRIPTION
Resolving issue when Absolute namespace for Entity is not passing through validation even if it should.
https://github.com/symfony/maker-bundle/issues/1365#issuecomment-1757938060