### PR TITLE
[make:crud] fixed issues with make CRUD test Controller generation

### DIFF
--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -49,9 +49,9 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
 <?php endforeach; ?>
         ]);
 
-        self::assertResponseRedirects('/sweet/food/');
+        self::assertResponseRedirects($this->path);
 
-        self::assertSame(1, $this->getRepository()->count([]));
+        self::assertSame(1, $this->repository->count([]));
     }
 
     public function testShow(): void
@@ -109,7 +109,7 @@ class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
         $fixture->set<?= ucfirst($form_field); ?>('Value');
 <?php endforeach; ?>
 
-        $this->manager->remove($fixture);
+        $this->manager->persist($fixture);
         $this->manager->flush();
 
         $this->client->request('GET', sprintf('%s%s', $this->path, $fixture->getId()));


### PR DESCRIPTION
I found 3 issues preventing simple CRUD controller tests classes from passing
this changes the TPL template to address these issues

method: `testNew()`
- bad path (sweet food!?) after creating new entity, changed to `$this-path`
- call to `$this->getRepository()` (no such method) instead of `$this->repository`

method: `testRemove()`
- needs to ADD (persist) fixture into DB to then visit show page and delete, change `remove(...)` to `persist(...)`

.. matt ..