### PR TITLE
[make:*] use `getPayload()` instead of accessing `request` on Request objects

### DIFF
--- a/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
+++ b/src/Resources/skeleton/authenticator/LoginFormAuthenticator.tpl.php
@@ -16,15 +16,15 @@ class <?= $class_name; ?> extends AbstractLoginFormAuthenticator
 
     public function authenticate(Request $request): Passport
     {
-        $<?= $username_field_var ?> = $request->request->get('<?= $username_field ?>', '');
+        $<?= $username_field_var ?> = $request->getPayload()->get('<?= $username_field ?>', '');
 
         $request->getSession()->set(SecurityRequestAttributes::LAST_USERNAME, $<?= $username_field_var ?>);
 
         return new Passport(
             new UserBadge($<?= $username_field_var ?>),
-            new PasswordCredentials($request->request->get('password', '')),
+            new PasswordCredentials($request->getPayload()->get('password', '')),
             [
-                new CsrfTokenBadge('authenticate', $request->request->get('_csrf_token')),<?= $remember_me_badge ? "
+                new CsrfTokenBadge('authenticate', $request->getPayload()->get('_csrf_token')),<?= $remember_me_badge ? "
                 new RememberMeBadge(),\n" : "" ?>
             ]
         );

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -77,7 +77,7 @@ class <?= $class_name ?> extends AbstractController
 <?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_delete', $route_name), ['POST']) ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, EntityManagerInterface $entityManager): Response
     {
-        if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->request->get('_token'))) {
+        if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->getPayload()->get('_token'))) {
             $entityManager->remove($<?= $entity_var_singular ?>);
             $entityManager->flush();
         }

--- a/tests/fixtures/make-crud/expected/WithCustomRepository.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepository.php
@@ -71,7 +71,7 @@ class SweetFoodController extends AbstractController
     #[Route('/{id}', name: 'app_sweet_food_delete', methods: ['POST'])]
     public function delete(Request $request, SweetFood $sweetFood, EntityManagerInterface $entityManager): Response
     {
-        if ($this->isCsrfTokenValid('delete'.$sweetFood->getId(), $request->request->get('_token'))) {
+        if ($this->isCsrfTokenValid('delete'.$sweetFood->getId(), $request->getPayload()->get('_token'))) {
             $entityManager->remove($sweetFood);
             $entityManager->flush();
         }


### PR DESCRIPTION
Fixes #1454 

Replace `request->request` by `request->getPayload()`