### PR TITLE
[make:form] fix generated field options_code indentation

### DIFF
--- a/src/Resources/config/php-cs-fixer.config.php
+++ b/src/Resources/config/php-cs-fixer.config.php
@@ -15,6 +15,7 @@ return (new PhpCsFixer\Config())
         '@Symfony:risky' => true,
         'native_function_invocation' => false,
         'blank_line_before_statement' => ['statements' => ['break', 'case', 'continue', 'declare', 'default', 'do', 'exit', 'for', 'foreach', 'goto', 'if', 'include', 'include_once', 'phpdoc', 'require', 'require_once', 'return', 'switch', 'throw', 'try', 'while', 'yield', 'yield_from']],
+        'array_indentation' => true,
     ])
     ->setRiskyAllowed(true)
 ;

--- a/src/Util/TemplateLinter.php
+++ b/src/Util/TemplateLinter.php
@@ -59,7 +59,7 @@ final class TemplateLinter
             $templateFilePath = [$templateFilePath];
         }
 
-        $ignoreEnv = str_contains(strtolower(\PHP_OS), 'win') ? 'set PHP_CS_FIXER_IGNORE_ENV=1&' : 'PHP_CS_FIXER_IGNORE_ENV=1 ';
+        $ignoreEnv = str_starts_with(strtolower(\PHP_OS), 'win') ? 'set PHP_CS_FIXER_IGNORE_ENV=1& ' : 'PHP_CS_FIXER_IGNORE_ENV=1 ';
 
         $cmdPrefix = $this->needsPhpCmdPrefix ? 'php ' : '';
 


### PR DESCRIPTION
when generating form with `EntityType`, the indentation of `options_code` looks wrong

below example is `Foo <-- ManyToMany --> Bar`
Before

```php
<?php

class BarType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('name')
            ->add('Foo', EntityType::class, [
                'class' => Foo::class,
'choice_label' => 'id',
'multiple' => true,
            ])
        ;
    }

    // ....
}
```

After 

```php
<?php

class BarType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('name')
            ->add('Foo', EntityType::class, [
                'class' => Foo::class,
                'choice_label' => 'id',
                'multiple' => true,
            ])
        ;
    }

    // ....
}
```