### PR TITLE
Add collection as reserved keywords

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -43,7 +43,7 @@ final class Validator
             'use', 'var', 'while', 'xor', 'yield',
             'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
             'iterable', 'object', '__file__', '__line__', '__dir__', '__function__', '__class__',
-            '__method__', '__namespace__', '__trait__', 'self', 'parent',
+            '__method__', '__namespace__', '__trait__', 'self', 'parent', 'collection',
         ];
 
         foreach ($pieces as $piece) {


### PR DESCRIPTION
Related to #1380 

In the `generate method`  we call the `Generator class` and the method  `createClassNameDetails`.

```
        $entityClassDetails = $generator->createClassNameDetails(
            $input->getArgument('name'),
            'Entity\\'
        );
```

And in this method we call the static method `validateClassName` of the `Validator class`.
In it we already have a check about the reserved keywords.

```
        $reservedKeywords = ['__halt_compiler', 'abstract', 'and', 'array',
            'as', 'break', 'callable', 'case', 'catch', 'class',
            'clone', 'const', 'continue', 'declare', 'default', 'die', 'do',
            'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor',
            'endforeach', 'endif', 'endswitch', 'endwhile', 'eval',
            'exit', 'extends', 'final', 'finally', 'fn', 'for', 'foreach', 'function',
            'global', 'goto', 'if', 'implements', 'include',
            'include_once', 'instanceof', 'insteadof', 'interface', 'isset',
            'list', 'match', 'namespace', 'new', 'or', 'print', 'private',
            'protected', 'public', 'readonly', 'require', 'require_once', 'return',
            'static', 'switch', 'throw', 'trait', 'try', 'unset',
            'use', 'var', 'while', 'xor', 'yield',
            'int', 'float', 'bool', 'string', 'true', 'false', 'null', 'void',
            'iterable', 'object', '__file__', '__line__', '__dir__', '__function__', '__class__',
            '__method__', '__namespace__', '__trait__', 'self', 'parent', 'collection',
        ];
```

Is this the best solution to avoid these dangerous/ambiguous class names?
Because this method is also called by the other makers.

Or do we need to add an additional verification in the entity maker? 
