### PR TITLE
Doctrine make:fixtures - Remove extra semicolon

### DIFF
--- a/src/Resources/skeleton/doctrine/Fixtures.tpl.php
+++ b/src/Resources/skeleton/doctrine/Fixtures.tpl.php
@@ -2,7 +2,7 @@
 
 namespace <?= $namespace; ?>;
 
-<?= $use_statements; ?>;
+<?= $use_statements; ?>
 
 class <?= $class_name ?> extends Fixture
 {


### PR DESCRIPTION
Using the command `make:fixtures` I noticed an extra semicolon in the generated file 

```
use Doctrine\Bundle\FixturesBundle\Fixture;
use Doctrine\Persistence\ObjectManager;
;
```