### PR TITLE
[make:*] interactivly install composer dependencies

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,7 @@
         <env name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
         <env name="MAKER_SKIP_MERCURE_TEST" value="false"/>
         <env name="MAKER_SKIP_PANTHER_TEST" value="false" />
+        <env name="MAKER_INTERACTIVE_DEPENDENCIES" value="false" />
 <!--    Overrides process timeout when step debugging -->
 <!--    <env name="MAKER_PROCESS_TIMEOUT" value="null" /> -->
     </php>

--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Command;
 
 use Symfony\Bundle\MakerBundle\ApplicationAwareMakerInterface;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Dependency\DependencyManager;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
@@ -61,6 +62,13 @@ final class MakerCommand extends Command
         if ($this->checkDependencies) {
             $dependencies = new DependencyBuilder();
             $this->maker->configureDependencies($dependencies, $input);
+
+            // env is for tests - this way we don't have to add a `y` to every test when a dependency is needed.
+            $dependencyManager = new DependencyManager($this->io, getenv('MAKER_INTERACTIVE_DEPENDS') ?? true);
+
+            $this->maker->configureComposerDependencies($dependencyManager);
+
+            $dependencyManager->installRequiredDependencies();
 
             if ($missingPackagesMessage = $dependencies->getMissingPackagesMessage($this->getName())) {
                 throw new RuntimeCommandException($missingPackagesMessage);

--- a/src/Dependency/DependencyManager.php
+++ b/src/Dependency/DependencyManager.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Dependency;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Dependency\Model\OptionalClassDependency;
+use Symfony\Bundle\MakerBundle\Dependency\Model\RequiredClassDependency;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Process\Process;
+
+/**
+ * @author Jesse Rushlow<jr@rushlow.dev>
+ *
+ * @internal
+ */
+final class DependencyManager
+{
+    /** @var RequiredClassDependency[] */
+    private array $requiredClassDependencies = [];
+
+    /** @var OptionalClassDependency[] */
+    private array $optionalClassDependencies = [];
+
+    private ConsoleStyle $io;
+
+    public function addRequiredDependency(RequiredClassDependency $dependency): self
+    {
+        $this->requiredClassDependencies[] = $dependency;
+
+        return $this;
+    }
+
+    public function addOptionalDependency(OptionalClassDependency $dependency): self
+    {
+        $this->optionalClassDependencies[] = $dependency;
+
+        return $this;
+    }
+
+    public function installRequiredDependencies(ConsoleStyle $io, ?string $preInstallMessage): self
+    {
+        $this->io = $io;
+
+        $preInstallMessage ?: $this->io->caution($preInstallMessage);
+
+        foreach ($this->requiredClassDependencies as $dependency) {
+            if (class_exists($dependency->className) || !$this->askToInstallDependency($dependency)) {
+                continue;
+            }
+
+            $this->runComposer($dependency);
+        }
+
+        return $this;
+    }
+
+    public function installOptionalDependencies(ConsoleStyle $io, ?string $preInstallMessage): self
+    {
+        $this->io = $io;
+
+        $preInstallMessage ?: $this->io->caution($preInstallMessage);
+
+        foreach ($this->optionalClassDependencies as $dependency) {
+            if (class_exists($dependency->className) || !$this->askToInstallDependency($dependency)) {
+                continue;
+            }
+
+            $this->runComposer($dependency);
+        }
+
+        return $this;
+    }
+
+    private function askToInstallDependency(RequiredClassDependency|OptionalClassDependency $dependency): bool
+    {
+        return $this->io->confirm(
+            question: sprintf('Do you want us to run <fg=yellow>composer require %s</> for you?', $dependency->composerPackage),
+            default: true // @TODO - Should we default to yes or no on this...
+        );
+    }
+
+    private function runComposer(RequiredClassDependency|OptionalClassDependency $dependency): void
+    {
+        $process = Process::fromShellCommandline(
+            sprintf('composer require%s %s', $dependency->installAsRequireDev ?: ' --dev', $dependency->composerPackage)
+        );
+
+        if (Command::SUCCESS === $process->run()) {
+            return;
+        }
+
+        $this->io->block($process->getErrorOutput());
+
+        throw new RuntimeCommandException(sprintf('Oops! There was a problem installing "%s". You\'ll need to install the package manually.', $dependency->className));
+    }
+}

--- a/src/Dependency/Model/AbstractClassDependency.php
+++ b/src/Dependency/Model/AbstractClassDependency.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Dependency\Model;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+abstract class AbstractClassDependency
+{
+    public function __construct(
+        public string $className,
+        public string $composerPackage,
+        public bool $installAsRequireDev = false,
+    ) {
+    }
+}

--- a/src/Dependency/Model/AbstractClassDependency.php
+++ b/src/Dependency/Model/AbstractClassDependency.php
@@ -22,6 +22,7 @@ abstract class AbstractClassDependency
         public string $className,
         public string $composerPackage,
         public bool $installAsRequireDev = false,
+        public ?string $preInstallMessage = null,
     ) {
     }
 }

