### PR TITLE
Add relations to entity form generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.52.0](https://github.com/symfony/maker-bundle/releases/tag/v1.52.0)
+
+### Feature
+
+- [#1372](https://github.com/symfony/maker-bundle/issue/1372) - Support Entity relations in form generation - *@maelanleborgne*
+
 ## [v1.50.0](https://github.com/symfony/maker-bundle/releases/tag/v1.50.0)
 
 ### Feature

--- a/src/Renderer/FormTypeRenderer.php
+++ b/src/Renderer/FormTypeRenderer.php
@@ -39,6 +39,14 @@ final class FormTypeRenderer
             if (isset($fieldTypeOptions['type'])) {
                 $fieldTypeUseStatements[] = $fieldTypeOptions['type'];
                 $fieldTypeOptions['type'] = Str::getShortClassName($fieldTypeOptions['type']);
+                if (\array_key_exists('extra_use_classes', $fieldTypeOptions) && \count($fieldTypeOptions['extra_use_classes']) > 0) {
+                    $extraUseClasses = array_merge($extraUseClasses, $fieldTypeOptions['extra_use_classes'] ?? []);
+                    $fieldTypeOptions['options_code'] = str_replace(
+                        $fieldTypeOptions['extra_use_classes'],
+                        array_map(fn ($class) => Str::getShortClassName($class), $fieldTypeOptions['extra_use_classes']),
+                        $fieldTypeOptions['options_code']
+                    );
+                }
             }
 
             $fields[$name] = $fieldTypeOptions;

--- a/src/Resources/skeleton/form/Type.tpl.php
+++ b/src/Resources/skeleton/form/Type.tpl.php
@@ -16,7 +16,7 @@ class <?= $class_name ?> extends AbstractType
             ->add('<?= $form_field ?>', <?= $typeOptions['type'] ?>::class)
 <?php else: ?>
             ->add('<?= $form_field ?>', <?= $typeOptions['type'] ? ($typeOptions['type'].'::class') : 'null' ?>, [
-<?= $typeOptions['options_code']."\n" ?>
+                <?= $typeOptions['options_code']."\n" ?>
             ])
 <?php endif; ?>
 <?php endforeach; ?>

--- a/tests/Maker/MakeFormTest.php
+++ b/tests/Maker/MakeFormTest.php
@@ -97,6 +97,90 @@ class MakeFormTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_form_with_many_to_one_relation' => [$this->createMakerTest()
+            ->addExtraDependencies('orm')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-form/relation_one_to_many/Book.php',
+                    'src/Entity/Book.php'
+                );
+                $runner->copy(
+                    'make-form/relation_one_to_many/Author.php',
+                    'src/Entity/Author.php'
+                );
+
+                $runner->runMaker([
+                    // Entity name
+                    'BookType',
+                    'Book',
+                ]);
+
+                $this->runFormTest($runner, 'it_generates_form_with_many_to_one_relation.php');
+            }),
+        ];
+        yield 'it_generates_form_with_one_to_many_relation' => [$this->createMakerTest()
+            ->addExtraDependencies('orm')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-form/relation_one_to_many/Book.php',
+                    'src/Entity/Book.php'
+                );
+                $runner->copy(
+                    'make-form/relation_one_to_many/Author.php',
+                    'src/Entity/Author.php'
+                );
+
+                $runner->runMaker([
+                    // Entity name
+                    'AuthorType',
+                    'Author',
+                ]);
+
+                $this->runFormTest($runner, 'it_generates_form_with_one_to_many_relation.php');
+            }),
+        ];
+        yield 'it_generates_form_with_many_to_many_relation' => [$this->createMakerTest()
+            ->addExtraDependencies('orm')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-form/relation_many_to_many/Book.php',
+                    'src/Entity/Book.php'
+                );
+                $runner->copy(
+                    'make-form/relation_many_to_many/Library.php',
+                    'src/Entity/Library.php'
+                );
+
+                $runner->runMaker([
+                    // Entity name
+                    'BookType',
+                    'Book',
+                ]);
+
+                $this->runFormTest($runner, 'it_generates_form_with_many_to_many_relation.php');
+            }),
+        ];
+        yield 'it_generates_form_with_one_to_one_relation' => [$this->createMakerTest()
+            ->addExtraDependencies('orm')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-form/relation_one_to_one/Librarian.php',
+                    'src/Entity/Librarian.php'
+                );
+                $runner->copy(
+                    'make-form/relation_one_to_one/Library.php',
+                    'src/Entity/Library.php'
+                );
+
+                $runner->runMaker([
+                    // Entity name
+                    'LibraryType',
+                    'Library',
+                ]);
+
+                $this->runFormTest($runner, 'it_generates_form_with_one_to_one_relation.php');
+            }),
+        ];
         yield 'it_generates_form_with_embeddable_entity' => [$this->createMakerTest()
             ->addExtraDependencies('orm')
             ->run(function (MakerTestRunner $runner) {

--- a/tests/fixtures/make-form/Property.php
+++ b/tests/fixtures/make-form/Property.php
@@ -18,4 +18,16 @@ class Property
     #[ORM\ManyToOne(inversedBy: 'properties')]
     #[ORM\JoinColumn(name: 'sour_food_id', referencedColumnName: 'id')]
     private ?SourFood $sourFood = null;
+
+    public function setSourFood(?SourFood $sourFood): static
+    {
+        $this->sourFood = $sourFood;
+
+        return $this;
+    }
+
+    public function getSourFood(): ?SourFood
+    {
+        return $this->sourFood;
+    }
 }

--- a/tests/fixtures/make-form/relation_many_to_many/Book.php
+++ b/tests/fixtures/make-form/relation_many_to_many/Book.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-class SourFood
+class Book
 {
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
@@ -17,37 +17,38 @@ class SourFood
     #[ORM\Column(name: 'title', length: 255)]
     private ?string $title = null;
 
-    #[ORM\OneToMany(targetEntity: Property::class, mappedBy: 'sourFood')]
-    private Collection $properties;
+    #[ORM\ManyToMany(targetEntity: Library::class, mappedBy: 'books')]
+    private Collection $libraries;
 
     public function __construct()
     {
-        $this->properties = new ArrayCollection();
+        $this->libraries = new ArrayCollection();
     }
 
-    /**
-     * @return mixed
-     */
     public function getId()
     {
         return $this->id;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
 
-    /**
-     * @param mixed $title
-     */
-    public function setTitle($title): static
+    public function setTitle(string $title): static
     {
         $this->title = $title;
 
+        return $this;
+    }
+
+    public function getLibraries(): Collection
+    {
+        return $this->libraries;
+    }
+    public function setLibraries(Collection $libraries): static
+    {
+        $this->libraries = $libraries;
         return $this;
     }
 }

--- a/tests/fixtures/make-form/relation_many_to_many/Library.php
+++ b/tests/fixtures/make-form/relation_many_to_many/Library.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Library
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\ManyToMany(targetEntity: Book::class, inversedBy: 'libraries')]
+    private Collection $books;
+
+    #[ORM\Column(name: 'name', length: 255)]
+    private string $name;
+
+    public function __construct()
+    {
+        $this->books = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBooks(): Collection
+    {
+        return $this->books;
+    }
+
+    public function addBook(Book $book): static
+    {
+        $this->books->add($book);
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+    public function setName(?string $name): static
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/tests/fixtures/make-form/relation_one_to_many/Author.php
+++ b/tests/fixtures/make-form/relation_one_to_many/Author.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Author
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\OneToMany(targetEntity: Book::class, mappedBy: 'library')]
+    private Collection $books;
+
+    #[ORM\Column(name: 'name', length: 255)]
+    private string $name;
+
+    public function __construct()
+    {
+        $this->books = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getBooks(): Collection
+    {
+        return $this->books;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+    public function setName(?string $name): static
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/tests/fixtures/make-form/relation_one_to_many/Book.php
+++ b/tests/fixtures/make-form/relation_one_to_many/Book.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Book
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'title', length: 255)]
+    private ?string $title = null;
+
+    #[ORM\ManyToOne(targetEntity: Author::class, inversedBy: 'books')]
+    private ?Author $author = null;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getAuthor(): ?Author
+    {
+        return $this->author;
+    }
+    public function setAuthor(?Author $author): static
+    {
+        $this->author = $author;
+        return $this;
+    }
+}

--- a/tests/fixtures/make-form/relation_one_to_one/Librarian.php
+++ b/tests/fixtures/make-form/relation_one_to_one/Librarian.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Librarian
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'name', length: 255)]
+    private ?string $name = null;
+
+    #[ORM\OneToOne(mappedBy: 'librarian', targetEntity: Library::class)]
+    private Library $library;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getLibrary(): Library
+    {
+        return $this->library;
+    }
+    public function setLibrary(Library $library): static
+    {
+        $this->library = $library;
+        return $this;
+    }
+}

