### PR TITLE
[make:registration-form] use validateEmailConfirmationFromRequest() when verifying emails

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -56,8 +56,8 @@ use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
-use SymfonyCasts\Bundle\VerifyEmail\Model\VerifyEmailSignatureComponents;
 use SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle;
+use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelper;
 use SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface;
 
 /**
@@ -444,13 +444,13 @@ final class MakeRegistrationForm extends AbstractMaker
         $missing = false;
         $composerMessage = 'composer require';
 
-        // verify-email-bundle 1.1.1 includes support for translations and a fix for the bad expiration time bug.
-        // we need to check that if the bundle is installed, it is version 1.1.1 or greater
+        // verify-email-bundle 1.17.0 includes the new validateEmailConfirmationFromRequest method.
+        // we need to check that if the bundle is installed, it is version 1.17.0 or greater
         if (class_exists(SymfonyCastsVerifyEmailBundle::class)) {
-            $reflectedComponents = new \ReflectionClass(VerifyEmailSignatureComponents::class);
+            $reflectedComponents = new \ReflectionClass(VerifyEmailHelper::class);
 
-            if (!$reflectedComponents->hasMethod('getExpirationMessageKey')) {
-                throw new RuntimeCommandException('Please upgrade symfonycasts/verify-email-bundle to version 1.1.1 or greater.');
+            if (!$reflectedComponents->hasMethod('validateEmailConfirmationFromRequest')) {
+                throw new RuntimeCommandException('Please upgrade symfonycasts/verify-email-bundle to version 1.17.0 or greater.');
             }
         } else {
             $missing = true;

--- a/src/Resources/skeleton/registration/RegistrationController.tpl.php
+++ b/src/Resources/skeleton/registration/RegistrationController.tpl.php
@@ -7,11 +7,8 @@ namespace <?= $namespace; ?>;
 class <?= $class_name; ?> extends AbstractController
 {
 <?php if ($will_verify_email): ?>
-    private <?= $generator->getPropertyType($email_verifier_class_details) ?>$emailVerifier;
-
-    public function __construct(<?= $email_verifier_class_details->getShortName() ?> $emailVerifier)
+    public function __construct(private <?= $generator->getPropertyType($email_verifier_class_details) ?>$emailVerifier)
     {
-        $this->emailVerifier = $emailVerifier;
     }
 
 <?php endif; ?>

--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -41,7 +41,7 @@ class <?= $class_name; ?><?= "\n" ?>
      */
     public function handleEmailConfirmation(Request $request, UserInterface $user): void
     {
-        $this->verifyEmailHelper->validateEmailConfirmation($request->getUri(), $user-><?= $id_getter ?>(), $user-><?= $email_getter?>());
+        $this->verifyEmailHelper->validateEmailConfirmationFromRequest($request, $user-><?= $id_getter ?>(), $user-><?= $email_getter?>());
 
         $user->setIsVerified(true);
 


### PR DESCRIPTION
Depends on:
- [x] https://github.com/SymfonyCasts/verify-email-bundle/pull/157
- [x] Verify Email Bundle 1.17.0 to be released