### PR TITLE
Update Class.tpl.php: Adding ` declare(strict_types=1);`

### DIFF
--- a/src/Resources/skeleton/Class.tpl.php
+++ b/src/Resources/skeleton/Class.tpl.php
@@ -1,4 +1,4 @@
-<?= "<?php\n" ?>
+<?= "<?php declare(strict_types=1);\n" ?>
 
 namespace <?= $namespace; ?>;
 


### PR DESCRIPTION
Well, a few years have passed since the latest suggestion to add `strict_types` https://github.com/symfony/maker-bundle/issues/929, so I thought it's about time for a new attempt ;-)

It was rejected cause Symfony isn't doing it either in their codebase: https://github.com/symfony/maker-bundle/issues/929#issuecomment-889711173
However: Symfony's argument was that they don't want to have it in their **internal** classes: https://github.com/symfony/symfony/issues/28423#issuecomment-466927534 But here in Maker Bundle, we're talking about pre-generated classes for the user.

Two arguments for adding it:
* It's good practice nowadays.
* It's easier to *delete* it (for those users who dont' want it), than it is to *add* it (for those who do want it).