### PR TITLE
[make:controller] remove CodeExtension::getFileLink() call when generating twig templates

### DIFF
--- a/src/GeneratorTwigHelper.php
+++ b/src/GeneratorTwigHelper.php
@@ -83,6 +83,8 @@ final class GeneratorTwigHelper
 
     public function getFileLink($path, $text = null, $line = 0): string
     {
+        trigger_deprecation('symfony/maker-bundle', 'v1.53.0', 'getFileLink() is deprecated and will be removed in the future.');
+
         $text = $text ?: $path;
 
         return "<a href=\"{{ '$path'|file_link($line) }}\">$text</a>";

--- a/src/Resources/skeleton/controller/twig_template.tpl.php
+++ b/src/Resources/skeleton/controller/twig_template.tpl.php
@@ -11,8 +11,8 @@
 
     This friendly message is coming from:
     <ul>
-        <li>Your controller at <code><?= $helper->getFileLink("$root_directory/$controller_path", "$controller_path"); ?></code></li>
-        <li>Your template at <code><?= $helper->getFileLink("$root_directory/$relative_path", "$relative_path"); ?></code></li>
+        <li>Your controller at <code><?= $root_directory ?>/<?= $controller_path ?></code></li>
+        <li>Your template at <code><?= $root_directory ?>/<?= $relative_path ?></code></li>
     </ul>
 </div>
 {% endblock %}


### PR DESCRIPTION
TwigBridge's `CodeExtension` was made `@internal` via https://github.com/symfony/twig-bridge/commit/76b43934b95308231fc82a4905fb10eeac31b310

- removes file link anchor in generated template to the controller and template
- deprecates `GeneratorTwigHelper::getFileLink()`

fixes #1415