### PR TITLE
[ci] windows tests on GitHub actions

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "CI Linux"
 
 on:
     pull_request:
@@ -26,34 +26,34 @@ jobs:
 
         steps:
             -
-                name: "Checkout code"
+                name: Checkout code
                 uses: "actions/checkout@v3"
 
             -
-                name: "Install PHP"
+                name: Install PHP
                 uses: "shivammathur/setup-php@v2"
                 with:
                     coverage: "none"
                     php-version: "${{ matrix.php-version }}"
 
             -
-                name: "Validate composer.json"
+                name: Validate composer.json
                 run: "composer validate --strict --no-check-lock"
 
             -
-                name: "Composer install"
+                name: Composer install
                 uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts"
 
             -
-                name: "Composer install php-cs-fixer"
+                name: Composer install php-cs-fixer
                 uses: "ramsey/composer-install@v2"
                 with:
                     composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
 
             -
-                name: "Run friendsofphp/php-cs-fixer"
+                name: Run PHP-CS-Fixer
                 run: "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff"
 
     test:
@@ -99,42 +99,42 @@ jobs:
                       dependency-versions: 'highest'
 
         steps:
-            - name: "Checkout code"
+            - name: Checkout code
               uses: actions/checkout@v3
 
-            - name: "Install PHP with extensions"
+            - name: Install PHP with extensions
               uses: shivammathur/setup-php@v2
               with:
                   coverage: "none"
                   php-version: ${{ matrix.php-version }}
 
-            - name: "Add PHPUnit matcher"
+            - name: Add PHPUnit matcher
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: "Composer install"
+            - name: Composer install
               uses: "ramsey/composer-install@v2"
               with:
                   dependency-versions: "${{ matrix.dependency-versions }}"
 
-            - name: "Composer install php-cs-fixer"
+            - name: Composer install php-cs-fixer
               uses: "ramsey/composer-install@v2"
               with:
                   composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
 
-            - name: "Composer install twigcs"
+            - name: Composer install twigcs
               uses: "ramsey/composer-install@v2"
               with:
                   composer-options: "--no-scripts --working-dir=tools/twigcs"
 
-            - name: "Install PHPUnit"
+            - name: Install PHPUnit
               run: |
                 if [[ ${{ matrix.dependency_versions == 'lowest' }} ]]; then
                   echo "SYMFONY_PHPUNIT_REQUIRE=nikic/php-parser:^4.18" >> $GITHUB_ENV
                 fi
                 vendor/bin/simple-phpunit install
 
-            - name: "PHPUnit version"
+            - name: PHPUnit version
               run: vendor/bin/simple-phpunit --version
 
-            - name: "Run tests"
+            - name: Run tests
               run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,0 +1,70 @@
+name: "CI Windows"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - 'main'
+    schedule:
+        -   cron: '0 0 * * *'
+
+env:
+    PHPUNIT_FLAGS: "-v"
+    SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
+    MAKER_SKIP_MERCURE_TEST: 1
+    MAKER_SKIP_PANTHER_TEST: 1
+    MAKER_DISABLE_FILE_LINKS: 1
+    MAKER_ALLOW_DEV_DEPS_IN_APP: 0
+    SYMFONY_VERSION: '7.0.x-dev'
+
+jobs:
+    tests:
+        name: Testing on Windows
+        runs-on: [windows-latest]
+        strategy:
+            fail-fast: false
+            matrix:
+                php-versions: [8.2]
+                dependency-versions: ['highest']
+        steps:
+            # This is needed in Windows, otherwise assertions comparing fixtures and generated code will fail.
+            - name: Use INPUT for autocrlf in Git Config
+              run: git config --global core.autocrlf input
+
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup SQLite For Entity Regen Tests
+              run: |
+                  choco install sqlite --params "/NoTools"
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  extensions: pdo, pdo_sqlite
+
+            - name: Composer Install
+              uses: "ramsey/composer-install@v2"
+              with:
+                  dependency-versions: "${{ matrix.dependency-versions }}"
+
+            - name: Composer install php-cs-fixer
+              uses: "ramsey/composer-install@v2"
+              with:
+                  composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
+
+            - name: Composer install twigcs
+              uses: "ramsey/composer-install@v2"
+              with:
+                  composer-options: "--no-scripts --working-dir=tools/twigcs"
+
+            - name: Install PHPUnit
+              run: |
+                  vendor/bin/simple-phpunit install
+
+            - name: PHPUnit Version
+              run: vendor/bin/simple-phpunit --version
+
+            - name: Run Tests
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
         <env name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
         <env name="MAKER_SKIP_MERCURE_TEST" value="false"/>
+        <env name="MAKER_SKIP_PANTHER_TEST" value="false" />
     </php>
 
     <testsuites>

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -22,6 +22,8 @@ use Symfony\Component\Process\InputStream;
  */
 final class MakerTestEnvironment
 {
+    public const GENERATED_FILES_REGEX = '#(?:created|updated):\s(?:.*\\\\)*(.*\.[a-z]{3,4}).*(?:\\\\n)?#ui';
+
     private Filesystem $fs;
     private bool|string $rootPath;
     private string $cachePath;
@@ -213,9 +215,9 @@ final class MakerTestEnvironment
 
         $matches = [];
 
-        preg_match_all('#(created|updated): (]8;;[^]*\\\)?(.*?)(]8;;\\\)?\n#iu', $output, $matches, \PREG_PATTERN_ORDER);
+        preg_match_all(self::GENERATED_FILES_REGEX, $output, $matches, \PREG_PATTERN_ORDER);
 
-        return array_map('trim', $matches[3]);
+        return array_map('trim', $matches[1]);
     }
 
     public function fileExists(string $file): bool

