### PR TITLE
do not include dev files in release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 .* export-ignore
 *.md export-ignore
-/appveyor.yml
-/phpunit.xml.dist
+/phpunit.xml.dist export-ignore
 /tests export-ignore
 /tools export-ignore
+docker-compose.yml export-ignore


### PR DESCRIPTION
Excludes the following from being "installed" by the user in a project
- https://github.com/symfony/maker-bundle/blob/main/phpunit.xml.dist
- https://github.com/symfony/maker-bundle/blob/main/docker-compose.yml