### PR TITLE
[dx] require >= PHPUnit 9.6, update phpunit schema, deprecate skipOnSymfony7() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.php-cs-fixer.cache
-/.phpunit.result.cache
+/.phpunit.cache
 /composer.lock
 /fake
 /phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "composer/semver": "^3.0",
         "doctrine/doctrine-bundle": "^2.5.0",
         "doctrine/orm": "^2.10.0",
-        "phpunit/phpunit": "^9.6",
         "symfony/http-client": "^6.4|^7.0",
         "symfony/phpunit-bridge": "^6.4.1|^7.0",
         "symfony/security-core": "^6.4|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "composer/semver": "^3.0",
         "doctrine/doctrine-bundle": "^2.5.0",
         "doctrine/orm": "^2.10.0",
+        "phpunit/phpunit": "^9.6",
         "symfony/http-client": "^6.4|^7.0",
         "symfony/phpunit-bridge": "^6.4.1|^7.0",
         "symfony/security-core": "^6.4|^7.0",
@@ -42,8 +43,7 @@
     },
     "conflict": {
         "doctrine/orm": "<2.10",
-        "doctrine/doctrine-bundle": "<2.4",
-        "phpunit/phpunit": "<9.6"
+        "doctrine/doctrine-bundle": "<2.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MakerBundle\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     },
     "conflict": {
         "doctrine/orm": "<2.10",
-        "doctrine/doctrine-bundle": "<2.4"
+        "doctrine/doctrine-bundle": "<2.4",
+        "phpunit/phpunit": "<9.6"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MakerBundle\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          colors="true"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
+         failOnIncomplete="true"
          failOnRisky="true"
          failOnWarning="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
         <ini name="error_reporting" value="-1" />
         <env name="TEST_DATABASE_DSN" value="mysql://root:root@127.0.0.1:3306/test_maker?serverVersion=5.7" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+        <env name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
         <env name="MAKER_SKIP_MERCURE_TEST" value="false"/>
     </php>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,12 +2,14 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
          failOnRisky="true"
          failOnWarning="true"
+         beStrictAboutTodoAnnotatedTests="true"
 >
     <php>
         <ini name="error_reporting" value="-1" />
@@ -16,20 +18,23 @@
     </php>
 
     <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests/</directory>
+        <testsuite name="makers">
+            <directory>tests/Maker</directory>
+        </testsuite>
+        <testsuite name="utils">
+            <directory>tests</directory>
             <exclude>tests/Maker</exclude>
             <exclude>tests/fixtures</exclude>
             <exclude>tests/tmp</exclude>
         </testsuite>
-        <testsuite name="Maker Test Suite">
-            <directory>tests/Maker</directory>
-        </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+    <coverage
+        cacheDirectory=".phpunit.cache/coverage"
+        processUncoveredFiles="true"
+    >
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
         <ini name="error_reporting" value="-1" />
         <env name="TEST_DATABASE_DSN" value="mysql://root:root@127.0.0.1:3306/test_maker?serverVersion=5.7" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+        <env name="MAKER_SKIP_MERCURE_TEST" value="false"/>
     </php>
 
     <testsuites>

--- a/src/Test/MakerTestCase.php
+++ b/src/Test/MakerTestCase.php
@@ -50,6 +50,10 @@ abstract class MakerTestCase extends TestCase
             throw new \LogicException('The MakerTestCase cannot be run as the Process component is not installed. Try running "compose require --dev symfony/process".');
         }
 
+        if ($testDetails->isTestSkipped()) {
+            $this->markTestSkipped($testDetails->getSkippedTestMessage());
+        }
+
         if (!$testDetails->isSupportedByCurrentPhpVersion()) {
             $this->markTestSkipped();
         }

--- a/src/Test/MakerTestCase.php
+++ b/src/Test/MakerTestCase.php
@@ -50,19 +50,11 @@ abstract class MakerTestCase extends TestCase
             throw new \LogicException('The MakerTestCase cannot be run as the Process component is not installed. Try running "compose require --dev symfony/process".');
         }
 
-        if ($testDetails->isTestSkipped()) {
+        if ($testDetails->isTestSkipped() || !$testDetails->isSupportedByCurrentPhpVersion()) {
             $this->markTestSkipped($testDetails->getSkippedTestMessage());
         }
 
-        if (!$testDetails->isSupportedByCurrentPhpVersion()) {
-            $this->markTestSkipped();
-        }
-
         $testEnv = MakerTestEnvironment::create($testDetails);
-
-        if ('7.0.x-dev' === $testEnv->getTargetSkeletonVersion() && $testDetails->getSkipOnSymfony7()) {
-            $this->markTestSkipped('This test is skipped on Symfony 7');
-        }
 
         // prepare environment to test
         $testEnv->prepareDirectory();

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -207,6 +207,7 @@ final class MakerTestDetails
             'v1.53.0',
             sprintf('%s() will be removed in a future version, use MakerTestDetails::isTestSkipped() instead.', __METHOD__)
         );
