### PR TITLE
[DoctrineHelper] handle property type for custom doctrine type

### DIFF
--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Doctrine;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
@@ -257,7 +258,7 @@ final class DoctrineHelper
 
     public static function getPropertyTypeForColumn(string $columnType): ?string
     {
-        return match ($columnType) {
+        $propertyType = match ($columnType) {
             Types::STRING, Types::TEXT, Types::GUID, Types::BIGINT, Types::DECIMAL => 'string',
             'array', Types::SIMPLE_ARRAY, Types::JSON => 'array',
             Types::BOOLEAN => 'bool',
@@ -271,6 +272,19 @@ final class DoctrineHelper
             'ulid' => '\\'.Ulid::class,
             default => null,
         };
+
+        if (null === $propertyType && Type::getTypeRegistry()->has($columnType)) {
+            $reflection = new \ReflectionClass(\get_class(Type::getTypeRegistry()->get($columnType)));
+            if ($reflection->hasMethod('convertToPHPValue') && $returnType = $reflection->getMethod('convertToPHPValue')->getReturnType()) {
+                if ($returnType->isBuiltin()) {
+                    $propertyType = $returnType->getName();
+                } else {
+                    $propertyType = '\\'.$returnType->getName();
+                }
+            }
+        }
+
+        return $propertyType;
     }
 
     /**


### PR DESCRIPTION
fixed: #1002
replace: #1021

sample custom type

```php
<?php

declare(strict_types=1);

namespace App\Doctrine\DBAL\Types;

use Cake\Chronos\Chronos;
use DateTimeImmutable;
use Doctrine\DBAL\Platforms\AbstractPlatform;
use Doctrine\DBAL\Types\ConversionException;
use Doctrine\DBAL\Types\DateTimeImmutableType;

class ChronosDateTimeType extends DateTimeImmutableType
{
    final public const CHRONOS_DATETIME = 'chronos_datetime';

    /**
     * {@inheritDoc}
     */
    public function convertToPHPValue($value, AbstractPlatform $platform): ?Chronos
    {
        if (null === $value) {
            return null;
        }

        $dateTime = parent::convertToPHPValue($value, $platform);

        return Chronos::instance($dateTime);
    }

    /*
     * ....
     */
}
```

this change will get `convertToPHPValue` function return type and set it as property type
if no return type defined on `convertToPHPValue` function then the property will not have any type hint