### PR TITLE
[make:entity] managing keyword prefixes (is, has) for boolean properties getters

### DIFF
--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -43,7 +43,7 @@ class <?= $class_name; ?><?= "\n" ?>
     {
         $this->verifyEmailHelper->validateEmailConfirmationFromRequest($request, $user-><?= $id_getter ?>(), $user-><?= $email_getter?>());
 
-        $user->setIsVerified(true);
+        $user->setVerified(true);
 
         $this->entityManager->persist($user);
         $this->entityManager->flush();

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -282,10 +282,12 @@ final class ClassSourceManipulator
         if ('bool' !== $returnType) {
             return 'get' . Str::asCamelCase($propertyName);
         }
+        
         // exclude is & has from getter definition if already in property name
-        if (!strncasecmp($propertyName, 'is', 2) && !strncasecmp($propertyName, 'has', 3)) {
+        if (0 !== strncasecmp($propertyName, 'is', 2) && 0 !== strncasecmp($propertyName, 'has', 3)) {
             return 'is' . Str::asCamelCase($propertyName);
         }
+
         return Str::asLowerCamelCase($propertyName);
     }
 

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -273,7 +273,7 @@ final class ClassSourceManipulator
         $methodName = $this->getGetterName($propertyName, $returnType);
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
     }
