### PR TITLE
[ci] re-enable mercure tests on linux

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -11,7 +11,6 @@ on:
 env:
     PHPUNIT_FLAGS: "-v"
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
-    MAKER_SKIP_MERCURE_TEST: 1
 
 jobs:
     coding-standards:


### PR DESCRIPTION
_Waiting on upstream fixes in `symfony/ux-turbo`_

Mercure tests were disabled in https://github.com/symfony/maker-bundle/pull/1439. 
- [x] Waiting for `Doctrine\Common\ClassUtils` fix upstream.
https://github.com/symfony/ux/pull/1471