+
         return $this->skipOnSymfony7;
     }
 
@@ -219,10 +220,10 @@ final class MakerTestDetails
      *
      * @internal
      */
-    public function skipTest(bool $skipped = true, string $message = ''): self
+    public function skipTest(string $message = '', bool $skipped = true): self
     {
-        $this->skipTest = $skipped;
         $this->skipTestMessage = $message;
+        $this->skipTest = $skipped;
 
         return $this;
     }

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -43,9 +43,7 @@ final class MakerTestDetails
 
     public function run(\Closure $callback): self
     {
-        if (!$this->skipTest) {
-            $this->runCallback = $callback;
-        }
+        $this->runCallback = $callback;
 
         return $this;
     }

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -43,7 +43,9 @@ final class MakerTestDetails
 
     public function run(\Closure $callback): self
     {
-        $this->runCallback = $callback;
+        if (!$this->skipTest) {
+            $this->runCallback = $callback;
+        }
 
         return $this;
     }

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -189,7 +189,11 @@ final class MakerTestDetails
 
     public function skipOnSymfony7(): self
     {
-        trigger_deprecation('symfony/maker-bundle', 'v1.53.0', 'This method will be removed in a future version, use MakerTestDetails::skipTest() instead.');
+        @trigger_deprecation(
+            'symfony/maker-bundle',
+            'v1.53.0',
+            sprintf('%s() will be removed in a future version, use MakerTestDetails::skipTest() instead.', __METHOD__)
+        );
 
         $this->skipOnSymfony7 = true;
 
@@ -198,8 +202,11 @@ final class MakerTestDetails
 
     public function getSkipOnSymfony7(): bool
     {
-        trigger_deprecation('symfony/maker-bundle', 'v1.53.0', 'This method will be removed in a future version, use MakerTestDetails::isTestSkipped() instead.');
-
+        @trigger_deprecation(
+            'symfony/maker-bundle',
+            'v1.53.0',
+            sprintf('%s() will be removed in a future version, use MakerTestDetails::isTestSkipped() instead.', __METHOD__)
+        );
         return $this->skipOnSymfony7;
     }
 

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -26,6 +26,16 @@ final class MakerTestDetails
     private int $blockedPhpVersionLower = 0;
     private bool $skipOnSymfony7 = false;
 
+    /**
+     * @internal
+     */
+    private bool $skipTest = false;
+
+    /**
+     * @internal
+     */
+    private string $skipTestMessage = '';
+
     public function __construct(
         private MakerInterface $maker,
     ) {
@@ -179,6 +189,8 @@ final class MakerTestDetails
 
     public function skipOnSymfony7(): self
     {
+        trigger_deprecation('symfony/maker-bundle', 'v1.53.0', 'This method will be removed in a future version, use MakerTestDetails::skipTest() instead.');
+
         $this->skipOnSymfony7 = true;
 
         return $this;
@@ -186,6 +198,45 @@ final class MakerTestDetails
 
     public function getSkipOnSymfony7(): bool
     {
+        trigger_deprecation('symfony/maker-bundle', 'v1.53.0', 'This method will be removed in a future version, use MakerTestDetails::isTestSkipped() instead.');
+
         return $this->skipOnSymfony7;
+    }
+
+    /**
+     * Skip an application test by calling this method and providing an optional
+     * message.
+     *
+     * This method should not be removed even if it is not being used, it may be
+     * needed in the future.
+     *
+     * @internal
+     */
+    public function skipTest(bool $skipped = true, string $message = ''): self
+    {
+        $this->skipTest = $skipped;
+        $this->skipTestMessage = $message;
+
+        return $this;
+    }
+
+    /**
+     * MakerTestCase uses this to determine if a test should be skipped.
+     *
+     * @internal
+     */
+    public function isTestSkipped(): bool
+    {
+        return $this->skipTest;
+    }
+
+    /**
+     * MakerTestCase uses this to get the skipped test message.
+     *
+     * @internal
+     */
+    public function getSkippedTestMessage(): string
+    {
+        return $this->skipTestMessage;
     }
 }

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -44,8 +44,14 @@ class MakeEntityTest extends MakerTestCase
             ;
         }
 
+        // @legacy - MakeEntity uses ux-turbo-mercure (archived), it needs to use ux-turbo (mercure built in) for Symfony 7.0
+        if ('7.0.x-dev' === $_SERVER['SYMFONY_VERSION']) {
+            return $this->createMakerTest()
+                ->skipTest( 'symfony/ux-turbo-mercure is not supported on Symfony 7.')
+            ;
+        }
+
         return $this->createMakeEntityTest()
-            ->skipOnSymfony7() // legacy remove when ux-turbo-mercure supports Symfony 7
             ->preRun(function (MakerTestRunner $runner) {
                 // installed manually later so that the compatibility check can run first
                 $runner->runProcess('composer require symfony/ux-turbo-mercure');

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -37,7 +37,15 @@ class MakeEntityTest extends MakerTestCase
 
     private function createMakeEntityTestForMercure(): MakerTestDetails
     {
-        return $this->createMakeEntityTest()
+        $testDetails = $this->createMakerTest();
+
+        if (getenv('MAKER_SKIP_MERCURE_TEST')) {
+            $testDetails->skipTest('MAKER_SKIP_MERCURE_TEST set to true');
+
+            return $testDetails;
+        }
+
+        return $testDetails
             ->skipOnSymfony7() // legacy remove when ux-turbo-mercure supports Symfony 7
             ->preRun(function (MakerTestRunner $runner) {
                 // installed manually later so that the compatibility check can run first
@@ -535,10 +543,7 @@ class MakeEntityTest extends MakerTestCase
                 $this->assertStringContainsString('use Symfony\UX\Turbo\Attribute\Broadcast;', $content);
                 $this->assertStringContainsString('#[Broadcast]', $content);
 
-                $skipMercureTest = $_SERVER['MAKER_SKIP_MERCURE_TEST'] ?? false;
-                if (!$skipMercureTest) {
-                    $this->runEntityTest($runner);
-                }
+                $this->runEntityTest($runner);
             }),
         ];
 

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -47,7 +47,7 @@ class MakeEntityTest extends MakerTestCase
         // @legacy - MakeEntity uses ux-turbo-mercure (archived), it needs to use ux-turbo (mercure built in) for Symfony 7.0
         if ('7.0.x-dev' === $_SERVER['SYMFONY_VERSION']) {
             return $this->createMakerTest()
-                ->skipTest( 'symfony/ux-turbo-mercure is not supported on Symfony 7.')
+                ->skipTest('symfony/ux-turbo-mercure is not supported on Symfony 7.')
             ;
         }
 

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -45,12 +45,14 @@ class MakeEntityTest extends MakerTestCase
             return $testDetails;
         }
 
-        return $testDetails
+        $testDetails
             ->skipOnSymfony7() // legacy remove when ux-turbo-mercure supports Symfony 7
             ->preRun(function (MakerTestRunner $runner) {
                 // installed manually later so that the compatibility check can run first
                 $runner->runProcess('composer require symfony/ux-turbo-mercure');
             });
+
+        return $testDetails;
     }
 
     public function getTestDetails(): \Generator

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -37,22 +37,20 @@ class MakeEntityTest extends MakerTestCase
 
     private function createMakeEntityTestForMercure(): MakerTestDetails
     {
-        $testDetails = $this->createMakerTest();
-
         if (getenv('MAKER_SKIP_MERCURE_TEST')) {
-            $testDetails->skipTest('MAKER_SKIP_MERCURE_TEST set to true');
-
-            return $testDetails;
+            // This test is skipped, don't worry about persistence
+            return $this->createMakerTest()
+                ->skipTest('MAKER_SKIP_MERCURE_TEST set to true')
+            ;
         }
 
-        $testDetails
+        return $this->createMakeEntityTest()
             ->skipOnSymfony7() // legacy remove when ux-turbo-mercure supports Symfony 7
             ->preRun(function (MakerTestRunner $runner) {
                 // installed manually later so that the compatibility check can run first
                 $runner->runProcess('composer require symfony/ux-turbo-mercure');
-            });
-
-        return $testDetails;
+            })
+        ;
     }
 
     public function getTestDetails(): \Generator


### PR DESCRIPTION
- deprecates `MakerTestDetails::skipOnSymfony7()` methods that were meant to be used internally.

- add ability to skip tests locally (e.g. mercure tests can be skipped by setting `MAKER_SKIP_MERCURE_TEST` to `true` in `phpunit.xml`. Previously that var had to be set in the `$_SERVER` super global.) This plays into Windows tests on GitHub actions.

- fix outdated / deprecated `phpunit.xml.dist` schema / attributes

- require PHPUnit 9.6+ in tests (Only have to worry about 1 phpunit.xml schema. )

- adds a `MakerTestDetails::skipTest()` method & logic to replace the now deprecated `skipOnSymfony7()` methods. Ideally, we'll keep the new method for future use even if we're not using it now. `skipTest()` is marked `@internal` for the time being.