-
+    
     private function getGetterName(string $propertyName, $returnType): string
     {
         if ('bool' !== $returnType) {
@@ -450,7 +450,7 @@ final class ClassSourceManipulator
 
     private function createSetterNodeBuilder(string $propertyName, $type, bool $isNullable, array $commentLines = []): Builder\Method
     {
-        $methodName = 'set'.Str::asCamelCase($propertyName);
+        $methodName = $this->getSetterName($propertyName, $type);
         $setterNodeBuilder = (new Builder\Method($methodName))->makePublic();
 
         if ($commentLines) {
@@ -464,6 +464,15 @@ final class ClassSourceManipulator
         $setterNodeBuilder->addParam($paramBuilder->getNode());
 
         return $setterNodeBuilder;
+    }
+
+    private function getSetterName(string $propertyName, $type): string
+    {
+        if ('bool' === $type && 0 === strncasecmp($propertyName, 'is', 2)) {
+            return 'set'.Str::asCamelCase(substr($propertyName, 2));
+        }
+
+        return 'set'.Str::asCamelCase($propertyName);
     }
 
     private function addSingularRelation(BaseRelation $relation): void

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -273,11 +273,8 @@ final class ClassSourceManipulator
         $methodName = $this->getGetterName($propertyName, $returnType);
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
     }
-
-    /**
-     * @return string|null : getter prefix or null if no prefix to append
-     */
-    private function getGetterName($propertyName, $returnType): ?string
+    
+    private function getGetterName($propertyName, $returnType): string
     {
         if ('bool' !== $returnType) {
             return 'get'.Str::asCamelCase($propertyName);

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -270,27 +270,23 @@ final class ClassSourceManipulator
 
     public function addGetter(string $propertyName, $returnType, bool $isReturnTypeNullable, array $commentLines = []): void
     {
-        $prefix = $this->getGetterPrefix($propertyName, $returnType);
-        $methodName = $prefix ? $prefix.Str::asCamelCase($propertyName) : Str::asLowerCamelCase($propertyName);
+        $methodName = $this->getGetterName($propertyName, $returnType);
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
     }
 
     /**
      * @return string|null : getter prefix or null if no prefix to append
      */
-    private function getGetterPrefix($propertyName, $returnType): ?string
+    private function getGetterName($propertyName, $returnType): ?string
     {
         if ('bool' !== $returnType) {
-            return 'get';
+            return 'get' . Str::asCamelCase($propertyName);
         }
-
         // exclude is & has from getter definition if already in property name
-        $propertyName = strtolower($propertyName);
-        if (!str_starts_with($propertyName, 'is') && !str_starts_with($propertyName, 'has')) {
-            return 'is';
+        if (!strncasecmp($propertyName, 'is', 2) && !strncasecmp($propertyName, 'has', 3)) {
+            return 'is' . Str::asCamelCase($propertyName);
         }
-
-        return null;
+        return Str::asLowerCamelCase($propertyName);
     }
 
     public function addSetter(string $propertyName, ?string $type, bool $isNullable, array $commentLines = []): void

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -280,12 +280,12 @@ final class ClassSourceManipulator
     private function getGetterName($propertyName, $returnType): ?string
     {
         if ('bool' !== $returnType) {
-            return 'get' . Str::asCamelCase($propertyName);
+            return 'get'.Str::asCamelCase($propertyName);
         }
-        
+
         // exclude is & has from getter definition if already in property name
         if (0 !== strncasecmp($propertyName, 'is', 2) && 0 !== strncasecmp($propertyName, 'has', 3)) {
-            return 'is' . Str::asCamelCase($propertyName);
+            return 'is'.Str::asCamelCase($propertyName);
         }
 
         return Str::asLowerCamelCase($propertyName);

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -270,8 +270,27 @@ final class ClassSourceManipulator
 
     public function addGetter(string $propertyName, $returnType, bool $isReturnTypeNullable, array $commentLines = []): void
     {
-        $methodName = ('bool' === $returnType ? 'is' : 'get').Str::asCamelCase($propertyName);
+        $prefix = $this->getGetterPrefix($propertyName, $returnType);
+        $methodName = $prefix ? $prefix.Str::asCamelCase($propertyName) : Str::asLowerCamelCase($propertyName);
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
+    }
+
+    /**
+     * @return string|null : getter prefix or null if no prefix to append
+     */
+    private function getGetterPrefix($propertyName, $returnType): ?string
+    {
+        if ('bool' !== $returnType) {
+            return 'get';
+        }
+
+        // exclude is & has from getter definition if already in property name
+        $propertyName = strtolower($propertyName);
+        if (!str_starts_with($propertyName, 'is') && !str_starts_with($propertyName, 'has')) {
+            return 'is';
+        }
+
+        return null;
     }
 
     public function addSetter(string $propertyName, ?string $type, bool $isNullable, array $commentLines = []): void

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -273,7 +273,7 @@ final class ClassSourceManipulator
         $methodName = $this->getGetterName($propertyName, $returnType);
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
     }
-    
+
     private function getGetterName(string $propertyName, $returnType): string
     {
         if ('bool' !== $returnType) {

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -273,8 +273,8 @@ final class ClassSourceManipulator
         $methodName = $this->getGetterName($propertyName, $returnType);
         $this->addCustomGetter($propertyName, $methodName, $returnType, $isReturnTypeNullable, $commentLines);
     }
-    
-    private function getGetterName($propertyName, $returnType): string
+
+    private function getGetterName(string $propertyName, $returnType): string
     {
         if ('bool' !== $returnType) {
             return 'get'.Str::asCamelCase($propertyName);

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -106,6 +106,22 @@ class ClassSourceManipulatorTest extends TestCase
             'User_simple_bool.php',
         ];
 
+        yield 'getter_bool_begins_with_is' => [
+            'User_simple.php',
+            'isFooProp',
+            'bool',
+            [],
+            'User_bool_begins_with_is.php',
+        ];
+
+        yield 'getter_bool_begins_with_has' => [
+            'User_simple.php',
+            'hasFooProp',
+            'bool',
+            [],
+            'User_bool_begins_with_has.php',
+        ];
+
         yield 'getter_no_props_comments' => [
             'User_no_props.php',
             'fooProp',

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -196,6 +196,15 @@ class ClassSourceManipulatorTest extends TestCase
             [],
             'User_simple_null_type.php',
         ];
+
+        yield 'setter_bool_begins_with_is' => [
+            'User_simple.php',
+            'isFooProp',
+            'bool',
+            false,
+            [],
+            'User_bool_begins_with_is.php',
+        ];
     }
 
     /**

--- a/tests/Util/fixtures/add_getter/User_bool_begins_with_has.php
+++ b/tests/Util/fixtures/add_getter/User_bool_begins_with_has.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function hasFooProp(): ?bool
+    {
+        return $this->hasFooProp;
+    }
+}

--- a/tests/Util/fixtures/add_getter/User_bool_begins_with_is.php
+++ b/tests/Util/fixtures/add_getter/User_bool_begins_with_is.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function isFooProp(): ?bool
+    {
+        return $this->isFooProp;
+    }
+}

--- a/tests/Util/fixtures/add_setter/User_bool_begins_with_is.php
+++ b/tests/Util/fixtures/add_setter/User_bool_begins_with_is.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setFooProp(bool $isFooProp): static
+    {
+        $this->isFooProp = $isFooProp;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
- Refactoring the getter prefixes  for `make:entity`
- Introducing exceptions for boolean fields : not adding the prefix to getter name if field begins with "is" or "has"

Related to #1492 

