### PR TITLE
[make:crud] Remove extra dot

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -96,7 +96,7 @@ final class MakeCrud extends AbstractMaker
             $defaultControllerClass
         );
 
-        $this->generateTests = $io->confirm('Do you want to generate tests for the controller?. [Experimental]', false);
+        $this->generateTests = $io->confirm('Do you want to generate tests for the controller? [Experimental]', false);
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void


### PR DESCRIPTION
Hi! Noticed an extra dot after a question mark in tests question

```
Do you want to generate tests for the controller?. [Experimental] (yes/no) [no]:
```