--- a/src/Dependency/Model/OptionalClassDependency.php
+++ b/src/Dependency/Model/OptionalClassDependency.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Dependency\Model;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+final class OptionalClassDependency extends AbstractClassDependency
+{
+}

--- a/src/Dependency/Model/RequiredClassDependency.php
+++ b/src/Dependency/Model/RequiredClassDependency.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Dependency\Model;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+final class RequiredClassDependency extends AbstractClassDependency
+{
+}

--- a/src/Maker/AbstractMaker.php
+++ b/src/Maker/AbstractMaker.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Dependency\DependencyManager;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -53,5 +54,16 @@ abstract class AbstractMaker implements MakerInterface
             static::getCommandName(),
             $message
         );
+    }
+
+    public function configureComposerDependencies(DependencyManager $dependencyManager): void
+    {
+        // @TODO - method here in abstract prevents BC with signature added to `MakerInterface::class`
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        // @TODO - do we deprecate this method in favor of the one above. then remove in 2.x
+        // @TODO - still have plenty of work todo to determine if thats possible or a good idea...
     }
 }

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -89,10 +89,6 @@ final class MakeTwigComponent extends AbstractMaker
         $name = $input->getArgument('name');
         $live = $input->getOption('live');
 
-        if ($live && !class_exists(AsLiveComponent::class)) {
-            throw new \RuntimeException('You must install symfony/ux-live-component to create a live component (composer require symfony/ux-live-component)');
-        }
-
         $factory = $generator->createClassNameDetails(
             $name,
             'Twig\\Components',

--- a/src/Maker/Security/MakeFormLogin.php
+++ b/src/Maker/Security/MakeFormLogin.php
@@ -14,7 +14,8 @@ namespace Symfony\Bundle\MakerBundle\Maker\Security;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
-use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Dependency\DependencyManager;
+use Symfony\Bundle\MakerBundle\Dependency\Model\RequiredClassDependency;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -77,22 +78,15 @@ final class MakeFormLogin extends AbstractMaker
         return 'Generate the code needed for the form_login authenticator';
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies): void
+    public function configureComposerDependencies(DependencyManager $dependencyManager): void
     {
-        $dependencies->addClassDependency(
-            SecurityBundle::class,
-            'security'
-        );
-
-        $dependencies->addClassDependency(TwigBundle::class, 'twig');
-
-        // needed to update the YAML files
-        $dependencies->addClassDependency(
-            Yaml::class,
-            'yaml'
-        );
-
-        $dependencies->addClassDependency(DoctrineBundle::class, 'orm');
+        $dependencyManager
+            ->addDependency([
+                new RequiredClassDependency(SecurityBundle::class, 'security'),
+                new RequiredClassDependency(TwigBundle::class, 'twig'),
+                new RequiredClassDependency(Yaml::class, 'yaml'),
+                new RequiredClassDependency(DoctrineBundle::class, 'orm'),
+        ]);
     }
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void

--- a/src/MakerInterface.php
+++ b/src/MakerInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle;
 
+use Symfony\Bundle\MakerBundle\Dependency\DependencyManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -18,6 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
  * Interface that all maker commands must implement.
  *
  * @method static string getCommandDescription()
+ * @method        void   configureComposerDependencies(DependencyManager $dependencyManager)
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */


### PR DESCRIPTION
- Instead of throwing an exception if `$isLiveComponent` but `ux-live-component` isn't installed, let's ask if they want us to run composer for them...

On Success (keep it clean with no output from the process):

![image](https://github.com/symfony/maker-bundle/assets/40327885/c70ab4ae-2f50-4b30-aebc-e5a988f14281)

On Failure (we dump composer output):

![image](https://github.com/symfony/maker-bundle/assets/40327885/5e6cd467-308d-452a-a74d-77ba09d8b6e1)

fixes: #1277 