### PR TITLE
[make:command] deprecate passing PhpCompatUtil to the constructor

### DIFF
--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -33,8 +33,15 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class MakeCommand extends AbstractMaker
 {
-    public function __construct(private PhpCompatUtil $phpCompatUtil)
+    public function __construct(private ?PhpCompatUtil $phpCompatUtil = null)
     {
+        if (null !== $phpCompatUtil) {
+            @trigger_deprecation(
+                'symfony/maker-bundle',
+                '1.55.0',
+                sprintf('Initializing MakeCommand while providing an instance of "%s" is deprecated. The $phpCompatUtil param will be removed in a future version.', PhpCompatUtil::class),
+            );
+        }
     }
 
     public static function getCommandName(): string

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -17,7 +17,6 @@
             </service>
 
             <service id="maker.maker.make_command" class="Symfony\Bundle\MakerBundle\Maker\MakeCommand">
-                <argument type="service" id="maker.php_compat_util" />
                 <tag name="maker.command" />
             </service>
 


### PR DESCRIPTION
`PhpCompatUtil` is no longer used in `make:command`