### PR TITLE
Fix tests CS violations

### DIFF
--- a/src/Doctrine/EntityDetails.php
+++ b/src/Doctrine/EntityDetails.php
@@ -67,7 +67,7 @@ final class EntityDetails
             }
             $fieldsWithTypes[$fieldName] = [
                 'type' => EntityType::class,
-                'options_code' => sprintf('\'class\' => %s::class,', $relation['targetEntity']).PHP_EOL.'\'choice_label\' => \'id\',',
+                'options_code' => sprintf('\'class\' => %s::class,', $relation['targetEntity']).\PHP_EOL.'\'choice_label\' => \'id\',',
                 'extra_use_classes' => [$relation['targetEntity']],
             ];
             if (\Doctrine\ORM\Mapping\ClassMetadata::MANY_TO_MANY === $relation['type']) {

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -251,9 +251,7 @@ final class MakeCrud extends AbstractMaker
                 $repositoryClassName,
             ]);
 
-
             $useStatements->addUseStatement(EntityRepository::class);
-
 
             if (EntityManagerInterface::class !== $repositoryClassName) {
                 $useStatements->addUseStatement(EntityManagerInterface::class);

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -283,7 +283,7 @@ final class MakerTestEnvironment
             // do not explicitly set the PHPUnit version
             [
                 'filename' => 'phpunit.xml.dist',
-                'find' => '<server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />',
+                'find' => '<server name="SYMFONY_PHPUNIT_VERSION" value="9.6" />',
                 'replace' => '',
             ],
         ];


### PR DESCRIPTION
Lately CI checks fail because of an [upgrade of the default phpunit version used in phpunit-bridge](https://github.com/symfony/symfony/pull/50760). This PR fixes this in the bundle's tests. And also a couple of minor cs fixes.

(EDIT: just noticed the CS part was fixed in #1397 just earlier)