### PR TITLE
[make:controller] deprecate passing PhpCompatUtil to the constructor

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -36,11 +36,13 @@ final class MakeController extends AbstractMaker
 {
     public function __construct(private ?PhpCompatUtil $phpCompatUtil = null)
     {
-        if (null === $phpCompatUtil) {
-            @trigger_error(sprintf('Passing a "%s" instance is mandatory since version 1.42.0', PhpCompatUtil::class), \E_USER_DEPRECATED);
+        if (null !== $phpCompatUtil) {
+            @trigger_deprecation(
+                'symfony/maker-bundle',
+                '1.55.0',
+                sprintf('Initializing MakeCommand while providing an instance of "%s" is deprecated. The $phpCompatUtil param will be removed in a future version.', PhpCompatUtil::class)
+            );
         }
-
-        $this->phpCompatUtil = $phpCompatUtil;
     }
 
     public static function getCommandName(): string

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -26,7 +26,6 @@
             </service>
 
             <service id="maker.maker.make_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeController">
-                <argument type="service" id="maker.php_compat_util" />
                 <tag name="maker.command" />
             </service>
 


### PR DESCRIPTION
`PhpCompatUtil` is no longer used in `make:controller`