### PR TITLE
Proper annotation for generated validator constraint

### DIFF
--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -59,7 +59,7 @@ final class MakeValidator extends AbstractMaker
             $validatorClassNameDetails->getFullName(),
             'validator/Validator.tpl.php',
             [
-                'constraint_class_name' => $constraintFullClassName,
+                'constraint_class_name' => Str::getShortClassName($constraintFullClassName),
             ]
         );
 

--- a/src/Resources/skeleton/validator/Validator.tpl.php
+++ b/src/Resources/skeleton/validator/Validator.tpl.php
@@ -9,7 +9,7 @@ class <?= $class_name ?> extends ConstraintValidator
 {
     public function validate($value, Constraint $constraint)
     {
-        /* @var <?= $constraint_class_name ?> $constraint */
+        /** @var <?= $constraint_class_name ?> $constraint */
 
         if (null === $value || '' === $value) {
             return;


### PR DESCRIPTION
Currently, if you are using phpstan in your project you'll get

> Access to an undefined property Symfony\Component\Validator\Constraint::$message

error on any new generated validator