### PR TITLE
remove references to SensioGenerator

### DIFF
--- a/src/Resources/doc/index.rst
+++ b/src/Resources/doc/index.rst
@@ -2,10 +2,8 @@ The Symfony MakerBundle
 =======================
 
 Symfony Maker helps you create empty commands, controllers, form classes,
-tests and more so you can forget about writing boilerplate code. This
-bundle is an alternative to `SensioGeneratorBundle`_ for modern Symfony
-applications and requires using Symfony 3.4 or newer. This bundle
-assumes you're using a standard Symfony 4 directory structure, but many
+tests and more so you can forget about writing boilerplate code. This bundle
+assumes you're using a standard Symfony 5 directory structure, but many
 commands can generate code into any application.
 
 Installation


### PR DESCRIPTION
SensioGenerator was archived years ago, there's not much of a reason to even mention it.