--- a/tests/fixtures/make-form/relation_one_to_one/Library.php
+++ b/tests/fixtures/make-form/relation_one_to_one/Library.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Library
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\OneToOne(mappedBy: 'library', targetEntity: Librarian::class)]
+    private Librarian $librarian;
+
+    #[ORM\Column(name: 'name', length: 255)]
+    private string $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getLibrarian(): Librarian
+    {
+        return $this->librarian;
+    }
+
+    public function setLibrarian(Librarian $librarian): static
+    {
+        $this->librarian = $librarian;
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+    public function setName(?string $name): static
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/tests/fixtures/make-form/tests/it_generates_form_with_many_to_many_relation.php
+++ b/tests/fixtures/make-form/tests/it_generates_form_with_many_to_many_relation.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Library;
+use App\Entity\Book;
+use App\Form\BookType;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class GeneratedFormTest extends TypeTestCase
+{
+    /**
+     * @dataProvider provideFormData
+     */
+    public function testGeneratedFormWithMultipleChoices($formData, $collection)
+    {
+        $form = $this->factory->create(BookType::class);
+        $form->submit($formData);
+
+        $object = new Book();
+        $object->setTitle('foobar');
+        $object->setLibraries($collection);
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($object, $form->getData());
+
+        $view = $form->createView();
+        $children = $view->children;
+
+        foreach (array_keys($formData) as $key) {
+            $this->assertArrayHasKey($key, $children);
+        }
+    }
+
+    public function provideFormData(): iterable
+    {
+        yield 'test_submit_with_single_choice_selected' =>
+        [
+            [
+                'title' => 'foobar',
+                'libraries' => [1],
+            ],
+            new ArrayCollection([
+                (new Library())->setName('bar'),
+            ]),
+        ];
+        yield ['test_submit_with_multiple_choices_selected' =>
+            [
+                'title' => 'foobar',
+                'libraries' => [0, 1],
+            ],
+            new ArrayCollection([
+                (new Library())->setName('foo'),
+                (new Library())->setName('bar'),
+            ]),
+        ];
+        yield ['test_submit_with_no_choice_selected' =>
+            [
+                'title' => 'foobar',
+                'libraries' => [],
+            ],
+            new ArrayCollection([]),
+        ];
+    }
+
+    protected function getExtensions(): array
+    {
+        $mockEntityManager = $this->createMock(EntityManager::class);
+        $mockEntityManager->method('getClassMetadata')
+            ->willReturnMap([
+                [Book::class, new ClassMetadata(Book::class)],
+                [Library::class, new ClassMetadata(Library::class)],
+            ]);
+
+        $execute = $this->createMock(AbstractQuery::class);
+        $execute->method('execute')
+            ->willReturn([
+                (new Library())->setName('foo'),
+                (new Library())->setName('bar'),
+            ]);
+
+        $query = $this->createMock(QueryBuilder::class);
+        $query->method('getQuery')
+            ->willReturn($execute);
+
+
+        $entityRepository = $this->createMock(EntityRepository::class);
+        $entityRepository->method('createQueryBuilder')
+            ->willReturn($query);
+
+        $mockEntityManager->method('getRepository')->willReturn($entityRepository);
+
+        $mockRegistry = $this->createMock(ManagerRegistry::class);
+        $mockRegistry->method('getManagerForClass')
+            ->willReturn($mockEntityManager);
+        $mockRegistry->method('getManagers')
+            ->willReturn([$mockEntityManager]);
+
+        return array_merge(parent::getExtensions(), [new DoctrineOrmExtension($mockRegistry)]);
+    }
+}

--- a/tests/fixtures/make-form/tests/it_generates_form_with_many_to_one_relation.php
+++ b/tests/fixtures/make-form/tests/it_generates_form_with_many_to_one_relation.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Author;
+use App\Entity\Book;
+use App\Form\BookType;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class GeneratedFormTest extends TypeTestCase
+{
+    public function testGeneratedForm()
+    {
+        $author = (new Author())
+            ->setName('foo');
+        $formData = [
+            'title' => 'bar',
+            'author' => 0,
+        ];
+
+        $form = $this->factory->create(BookType::class);
+        $form->submit($formData);
+
+        $object = new Book();
+        $object->setTitle('bar');
+        $object->setAuthor($author);
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($object, $form->getData());
+
+        $view = $form->createView();
+        $children = $view->children;
+
+        foreach (array_keys($formData) as $key) {
+            $this->assertArrayHasKey($key, $children);
+        }
+    }
+
+    protected function getExtensions(): array
+    {
+        $mockEntityManager = $this->createMock(EntityManager::class);
+        $mockEntityManager->method('getClassMetadata')
+            ->willReturnMap([
+                [Book::class, new ClassMetadata(Book::class)],
+                [Author::class, new ClassMetadata(Author::class)],
+            ])
+        ;
+
+        $execute = $this->createMock(AbstractQuery::class);
+        $execute->method('execute')
+            ->willReturn([
+                (new Author())->setName('foo')
+            ]);
+
+        $query = $this->createMock(QueryBuilder::class);
+        $query->method('getQuery')
+            ->willReturn($execute);
+
+
+        $entityRepository = $this->createMock(EntityRepository::class);
+        $entityRepository->method('createQueryBuilder')
+            ->willReturn($query)
+        ;
+
+        $mockEntityManager->method('getRepository')->willReturn($entityRepository);
+
+        $mockRegistry = $this->createMock(ManagerRegistry::class);
+        $mockRegistry->method('getManagerForClass')
+            ->willReturn($mockEntityManager)
+        ;
+        $mockRegistry->method('getManagers')
+            ->willReturn([$mockEntityManager])
+        ;
+
+        return array_merge(parent::getExtensions(), [new DoctrineOrmExtension($mockRegistry)]);
+    }
+}

--- a/tests/fixtures/make-form/tests/it_generates_form_with_one_to_many_relation.php
+++ b/tests/fixtures/make-form/tests/it_generates_form_with_one_to_many_relation.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Author;
+use App\Entity\Book;
+use App\Form\AuthorType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class GeneratedFormTest extends TypeTestCase
+{
+    public function testGeneratedForm()
+    {
+        $formData = [
+            'name' => 'foo',
+        ];
+
+        $form = $this->factory->create(AuthorType::class);
+        $form->submit($formData);
+
+        $object = new Author();
+        $object->setName('foo');
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($object, $form->getData());
+
+        $view = $form->createView();
+        $children = $view->children;
+
+        foreach (array_keys($formData) as $key) {
+            $this->assertArrayHasKey($key, $children);
+        }
+        $this->assertArrayNotHasKey('books', $children);
+    }
+}

--- a/tests/fixtures/make-form/tests/it_generates_form_with_one_to_one_relation.php
+++ b/tests/fixtures/make-form/tests/it_generates_form_with_one_to_one_relation.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Librarian;
+use App\Entity\Library;
+use App\Form\LibraryType;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class GeneratedFormTest extends TypeTestCase
+{
+    public function testGeneratedForm()
+    {
+        $librarian = (new Librarian())
+            ->setName('foo');
+        $formData = [
+            'name' => 'bar',
+            'librarian' => 0,
+        ];
+
+        $form = $this->factory->create(LibraryType::class);
+        $form->submit($formData);
+
+        $object = new Library();
+        $object->setName('bar');
+        $object->setLibrarian($librarian);
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($object, $form->getData());
+
+        $view = $form->createView();
+        $children = $view->children;
+
+        foreach (array_keys($formData) as $key) {
+            $this->assertArrayHasKey($key, $children);
+        }
+    }
+
+    protected function getExtensions(): array
+    {
+        $mockEntityManager = $this->createMock(EntityManager::class);
+        $mockEntityManager->method('getClassMetadata')
+            ->willReturnMap([
+                [Library::class, new ClassMetadata(Library::class)],
+                [Librarian::class, new ClassMetadata(Librarian::class)],
+            ])
+        ;
+
+        $execute = $this->createMock(AbstractQuery::class);
+        $execute->method('execute')
+            ->willReturn([
+                (new Librarian())->setName('foo')
+            ]);
+
+        $query = $this->createMock(QueryBuilder::class);
+        $query->method('getQuery')
+            ->willReturn($execute);
+
+
+        $entityRepository = $this->createMock(EntityRepository::class);
+        $entityRepository->method('createQueryBuilder')
+            ->willReturn($query)
+        ;
+
+        $mockEntityManager->method('getRepository')->willReturn($entityRepository);
+
+        $mockRegistry = $this->createMock(ManagerRegistry::class);
+        $mockRegistry->method('getManagerForClass')
+            ->willReturn($mockEntityManager)
+        ;
+        $mockRegistry->method('getManagers')
+            ->willReturn([$mockEntityManager])
+        ;
+
+        return array_merge(parent::getExtensions(), [new DoctrineOrmExtension($mockRegistry)]);
+    }
+}


### PR DESCRIPTION
PR for #1372 

When generating a form for an entity (through `make:form` or `make:crud`), this feature adds an EntityType input for each compatible relations in the generate form.

- [x] Add tests