### PR TITLE
Compatibility to dependency php parser v5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,11 @@ jobs:
                   composer-options: "--no-scripts --working-dir=tools/twigcs"
 
             - name: "Install PHPUnit"
-              run: vendor/bin/simple-phpunit install
+              run: |
+                if [[ ${{ matrix.dependency_versions == 'lowest' }} ]]; then
+                  echo "SYMFONY_PHPUNIT_REQUIRE=nikic/php-parser:^4.18" >> $GITHUB_ENV
+                fi
+                vendor/bin/simple-phpunit install
 
             - name: "PHPUnit version"
               run: vendor/bin/simple-phpunit --version

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/inflector": "^2.0",
-        "nikic/php-parser": "^4.11",
+        "nikic/php-parser": "^5.0",
         "symfony/config": "^6.3|^7.0",
         "symfony/console": "^6.3|^7.0",
         "symfony/dependency-injection": "^6.3|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/inflector": "^2.0",
-        "nikic/php-parser": "^5.0",
+        "nikic/php-parser": "^4.18|^5.0",
         "symfony/config": "^6.3|^7.0",
         "symfony/console": "^6.3|^7.0",
         "symfony/dependency-injection": "^6.3|^7.0",

--- a/src/Security/SecurityControllerBuilder.php
+++ b/src/Security/SecurityControllerBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Security;
 
+use PhpParser\Builder\Param;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -32,7 +33,7 @@ final class SecurityControllerBuilder
         $manipulator->addUseStatementIfNecessary(AuthenticationUtils::class);
 
         $loginMethodBuilder->addParam(
-            (new \PhpParser\Builder\Param('authenticationUtils'))->setTypeHint('AuthenticationUtils')
+            (new Param('authenticationUtils'))->setType('AuthenticationUtils')
         );
 
         $manipulator->addMethodBody($loginMethodBuilder, <<<'CODE'

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -23,11 +23,11 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use PhpParser\Builder;
 use PhpParser\BuilderHelpers;
-use PhpParser\Lexer;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\Doctrine\BaseCollectionRelation;
 use Symfony\Bundle\MakerBundle\Doctrine\BaseRelation;
@@ -48,8 +48,7 @@ final class ClassSourceManipulator
     private const CONTEXT_CLASS_METHOD = 'class_method';
     private const DEFAULT_VALUE_NONE = '__default_value_none';
 
-    private Parser\Php7 $parser;
-    private Lexer\Emulative $lexer;
+    private Parser\Php8 $parser;
     private PrettyPrinter $printer;
     private ?ConsoleStyle $io = null;
 
@@ -64,14 +63,7 @@ final class ClassSourceManipulator
         private bool $overwrite = false,
         private bool $useAttributesForDoctrineMapping = true,
     ) {
-        $this->lexer = new Lexer\Emulative([
-            'usedAttributes' => [
-                'comments',
-                'startLine', 'endLine',
-                'startTokenPos', 'endTokenPos',
-            ],
-        ]);
-        $this->parser = new Parser\Php7($this->lexer);
+        $this->parser = (new ParserFactory())->createForNewestSupportedVersion();
         $this->printer = new PrettyPrinter();
 
         $this->setSourceCode($sourceCode);
@@ -327,7 +319,7 @@ final class ClassSourceManipulator
             if (class_exists($returnType) || interface_exists($returnType)) {
                 $returnType = $this->addUseStatementIfNecessary($returnType);
             }
-            $methodNodeBuilder->setReturnType($isReturnTypeNullable ? new Node\NullableType($returnType) : $returnType);
+            $methodNodeBuilder->setReturnType($isReturnTypeNullable ? new Node\NullableType(new Node\Identifier($returnType)) : $returnType);
         }
 
         if ($commentLines) {
@@ -414,7 +406,7 @@ final class ClassSourceManipulator
             );
 
         if (null !== $returnType) {
-            $getterNodeBuilder->setReturnType($isReturnTypeNullable ? new Node\NullableType($returnType) : $returnType);
+            $getterNodeBuilder->setReturnType($isReturnTypeNullable ? new Node\NullableType(new Node\Identifier($returnType)) : $returnType);
         }
 
         if ($commentLines) {
@@ -435,7 +427,7 @@ final class ClassSourceManipulator
 
         $paramBuilder = new Builder\Param($propertyName);
         if (null !== $type) {
-            $paramBuilder->setType($isNullable ? new Node\NullableType($type) : $type);
+            $paramBuilder->setType($isNullable ? new Node\NullableType(new Node\Identifier($type)) : $type);
         }
         $setterNodeBuilder->addParam($paramBuilder->getNode());
 
@@ -641,7 +633,7 @@ final class ClassSourceManipulator
         $removerNodeBuilder = (new Builder\Method($relation->getRemoverMethodName()))->makePublic();
 
         $paramBuilder = new Builder\Param($argName);
-        $paramBuilder->setTypeHint($typeHint);
+        $paramBuilder->setType($typeHint);
         $removerNodeBuilder->addParam($paramBuilder->getNode());
 
         // $this->avatars->removeElement($avatar)
@@ -841,7 +833,7 @@ final class ClassSourceManipulator
         $context = $this;
         $nodeArguments = array_map(static function (string $option, mixed $value) use ($context) {
             if (null === $value) {
-                return new Node\NullableType($option);
+                return new Node\NullableType(new Node\Identifier($option));
             }
 
             // Use the Doctrine Types constant
@@ -900,7 +892,7 @@ final class ClassSourceManipulator
     {
         $this->sourceCode = $sourceCode;
         $this->oldStmts = $this->parser->parse($sourceCode);
-        $this->oldTokens = $this->lexer->getTokens();
+        $this->oldTokens = $this->parser->getTokens();
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NodeVisitor\CloningVisitor());

--- a/src/Util/PrettyPrinter.php
+++ b/src/Util/PrettyPrinter.php
@@ -52,7 +52,7 @@ final class PrettyPrinter extends Standard
      * After
      *      public function getFoo(): string
      */
-    protected function pStmt_ClassMethod(Stmt\ClassMethod $node)
+    protected function pStmt_ClassMethod(Stmt\ClassMethod $node): string
     {
         $classMethod = parent::pStmt_ClassMethod($node);
 

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -698,7 +698,7 @@ class ClassSourceManipulatorTest extends TestCase
 
         $methodBuilder = $manipulator->createMethodBuilder('action', 'JsonResponse', false, ['@Route("/action", name="app_action")']);
         $methodBuilder->addParam(
-            (new Param('param'))->setTypeHint('string')
+            (new Param('param'))->setType('string')
         );
         $manipulator->addMethodBody($methodBuilder,
             <<<'CODE'


### PR DESCRIPTION
This PR adds compatibility for dependency `nikic/php-parser` v5. 

Not sure if it works without additional changes, lets see if the tests will succeed.

**Edit:** Looks like a new major (or at least minor) version is required in order to make it compatible with v5, because v4 will not be compatible anymore.

**Edit2:** I did some refactoring and now it is working with v4 and v5.