### PR TITLE
[make:entity] Fix exception message if mercure bundle not found with --broadcast

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -156,7 +156,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
             // Mercure is needed
             if ($isBroadcast && !class_exists(MercureExtension::class)) {
-                throw new RuntimeCommandException('Please run "composer require symfony/mercure". It is needed to broadcast entities.');
+                throw new RuntimeCommandException('Please run "composer require symfony/mercure-bundle". It is needed to broadcast entities.');
             }
 
             $input->setOption('broadcast', $isBroadcast);


### PR DESCRIPTION
Error says `symfony/mercure` but the `class_exist` looks for `Symfony\Bundle\MercureBundle\DependencyInjection\MercureExtension`.
Switch to `symfony/mercure-bundle` instead.