### PR TITLE
[ci] handle doctrine lazy ghost deprecation in entity regen tests

### DIFF
--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Doctrine;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Persistence\Reflection\RuntimeReflectionProperty;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -166,19 +167,26 @@ class TestEntityRegeneratorKernel extends Kernel
             'url' => 'sqlite:///fake',
         ];
 
-        $c->prependExtensionConfig('doctrine', [
-            'dbal' => $dbal,
-            'orm' => [
-                'mappings' => [
-                    'EntityRegenerator' => [
-                        'is_bundle' => false,
-                        'dir' => '%kernel.project_dir%/src/Entity',
-                        'prefix' => 'Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity',
-                        'alias' => 'EntityRegeneratorApp',
-                        'type' => 'attribute',
-                    ],
+        $orm = [
+            'mappings' => [
+                'EntityRegenerator' => [
+                    'is_bundle' => false,
+                    'dir' => '%kernel.project_dir%/src/Entity',
+                    'prefix' => 'Symfony\Bundle\MakerBundle\Tests\tmp\current_project\src\Entity',
+                    'alias' => 'EntityRegeneratorApp',
+                    'type' => 'attribute',
                 ],
             ],
+        ];
+
+        /* @legacy Remove conditional when doctrine/persistence <3.1 are no longer supported. */
+        if (class_exists(RuntimeReflectionProperty::class)) {
+            $orm['enable_lazy_ghost_objects'] = true;
+        }
+
+        $c->prependExtensionConfig('doctrine', [
+            'dbal' => $dbal,
+            'orm' => $orm,
         ]);
     }
 
@@ -219,20 +227,27 @@ class TestXmlEntityRegeneratorKernel extends Kernel
             'url' => 'sqlite:///fake',
         ];
 
-        $c->prependExtensionConfig('doctrine', [
-            'dbal' => $dbal,
-            'orm' => [
-                'auto_generate_proxy_classes' => true,
-                'mappings' => [
-                    'EntityRegenerator' => [
-                        'is_bundle' => false,
-                        'type' => 'xml',
-                        'dir' => '%kernel.project_dir%/config/doctrine',
-                        'prefix' => 'Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity',
-                        'alias' => 'EntityRegeneratorApp',
-                    ],
+        $orm = [
+            'auto_generate_proxy_classes' => true,
+            'mappings' => [
+                'EntityRegenerator' => [
+                    'is_bundle' => false,
+                    'type' => 'xml',
+                    'dir' => '%kernel.project_dir%/config/doctrine',
+                    'prefix' => 'Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity',
+                    'alias' => 'EntityRegeneratorApp',
                 ],
             ],
+        ];
+
+        /* @legacy Remove conditional when doctrine/persistence <3.1 are no longer supported. */
+        if (class_exists(RuntimeReflectionProperty::class)) {
+            $orm['enable_lazy_ghost_objects'] = true;
+        }
+
+        $c->prependExtensionConfig('doctrine', [
+            'dbal' => $dbal,
+            'orm' => $orm,
         ]);
     }
 


### PR DESCRIPTION
```
  3x: Not enabling lazy ghost objects is deprecated and will not be supported in Doctrine ORM 3.0. Ensure Doctrine\ORM\Configuration::setLazyGhostObjectEnabled(true) is called to enable them. (ProxyFactory.php:166 called by EntityManager.php:178, https://github.com/doctrine/orm/pull/10837/, package doctrine/orm)
    2x in EntityRegeneratorTest::testRegenerateEntities from Symfony\Bundle\MakerBundle\Tests\Doctrine
    1x in EntityRegeneratorTest::testXmlRegeneration from Symfony\Bundle\MakerBundle\Tests\Doctrine
```