### PR TITLE
[make:reset-password] increase password strength & check for comprimised password

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -53,6 +53,8 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotCompromisedPassword;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -292,6 +294,8 @@ class MakeResetPassword extends AbstractMaker
             OptionsResolver::class,
             Length::class,
             NotBlank::class,
+            NotCompromisedPassword::class,
+            PasswordStrength::class,
         ]);
 
         $generator->generateClass(

--- a/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ChangePasswordFormType.tpl.php
@@ -22,11 +22,13 @@ class <?= $class_name ?> extends AbstractType
                             'message' => 'Please enter a password',
                         ]),
                         new Length([
-                            'min' => 6,
+                            'min' => 12,
                             'minMessage' => 'Your password should be at least {{ limit }} characters',
                             // max length allowed by Symfony for security reasons
                             'max' => 4096,
                         ]),
+                        new PasswordStrength(),
+                        new NotCompromisedPassword(),
                     ],
                     'label' => 'New password',
                 ],


### PR DESCRIPTION
For the password reset process:
* [x] Adds the `NotCompromisedPassword` and `PasswordStrength` constraints to the password reset form
* [x] Set a minimal password length to 12 instead of 6
