### PR TITLE
[make:auth] Add throttling support to authenticator maker

### DIFF
--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -69,7 +69,7 @@ final class SecurityConfigUpdater
         return $contents;
     }
 
-    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe): string
+    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe, bool $supportThrottling): string
     {
         $this->createYamlSourceManipulator($yamlSource);
 
@@ -143,6 +143,10 @@ final class SecurityConfigUpdater
             } else {
                 $firewall['remember_me'][] = $this->manipulator->createCommentLine('always_remember_me: true');
             }
+        }
+
+        if ($supportThrottling) {
+            $firewall['throttling'] = '~';
         }
 
         $newData['security']['firewalls'][$firewallName] = $firewall;


### PR DESCRIPTION
In the MakeAuthenticator class, a new optional argument 'support-throttling' was added. This allows the user to specify if they want to enable throttling protection during the authentication generation process. If 'support-throttling' is enabled, the LimiterInterface dependency is added and the 'throttling' node is set in the firewall configuration.