### PR TITLE
[make:serializer:normalizer] stop using CacheableSupportsMethodInterface

### DIFF
--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -97,7 +97,6 @@
             </service>
 
             <service id="maker.maker.make_serializer_normalizer" class="Symfony\Bundle\MakerBundle\Maker\MakeSerializerNormalizer">
-                <argument type="service" id="maker.file_manager" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/skeleton/serializer/Normalizer.tpl.php
+++ b/src/Resources/skeleton/serializer/Normalizer.tpl.php
@@ -4,10 +4,12 @@ namespace <?= $namespace; ?>;
 
 <?= $use_statements; ?>
 
-class <?= $class_name ?> implements NormalizerInterface, CacheableSupportsMethodInterface
+class <?= $class_name ?> implements NormalizerInterface
 {
-    public function __construct(private NormalizerInterface $objectNormalizer)
-    {
+    public function __construct(
+        #[Autowire(service: 'serializer.normalizer.object')]
+        private NormalizerInterface $normalizer
+    ) {
     }
 
     public function normalize($object, string $format = null, array $context = []): array
@@ -21,11 +23,19 @@ class <?= $class_name ?> implements NormalizerInterface, CacheableSupportsMethod
 
     public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
-        return $data instanceof \App\Entity\<?= str_replace('Normalizer', '', $class_name) ?>;
+<?php if ($entity_exists): ?>
+        return $data instanceof <?= $entity_name ?>;
+<?php else: ?>
+        // TODO: return $data instanceof Object
+<?php endif ?>
     }
 
-    public function hasCacheableSupportsMethod(): bool
+    public function getSupportedTypes(?string $format): array
     {
-        return true;
+<?php if ($entity_exists): ?>
+        return [<?= $entity_name ?>::class => true];
+<?php else: ?>
+        // TODO: return [Object::class => true];
+<?php endif ?>
     }
 }

--- a/tests/Maker/MakeSerializerNormalizerTest.php
+++ b/tests/Maker/MakeSerializerNormalizerTest.php
@@ -22,20 +22,36 @@ class MakeSerializerNormalizerTest extends MakerTestCase
         return MakeSerializerNormalizer::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_makes_serializer_normalizer' => [$this->createMakerTest()
-            // serializer-pack 1.1 requires symfony/property-info >= 5.4
-            // adding symfony/serializer-pack:* as an extra depends allows
-            // us to use serializer-pack < 1.1 which does not conflict with
-            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
-            ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
-                $runner->runMaker(
-                    [
-                        // normalizer class name
-                        'FooBarNormalizer',
-                    ]
+                $output = $runner->runMaker(
+                    ['FooBarNormalizer']
+                );
+
+                $this->assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-serializer-normalizer/FooBarNormalizer.php',
+                    $runner->getPath('src/Serializer/Normalizer/FooBarNormalizer.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_serializer_normalizer_with_existing_entity' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->copy('make-serializer-normalizer/EntityFixture.php', 'src/Entity/EntityFixture.php');
+
+                $output = $runner->runMaker(
+                    ['EntityFixture']
+                );
+
+                $this->assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-serializer-normalizer/EntityFixtureNormalizer.php',
+                    $runner->getPath('src/Serializer/Normalizer/EntityFixtureNormalizer.php')
                 );
             }),
         ];

--- a/tests/fixtures/make-serializer-normalizer/EntityFixture.php
+++ b/tests/fixtures/make-serializer-normalizer/EntityFixture.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Entity;
+
+class EntityFixture
+{
+}

--- a/tests/fixtures/make-serializer-normalizer/EntityFixtureNormalizer.php
+++ b/tests/fixtures/make-serializer-normalizer/EntityFixtureNormalizer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Serializer\Normalizer;
+
+use App\Entity\EntityFixture;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class EntityFixtureNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        #[Autowire(service: 'serializer.normalizer.object')]
+        private NormalizerInterface $normalizer
+    ) {
+    }
+
+    public function normalize($object, ?string $format = null, array $context = []): array
+    {
+        $data = $this->normalizer->normalize($object, $format, $context);
+
+        // TODO: add, edit, or delete some data
+
+        return $data;
+    }
+
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof EntityFixture;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [EntityFixture::class => true];
+    }
+}

--- a/tests/fixtures/make-serializer-normalizer/FooBarNormalizer.php
+++ b/tests/fixtures/make-serializer-normalizer/FooBarNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Serializer\Normalizer;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class FooBarNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        #[Autowire(service: 'serializer.normalizer.object')]
+        private NormalizerInterface $normalizer
+    ) {
+    }
+
+    public function normalize($object, ?string $format = null, array $context = []): array
+    {
+        $data = $this->normalizer->normalize($object, $format, $context);
+
+        // TODO: add, edit, or delete some data
+
+        return $data;
+    }
+
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
+    {
+        // TODO: return $data instanceof Object
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        // TODO: return [Object::class => true];
+    }
+}


### PR DESCRIPTION
- `CacheableSupportsMethodInterface` is deprecated since Symfony 6.3 https://github.com/symfony/symfony/blob/3e296f1a924af7ceccaac96d1279c583d32c6ff1/src/Symfony/Component/Serializer/Normalizer/CacheableSupportsMethodInterface.php#L23

- fix normalizer property param name - refs #1273 

- removes legacy test dependency related to symfony <5.4 composer conflict

- use `[#Autowire()]` attribute instead of modifying `services.yaml` 

- import entity class instead of using FQCN in template