### PR TITLE
[make:auth] Fix 'always-remember-me' param always set to true

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -218,7 +218,7 @@ final class MakeAuthenticator extends AbstractMaker
         $securityData = $manipulator->getData();
 
         $supportRememberMe = $input->hasArgument('support-remember-me') ? $input->getArgument('support-remember-me') : false;
-        $alwaysRememberMe = $input->hasArgument('always-remember-me') ? $input->getArgument('always-remember-me') : false;
+        $alwaysRememberMe = $input->hasArgument('always-remember-me') && self::REMEMBER_ME_TYPE_ALWAYS === $input->getArgument('always-remember-me');
 
         $this->generateAuthenticatorClass(
             $securityData,

--- a/tests/Maker/MakeAuthenticatorTest.php
+++ b/tests/Maker/MakeAuthenticatorTest.php
@@ -305,6 +305,7 @@ class MakeAuthenticatorTest extends MakerTestCase
 
                 $this->assertEquals('%kernel.secret%', $firewallMain['remember_me']['secret']);
                 $this->assertEquals('604800', $firewallMain['remember_me']['lifetime']);
+                $this->assertArrayNotHasKey('always_remember_me', $firewallMain['remember_me']);
             }),
         ];
 


### PR DESCRIPTION
Fixes #1412 and adds test to prevent regression