### PR TITLE
[make:entity] only show supported types in cli wizard

### DIFF
--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -74,6 +74,32 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_only_shows_supported_types' => [$this->createMakeEntityTest()
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([
+                    // entity class name
+                    'Developer',
+                    // property name
+                    'keyboards',
+                    // field type
+                    '?',
+                    // use default type
+                    '',
+                    // default length
+                    '',
+                    // nullable
+                    '',
+                    // no more properties
+                    '',
+                ]);
+
+                self::assertStringContainsString('Main Types', $output);
+                self::assertStringContainsString('* string or ascii_string', $output);
+                self::assertStringContainsString('* ManyToOne', $output);
+                self::assertStringNotContainsString('* object', $output);
+            }),
+        ];
+
         yield 'it_creates_a_new_class_and_api_resource' => [$this->createMakeEntityTest()
             ->addExtraDependencies('api')
             ->run(function (MakerTestRunner $runner) {

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -96,7 +96,15 @@ class MakeEntityTest extends MakerTestCase
                 self::assertStringContainsString('Main Types', $output);
                 self::assertStringContainsString('* string or ascii_string', $output);
                 self::assertStringContainsString('* ManyToOne', $output);
-                self::assertStringNotContainsString('* object', $output);
+
+                // get the dependencies installed in the test project (tmp/cache/TEST)
+                $installedVersions = require $runner->getPath('vendor/composer/installed.php');
+
+                if (!str_starts_with($installedVersions['versions']['doctrine/dbal']['version'], '3.')) {
+                    self::assertStringNotContainsString('* object', $output);
+                } else {
+                    self::assertStringContainsString('* object', $output);
+                }
             }),
         ];
 


### PR DESCRIPTION
Relates to `make:entity` field type question when passing `?` to see all available types.
- dynamically remove types that are unsupported by the platform.
- adds `ascii_string` as an "or" type for `string`
- replacement for #1447 

allows for removed types in DBAL 4 to still be available for users on DBAL 3

fixes #1446 