### PR TITLE
[make:user] handle ORM\Column.unique deprecation - use ORM\UniqueConstrain

### DIFF
--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Security;
 
 use PhpParser\Node;
+use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassProperty;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -27,6 +28,8 @@ final class UserClassBuilder
     public function addUserInterfaceImplementation(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
     {
         $manipulator->addInterface(UserInterface::class);
+
+        $this->addUniqueConstraint($manipulator, $userClassConfig);
 
         $this->addGetUsername($manipulator, $userClassConfig);
 
@@ -57,7 +60,6 @@ final class UserClassBuilder
                     propertyName: $userClassConfig->getIdentityPropertyName(),
                     type: 'string',
                     length: 180,
-                    unique: true,
                 )
             );
         } else {
@@ -258,5 +260,18 @@ final class UserClassBuilder
         );
 
         $manipulator->addMethodBuilder($builder);
+    }
+
+    private function addUniqueConstraint(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
+    {
+        if ($userClassConfig->isEntity()) {
+            $manipulator->addAttributeToClass(
+                'ORM\\UniqueConstraint',
+                [
+                    'name' => 'UNIQ_IDENTIFIER_' . strtoupper(Str::asSnakeCase($userClassConfig->getIdentityPropertyName())),
+                    'fields' => [$userClassConfig->getIdentityPropertyName()],
+                ]
+            );
+        }
     }
 }

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -268,7 +268,7 @@ final class UserClassBuilder
             $manipulator->addAttributeToClass(
                 'ORM\\UniqueConstraint',
                 [
-                    'name' => 'UNIQ_IDENTIFIER_' . strtoupper(Str::asSnakeCase($userClassConfig->getIdentityPropertyName())),
+                    'name' => 'UNIQ_IDENTIFIER_'.strtoupper(Str::asSnakeCase($userClassConfig->getIdentityPropertyName())),
                     'fields' => [$userClassConfig->getIdentityPropertyName()],
                 ]
             );

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -264,14 +264,16 @@ final class UserClassBuilder
 
     private function addUniqueConstraint(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
     {
-        if ($userClassConfig->isEntity()) {
-            $manipulator->addAttributeToClass(
-                'ORM\\UniqueConstraint',
-                [
-                    'name' => 'UNIQ_IDENTIFIER_'.strtoupper(Str::asSnakeCase($userClassConfig->getIdentityPropertyName())),
-                    'fields' => [$userClassConfig->getIdentityPropertyName()],
-                ]
-            );
+        if (!$userClassConfig->isEntity()) {
+            return;
         }
+
+        $manipulator->addAttributeToClass(
+            'ORM\\UniqueConstraint',
+            [
+                'name' => 'UNIQ_IDENTIFIER_'.strtoupper(Str::asSnakeCase($userClassConfig->getIdentityPropertyName())),
+                'fields' => [$userClassConfig->getIdentityPropertyName()],
+            ]
+        );
     }
 }

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -395,7 +395,9 @@ final class ClassSourceManipulator
 
         $classNode = $this->getClassNode();
 
-        $classNode->attrGroups[] = new Node\AttributeGroup([$this->buildAttributeNode($attributeClass, $options)]);
+        $attributePrefix = str_starts_with($attributeClass, 'ORM\\') ? 'ORM' : null;
+
+        $classNode->attrGroups[] = new Node\AttributeGroup([$this->buildAttributeNode($attributeClass, $options, $attributePrefix)]);
 
         $this->updateSourceCodeFromNewStmts();
     }
@@ -781,6 +783,10 @@ final class ClassSourceManipulator
                     // the use statement already exists? Don't add it again
                     if ($class === (string) $use->name) {
                         return $alias;
+                    }
+
+                    if (str_starts_with($class, $alias)) {
+                        return $class;
                     }
 
                     if ($alias === $shortClassName) {

--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -7,6 +7,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
@@ -14,7 +15,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column()]
     private ?int $id = null;
 
-    #[ORM\Column(length: 180, unique: true)]
+    #[ORM\Column(length: 180)]
     private ?string $email = null;
 
     /**

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -7,6 +7,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['userIdentifier'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
@@ -14,7 +15,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column()]
     private ?int $id = null;
 
-    #[ORM\Column(length: 180, unique: true)]
+    #[ORM\Column(length: 180)]
     private ?string $userIdentifier = null;
 
     /**

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -7,6 +7,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['user_identifier'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]
@@ -14,7 +15,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column()]
     private ?int $id = null;
 
-    #[ORM\Column(length: 180, unique: true)]
+    #[ORM\Column(length: 180)]
     private ?string $user_identifier = null;
 
     /**

--- a/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['userIdentifier'])]
 class User implements UserInterface
 {
     #[ORM\Id]
@@ -13,7 +14,7 @@ class User implements UserInterface
     #[ORM\Column()]
     private ?int $id = null;
 
-    #[ORM\Column(length: 180, unique: true)]
+    #[ORM\Column(length: 180)]
     private ?string $userIdentifier = null;
 
     /**


### PR DESCRIPTION
As a result of https://github.com/doctrine/dbal/pull/5656, we should stop using the `unique` property of the `ORM\Column` attribute in the `make:user` command and prefer the `ORM\UniqueConstraint`.

This PR should solve this problem 🙂