### PR TITLE
WIP - [make:reset-password] add remove requests

### DIFF
--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -113,6 +113,21 @@ class <?= $class_name ?> extends AbstractController
         ]);
     }
 
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[Route('/remove/{user}', name: 'app_reset_password_remove', methods: ['POST'])]
+    public function flushRequests(Request $request, User $user, ResetPasswordRequestRepository $repository): Response
+    {
+        // @TODO - Use the reset_password/_remove_requests.html.twig template to submit requests
+        if ($this->isCsrfTokenValid('remove'.$user->getId(), $request->getPayload()->get('_token'))) {
+        $repository->removeRequests($user);
+
+        // @TODO - Inform the user the requests have been removed
+        // $this->addFlash('SUCCESS', 'Flushed your reset password requests...');
+        }
+
+        return $this->redirectToRoute('app_forgot_password_request');
+    }
+
     private function processSendingPasswordResetEmail(string $emailFormData, MailerInterface $mailer<?php if ($translator_available): ?>, TranslatorInterface $translator<?php endif ?>): RedirectResponse
     {
         $user = $this->entityManager->getRepository(<?= $user_class_name ?>::class)->findOneBy([

--- a/src/Resources/skeleton/resetPassword/twig_remove_requests.tpl.php
+++ b/src/Resources/skeleton/resetPassword/twig_remove_requests.tpl.php
@@ -1,0 +1,4 @@
+<form method="post" action="{{ path('app_reset_password_remove', {'id': user.id}) }}" onsubmit="return confirm('Are you sure you want to delete this item?');">
+    <input type="hidden" name="_token" value="{{ csrf_token('remove' ~ user.id) }}">
+    <button class="btn">Delete</button>
+</form>


### PR DESCRIPTION
I'm not sure this is a good idea to just include in the generated template. This feature is something you would implement in other parts of an application (like a user profile page). But, I do think we should advertise the ability to flush requests for a user. Perhaps including this method and commenting out the entire thing? Hmm....

- [ ] Depends on https://github.com/SymfonyCasts/reset-password-bundle/pull/284