### PR TITLE
Generator verifies if class exists before altering class name

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -147,7 +147,13 @@ class Generator
             // class is already "absolute" - leave it alone (but strip opening \)
             $className = substr($name, 1);
         } else {
-            $className = rtrim($fullNamespacePrefix, '\\').'\\'.Str::asClassName($name, $suffix);
+            $className = Str::asClassName($name, $suffix);
+
+            try {
+                Validator::classDoesNotExist($className);
+                $className = rtrim($fullNamespacePrefix, '\\').'\\'.$className;
+            } catch (RuntimeCommandException $e) {
+            }
         }
 
         Validator::validateClassName($className, $validationErrorMessage);

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -76,5 +76,29 @@ class GeneratorTest extends TestCase
             'App\\Entity\\User',
             'User',
         ];
+
+        yield 'non_prefixed_fake_fqcn' => [
+            'App\\Entity\\User',
+            '',
+            '',
+            'App\\App\\Entity\\User',
+            'Entity\\User',
+        ];
+
+        yield 'real_fqcn_with_suffix' => [
+            'Symfony\\Bundle\\MakerBundle\\Tests\\Generator',
+            'Test',
+            'Test',
+            'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
+            'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
+        ];
+
+        yield 'real_fqcn_without_suffix' => [
+            'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
+            '',
+            '',
+            'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
+            'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
+        ];
     }
 }


### PR DESCRIPTION
Generator was changing namespace of the class with Prefixed namespace, even in the case it was absolute.
Now if class exists, even if it is not starting with backslash `\`, it would be accepted.

https://github.com/symfony/maker-bundle/issues/1371