### PR TITLE
remove LegacyApiTestCase from code

### DIFF
--- a/src/Maker/MakeTest.php
+++ b/src/Maker/MakeTest.php
@@ -146,7 +146,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
             "test/$type.tpl.php",
             [
                 'web_assertions_are_available' => trait_exists(WebTestAssertionsTrait::class),
-                'api_test_case_fqcn' => !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
+                'api_test_case_fqcn' => ApiTestCase::class,
             ]
         );
 
@@ -185,7 +185,7 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
 
             case 'ApiTestCase':
                 $dependencies->addClassDependency(
-                    !class_exists(ApiTestCase::class) ? LegacyApiTestCase::class : ApiTestCase::class,
+                    ApiTestCase::class,
                     'api',
                     true,
                     false


### PR DESCRIPTION
In this commit, https://github.com/symfony/maker-bundle/commit/4da6e4a9615c8a32bae48630626ca7dac2af06a0 was removed import related to `LegacyApiTestCase` but `MakerTest` class still use `LegacyApiTestCase::class` as a result generated API test case class with incorrect import.

`use Symfony\Bundle\MakerBundle\Maker\LegacyApiTestCase;`