--- a/tests/Maker/MakeFunctionalTestTest.php
+++ b/tests/Maker/MakeFunctionalTestTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 
 use Symfony\Bundle\MakerBundle\Maker\MakeFunctionalTest;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 
 /**
@@ -27,7 +28,7 @@ class MakeFunctionalTestTest extends MakerTestCase
 
     public function getTestDetails(): \Generator
     {
-        yield 'it_generates_test_with_panther' => [$this->createMakerTest()
+        yield 'it_generates_test_with_panther' => [$this->getPantherTest()
             ->addExtraDependencies('panther')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
@@ -47,5 +48,14 @@ class MakeFunctionalTestTest extends MakerTestCase
                 $runner->runTests();
             }),
         ];
+    }
+
+    protected function getPantherTest(): MakerTestDetails
+    {
+        return $this->createMakerTest()
+            ->skipTest(
+                message: 'Panther test skipped - MAKER_SKIP_PANTHER_TEST set to TRUE.',
+                skipped: getenv('MAKER_SKIP_PANTHER_TEST')
+            );
     }
 }

--- a/tests/Maker/MakeTestTest.php
+++ b/tests/Maker/MakeTestTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 
 use Symfony\Bundle\MakerBundle\Maker\MakeTest;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 
 class MakeTestTest extends MakerTestCase
@@ -79,7 +80,7 @@ class MakeTestTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_PantherTestCase_type' => [$this->createMakerTest()
+        yield 'it_makes_PantherTestCase_type' => [$this->getPantherTest()
             ->addExtraDependencies('panther')
             ->run(function (MakerTestRunner $runner) {
                 $runner->copy(
@@ -102,5 +103,14 @@ class MakeTestTest extends MakerTestCase
                 $runner->runTests();
             }),
         ];
+    }
+
+    protected function getPantherTest(): MakerTestDetails
+    {
+        return $this->createMakerTest()
+            ->skipTest(
+                message: 'Panther test skipped - MAKER_SKIP_PANTHER_TEST set to TRUE.',
+                skipped: getenv('MAKER_SKIP_PANTHER_TEST')
+            );
     }
 }

--- a/tests/RegexTest.php
+++ b/tests/RegexTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestEnvironment;
+
+class RegexTest extends TestCase
+{
+    /** @dataProvider regexDataProvider */
+    public function testRegex(string $data, array $expectedResult): void
+    {
+        $result = [];
+
+        preg_match_all(MakerTestEnvironment::GENERATED_FILES_REGEX, $data, $result, \PREG_PATTERN_ORDER);
+
+        self::assertSame($expectedResult, $result[1]);
+    }
+
+    public function regexDataProvider(): \Generator
+    {
+        yield 'Created Prefix' => ['created: test/something.php', ['test/something.php']];
+        yield 'Updated Prefix' => ['updated: test/something.php', ['test/something.php']];
+        yield 'Twig file' => ['created: test/something.html.twig', ['test/something.html.twig']];
+        yield 'Config file (no dir)' => ['updated: service.yaml', ['service.yaml']];
+        yield 'Line Char + 2 dir' => ['\n success\ncreated: test/somewhere/else.php\n', ['test/somewhere/else.php']];
+        yield 'Multiline' => [<<< 'EOT'
+            Congrats!\n
+            Created: some/file.php\n
+            Updated: another/config.yaml\n
+            \n
+            EOT,
+            ['some/file.php', 'another/config.yaml'],
+        ];
+        yield 'Linux CI Results' => [<<< 'EOT'
+            Bundled PHP-CS-Fixer & Bundled PHP-CS-Fixer Configuration\n
+            \n
+             created: \e]8;;file:///home/runner/work/maker-bundle/maker-bundle/tests/tmp/cache/maker_app_40cd750bba9870f18aada2478b24840a_6.4.x-dev/tests/FooBarTest.php#L1\e\tests/FooBarTest.php\e]8;;\e\\n
+            \n
+            EOT,
+            ['tests/FooBarTest.php'],
+        ];
+        yield 'Windows CI Results' => [<<< 'EOT'
+                Bundled PHP-CS-Fixer & Bundled PHP-CS-Fixer Configuration\r\n
+                \r\n
+                 created: tests/FooBarTest.php\r\n
+                \r\n
+            EOT,
+            ['tests/FooBarTest.php'],
+        ];
+    }
+}


### PR DESCRIPTION
- tests that use `symfony/panther` are skipped on windows. The windows runner does not chrome/firefox/etc pre-installed.

- fixes regex that gets a list of files create or updated by MakerBundle (used to test those files were actually created). the file path in the output differs on linux, github actions linux images, macos, & windows. The new regex pattern handles all of those cases. This regex is only used in Maker tests

- adds a test for that regex to protect from hidden test failures in the future.