### PR TITLE
[make:entity] confirm to allow non-ascii char's in entity names

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -819,6 +819,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         return $io->askQuestion($question);
     }
 
+    /** @return string[] */
     private function verifyEntityName(string $entityName): array
     {
         preg_match('/([^\x00-\x7F]+)/u', $entityName, $matches);

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -107,11 +107,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
-        if ($input->getArgument('name')) {
-            if (!$this->verifyEntityName($input->getArgument('name'))) {
-                throw new \InvalidArgumentException('An entity can only have ASCII letters');
-            }
-
+        if (($entityClassName = $input->getArgument('name')) && empty($this->verifyEntityName($entityClassName))) {
             return;
         }
 
@@ -131,10 +127,13 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         $argument = $command->getDefinition()->getArgument('name');
         $question = $this->createEntityClassQuestion($argument->getDescription());
-        $entityClassName = $io->askQuestion($question);
+        $entityClassName ??= $io->askQuestion($question);
 
-        while (!$this->verifyEntityName($entityClassName)) {
-            $io->error('An entity can only have ASCII letters');
+        while ($dangerous = $this->verifyEntityName($entityClassName)) {
+            if ($io->confirm(sprintf('The %s character is non-ASCII, which are potentially problematic with some database. It is recommended to use only ASCII characters in entity names. Would you keep entered name ?', $dangerous[0]), false)) {
+                break;
+            }
+
             $entityClassName = $io->askQuestion($question);
         }
 
@@ -820,9 +819,11 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         return $io->askQuestion($question);
     }
 
-    private function verifyEntityName(string $entityName): bool
+    private function verifyEntityName(string $entityName): array
     {
-        return preg_match('/^[a-zA-Z\\\\]+$/', $entityName);
+        preg_match('/[^\x00-\x7F]/u', $entityName, $matches);
+
+        return $matches;
     }
 
     private function createClassManipulator(string $path, ConsoleStyle $io, bool $overwrite): ClassSourceManipulator

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -821,7 +821,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
     private function verifyEntityName(string $entityName): array
     {
-        preg_match('/[^\x00-\x7F]/u', $entityName, $matches);
+        preg_match('/([^\x00-\x7F]+)/u', $entityName, $matches);
 
         return $matches;
     }

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -130,7 +130,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         $entityClassName ??= $io->askQuestion($question);
 
         while ($dangerous = $this->verifyEntityName($entityClassName)) {
-            if ($io->confirm(sprintf('The %s character is non-ASCII, which are potentially problematic with some database. It is recommended to use only ASCII characters in entity names. Would you keep entered name ?', $dangerous[0]), false)) {
+            if ($io->confirm(sprintf('"%s" contains one or more non-ASCII characters, which are potentially problematic with some database. It is recommended to use only ASCII characters for entity names. Continue anyway?', $entityClassName), false)) {
                 break;
             }
 

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -107,6 +107,8 @@ class MakeEntityTest extends MakerTestCase
                 $runner->runMaker([
                     // entity class with accent
                     'Usé',
+                    // Say no,
+                    'n',
                     // entity class without accent
                     'User',
                     // no fields


### PR DESCRIPTION
Following the message https://github.com/symfony/maker-bundle/pull/1474#issuecomment-2027716072, I made some modifications

---
edited by @jrushlow 
fixes #1556 