### PR TITLE
[make:*] add ability to generate tests

### DIFF
--- a/src/Maker/Common/CanGenerateTestsTrait.php
+++ b/src/Maker/Common/CanGenerateTestsTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker\Common;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+trait CanGenerateTestsTrait
+{
+    private bool $generateTests = false;
+
+    public function configureCommandWithTestsOption(Command $command): Command
+    {
+        $testsHelp = file_get_contents(\dirname(__DIR__, 2).'/Resources/help/_WithTests.txt');
+        $help = $command->getHelp()."\n".$testsHelp;
+
+        $command
+            ->addOption(name: 'with-tests', mode: InputOption::VALUE_NONE, description: 'Generate PHPUnit Tests')
+            ->setHelp($help)
+        ;
+
+        return $command;
+    }
+
+    public function interactSetGenerateTests(InputInterface $input, ConsoleStyle $io): void
+    {
+        // Sanity check for maker dev's - End user should never see this.
+        if (!$input->hasOption('with-tests')) {
+            throw new RuntimeCommandException('Whoops! "--with-tests" option does not exist. Call "addWithTestsOptions()" in the makers "configureCommand().');
+        }
+
+        $this->generateTests = $input->getOption('with-tests');
+
+        if (!$this->generateTests) {
+            $this->generateTests = $io->confirm('Do you want to generate PHPUnit tests? [Experimental]', false);
+        }
+    }
+
+    public function shouldGenerateTests(): bool
+    {
+        return $this->generateTests;
+    }
+}

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -24,6 +24,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\Common\CanGenerateTestsTrait;
 use Symfony\Bundle\MakerBundle\Renderer\FormTypeRenderer;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
@@ -45,6 +46,8 @@ use Symfony\Component\Validator\Validation;
  */
 final class MakeCrud extends AbstractMaker
 {
+    use CanGenerateTestsTrait;
+
     private Inflector $inflector;
     private string $controllerClassName;
     private bool $generateTests = false;
@@ -72,6 +75,7 @@ final class MakeCrud extends AbstractMaker
         ;
 
         $inputConfig->setArgumentAsNonInteractive('entity-class');
+        $this->configureCommandWithTestsOption($command);
     }
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
@@ -96,7 +100,7 @@ final class MakeCrud extends AbstractMaker
             $defaultControllerClass
         );
 
-        $this->generateTests = $io->confirm('Do you want to generate tests for the controller? [Experimental]', false);
+        $this->interactSetGenerateTests($input, $io);
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
@@ -237,7 +241,7 @@ final class MakeCrud extends AbstractMaker
             );
         }
 
-        if ($this->generateTests) {
+        if ($this->shouldGenerateTests()) {
             $testClassDetails = $generator->createClassNameDetails(
                 $entityClassDetails->getRelativeNameWithoutSuffix(),
                 'Test\\Controller\\',

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use PhpParser\Builder\Param;
 use Symfony\Bridge\Twig\AppVariable;
@@ -365,7 +364,7 @@ class MakeResetPassword extends AbstractMaker
             $useStatements = new UseStatementGenerator([
                 $userClassNameDetails->getFullName(),
                 $userRepositoryDetails->getFullName(),
-                EntityManager::class,
+                EntityManagerInterface::class,
                 KernelBrowser::class,
                 WebTestCase::class,
                 UserPasswordHasherInterface::class,

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -89,6 +89,7 @@
                 <argument type="service" id="maker.file_manager" />
                 <argument type="service" id="maker.doctrine_helper" />
                 <argument type="service" id="maker.entity_class_generator" />
+                <argument type="service" id="router" on-invalid="ignore" />
                 <tag name="maker.command" />
             </service>
 

--- a/src/Resources/help/_WithTests.txt
+++ b/src/Resources/help/_WithTests.txt
@@ -1,0 +1,6 @@
+To generate tailored PHPUnit tests, simply call:
+
+<info>php %command.full_name% --with-tests</info>
+
+This will generate a unit test in <info>tests/</info> for you to review then use
+to test the new functionality of your app.

--- a/src/Resources/skeleton/registration/Test.WithVerify.tpl.php
+++ b/src/Resources/skeleton/registration/Test.WithVerify.tpl.php
@@ -31,6 +31,7 @@ class RegistrationControllerTest extends WebTestCase
         // Register a new user
         $this->client->request('GET', '/register');
         self::assertResponseIsSuccessful();
+        self::assertPageTitleContains('Register');
 
         $this->client->submitForm('Register', [
             'registration_form[email]' => 'me@example.com',
@@ -61,6 +62,7 @@ class RegistrationControllerTest extends WebTestCase
         /** @var TemplatedEmail $templatedEmail */
         $templatedEmail = $messages[0];
         $messageBody = $templatedEmail->getHtmlBody();
+        self::assertIsString($messageBody);
 
         preg_match('#(http://localhost/verify/email.+)">#', $messageBody, $resetLink);
 

--- a/src/Resources/skeleton/registration/Test.WithVerify.tpl.php
+++ b/src/Resources/skeleton/registration/Test.WithVerify.tpl.php
@@ -1,0 +1,73 @@
+<?= "<?php\n" ?>
+namespace App\Tests;
+
+<?= $use_statements ?>
+
+class RegistrationControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private <?= $repository_class_name ?> $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+
+        // Ensure we have a clean database
+        $container = static::getContainer();
+
+        /** @var EntityManager $em */
+        $em = $container->get('doctrine')->getManager();
+        $this->userRepository = $container->get(<?= $repository_class_name ?>::class);
+
+        foreach ($this->userRepository->findAll() as $user) {
+            $em->remove($user);
+        }
+
+        $em->flush();
+    }
+
+    public function testRegister(): void
+    {
+        // Register a new user
+        $this->client->request('GET', '/register');
+        self::assertResponseIsSuccessful();
+
+        $this->client->submitForm('Register', [
+            'registration_form[email]' => 'me@example.com',
+            'registration_form[plainPassword]' => 'password',
+            'registration_form[agreeTerms]' => true,
+        ]);
+
+        // Ensure the response redirects after submitting the form, the user exists, and is not verified
+        // self::assertResponseRedirects('/');  @TODO: set the appropriate path that the user is redirected to.
+        self::assertCount(1, $this->userRepository->findAll());
+        self::assertFalse(($user = $this->userRepository->findAll()[0])->isVerified());
+
+        // Ensure the verification email was sent
+        // Use either assertQueuedEmailCount() || assertEmailCount() depending on your mailer setup
+        // self::assertQueuedEmailCount(1);
+        self::assertEmailCount(1);
+
+        self::assertCount(1, $messages = $this->getMailerMessages());
+        self::assertEmailAddressContains($messages[0], 'from', '<?= $from_email ?>');
+        self::assertEmailAddressContains($messages[0], 'to', 'me@example.com');
+        self::assertEmailTextBodyContains($messages[0], 'This link will expire in 1 hour.');
+
+        // Login the new user
+        $this->client->followRedirect();
+        $this->client->loginUser($user);
+
+        // Get the verification link from the email
+        /** @var TemplatedEmail $templatedEmail */
+        $templatedEmail = $messages[0];
+        $messageBody = $templatedEmail->getHtmlBody();
+
+        preg_match('#(http://localhost/verify/email.+)">#', $messageBody, $resetLink);
+
+        // "Click" the link and see if the user is verified
+        $this->client->request('GET', $resetLink[1]);
+        $this->client->followRedirect();
+
+        self::assertTrue(static::getContainer()->get(<?= $repository_class_name ?>::class)->findAll()[0]->isVerified());
+    }
+}

--- a/src/Resources/skeleton/registration/Test.WithoutVerify.tpl.php
+++ b/src/Resources/skeleton/registration/Test.WithoutVerify.tpl.php
@@ -1,0 +1,45 @@
+<?= "<?php\n" ?>
+namespace App\Tests;
+
+<?= $use_statements ?>
+
+class RegistrationControllerTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private <?= $repository_class_name ?> $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+
+        // Ensure we have a clean database
+        $container = static::getContainer();
+
+        /** @var EntityManager $em */
+        $em = $container->get('doctrine')->getManager();
+        $this->userRepository = $container->get(<?= $repository_class_name ?>::class);
+
+        foreach ($this->userRepository->findAll() as $user) {
+            $em->remove($user);
+        }
+
+        $em->flush();
+    }
+
+    public function testRegister(): void
+    {
+        // Register a new user
+        $this->client->request('GET', '/register');
+        self::assertResponseIsSuccessful();
+
+        $this->client->submitForm('Register', [
+            'registration_form[email]' => 'me@example.com',
+            'registration_form[plainPassword]' => 'password',
+            'registration_form[agreeTerms]' => true,
+        ]);
+
+        // Ensure the response redirects after submitting the form, the user exists, and is not verified
+        // self::assertResponseRedirects('/'); @TODO: set the appropriate path that the user is redirected to.
+        self::assertCount(1, $this->userRepository->findAll());
+    }
+}

--- a/src/Resources/skeleton/registration/Test.WithoutVerify.tpl.php
+++ b/src/Resources/skeleton/registration/Test.WithoutVerify.tpl.php
@@ -31,6 +31,7 @@ class RegistrationControllerTest extends WebTestCase
         // Register a new user
         $this->client->request('GET', '/register');
         self::assertResponseIsSuccessful();
+        self::assertPageTitleContains('Register');
 
         $this->client->submitForm('Register', [
             'registration_form[email]' => 'me@example.com',

--- a/src/Resources/skeleton/resetPassword/Test.ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/Test.ResetPasswordController.tpl.php
@@ -6,7 +6,7 @@ namespace App\Tests;
 class ResetPasswordTest extends WebTestCase
 {
     private KernelBrowser $client;
-    private EntityManager $em;
+    private EntityManagerInterface $em;
     private <?= $user_repo_short_name ?> $userRepository;
 
     protected function setUp(): void
@@ -15,8 +15,12 @@ class ResetPasswordTest extends WebTestCase
 
         // Ensure we have a clean database
         $container = static::getContainer();
-        $this->em = $container->get('doctrine')->getManager();
-        $this->userRepository = $this->em->getRepository(<?= $user_short_name ?>::class);
+
+        /** @var EntityManagerInterface $em */
+        $em = $container->get('doctrine')->getManager();
+        $this->em = $em;
+
+        $this->userRepository = $container->get(<?= $user_repo_short_name ?>::class);
 
         foreach ($this->userRepository->findAll() as $user) {
             $this->em->remove($user);
@@ -25,7 +29,7 @@ class ResetPasswordTest extends WebTestCase
         $this->em->flush();
     }
 
-    public function testMaker(): void
+    public function testResetPasswordController(): void
     {
         // Create a test user
         $user = (new <?= $user_short_name ?>())
@@ -84,6 +88,8 @@ class ResetPasswordTest extends WebTestCase
         self::assertResponseRedirects('<?= $success_route_path ?>');
 
         $user = $this->userRepository->findOneBy(['email' => 'me@example.com']);
+
+        self::assertInstanceOf(<?= $user_short_name ?>::class, $user);
 
         /** @var UserPasswordHasherInterface $passwordHasher */
         $passwordHasher = static::getContainer()->get(UserPasswordHasherInterface::class);

--- a/src/Resources/skeleton/resetPassword/Test.ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/Test.ResetPasswordController.tpl.php
@@ -1,0 +1,92 @@
+<?= "<?php\n" ?>
+namespace App\Tests;
+
+<?= $use_statements ?>
+
+class ResetPasswordTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManager $em;
+    private <?= $user_repo_short_name ?> $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+
+        // Ensure we have a clean database
+        $container = static::getContainer();
+        $this->em = $container->get('doctrine')->getManager();
+        $this->userRepository = $this->em->getRepository(<?= $user_short_name ?>::class);
+
+        foreach ($this->userRepository->findAll() as $user) {
+            $this->em->remove($user);
+        }
+
+        $this->em->flush();
+    }
+
+    public function testMaker(): void
+    {
+        // Create a test user
+        $user = (new <?= $user_short_name ?>())
+            ->setEmail('me@example.com')
+            ->setPassword('a-test-password-that-will-be-changed-later')
+        ;
+        $this->em->persist($user);
+        $this->em->flush();
+
+        // Test Request reset password page
+        $this->client->request('GET', '/reset-password');
+
+        self::assertResponseIsSuccessful();
+        self::assertPageTitleContains('Reset your password');
+
+        // Submit the reset password form and test email message is queued / sent
+        $this->client->submitForm('Send password reset email', [
+            'reset_password_request_form[email]' => 'me@example.com',
+        ]);
+
+        // Ensure the reset password email was sent
+        // Use either assertQueuedEmailCount() || assertEmailCount() depending on your mailer setup
+        // self::assertQueuedEmailCount(1);
+        self::assertEmailCount(1);
+
+        self::assertCount(1, $messages = $this->getMailerMessages());
+
+        self::assertEmailAddressContains($messages[0], 'from', '<?= $from_email ?>');
+        self::assertEmailAddressContains($messages[0], 'to', 'me@example.com');
+        self::assertEmailTextBodyContains($messages[0], 'This link will expire in 1 hour.');
+
+        self::assertResponseRedirects('/reset-password/check-email');
+
+        // Test check email landing page shows correct "expires at" time
+        $crawler = $this->client->followRedirect();
+
+        self::assertPageTitleContains('Password Reset Email Sent');
+        self::assertStringContainsString('This link will expire in 1 hour', $crawler->html());
+
+        // Test the link sent in the email is valid
+        $email = $messages[0]->toString();
+        preg_match('#(/reset-password/reset/[a-zA-Z0-9]+)#', $email, $resetLink);
+
+        $this->client->request('GET', $resetLink[1]);
+
+        self::assertResponseRedirects('/reset-password/reset');
+
+        $this->client->followRedirect();
+
+        // Test we can set a new password
+        $this->client->submitForm('Reset password', [
+            'change_password_form[plainPassword][first]' => 'newStrongPassword',
+            'change_password_form[plainPassword][second]' => 'newStrongPassword',
+        ]);
+
+        self::assertResponseRedirects('<?= $success_route_path ?>');
+
+        $user = $this->userRepository->findOneBy(['email' => 'me@example.com']);
+
+        /** @var UserPasswordHasherInterface $passwordHasher */
+        $passwordHasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+        self::assertTrue($passwordHasher->isPasswordValid($user, 'newStrongPassword'));
+    }
+}

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -229,6 +229,89 @@ class MakeRegistrationFormTest extends MakerTestCase
                 $this->runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
             }),
         ];
+
+        yield 'it_generates_registration_form_with_tests' => [$this->createRegistrationFormTest()
+            ->run(function (MakerTestRunner $runner) {
+                $this->makeUser($runner);
+
+                $output = $runner->runMaker([
+                    'n', // add UniqueEntity
+                    'n', // verify user
+                    'n', // automatically authenticate after registration
+                    'app_anonymous', // route number to redirect to
+                    'y', // Generate tests
+                ]);
+
+                $this->assertStringContainsString('Success', $output);
+                $this->assertFileExists($runner->getPath('tests/RegistrationControllerTest.php'));
+
+                $runner->configureDatabase();
+                $runner->runTests();
+            }),
+        ];
+
+        yield 'it_generates_registration_form_with_tests_using_flag' => [$this->createRegistrationFormTest()
+            ->run(function (MakerTestRunner $runner) {
+                $this->makeUser($runner);
+
+                $output = $runner->runMaker([
+                    'n', // add UniqueEntity
+                    'n', // verify user
+                    'n', // automatically authenticate after registration
+                    'app_anonymous', // route number to redirect to
+                ], '--with-tests');
+
+                $this->assertStringContainsString('Success', $output);
+                $this->assertFileExists($runner->getPath('tests/RegistrationControllerTest.php'));
+
+                $runner->configureDatabase();
+                $runner->runTests();
+            }),
+        ];
+
+        yield 'it_generates_registration_form_with_verification_and_with_tests' => [$this->createRegistrationFormTest()
+            ->addExtraDependencies('symfonycasts/verify-email-bundle')
+            // needed for internal functional test
+            ->addExtraDependencies('symfony/web-profiler-bundle', 'mailer')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->writeFile(
+                    'config/packages/mailer.yaml',
+                    Yaml::dump(['framework' => [
+                        'mailer' => ['dsn' => 'null://null'],
+                    ]])
+                );
+
+                $this->makeUser($runner);
+
+                $output = $runner->runMaker([
+                    'n', // add UniqueEntity
+                    'y', // verify user
+                    'y', // require authentication to verify user email
+                    'jr@rushlow.dev', // from email address
+                    'SymfonyCasts', // From Name
+                    'n', // no authenticate after
+                    'app_anonymous', // route number to redirect to
+                    'y', // Generate tests
+                ]);
+
+                $this->assertStringContainsString('Success', $output);
+
+                $generatedFiles = [
+                    'src/Security/EmailVerifier.php',
+                    'templates/registration/confirmation_email.html.twig',
+                    'tests/RegistrationControllerTest.php',
+                ];
+
+                foreach ($generatedFiles as $file) {
+                    $this->assertFileExists($runner->getPath($file));
+                }
+
+                $runner->runConsole('cache:clear', [], '--env=test');
+
+                $runner->configureDatabase();
+                $runner->runTests();
+            }),
+        ];
     }
 
     private function makeUser(MakerTestRunner $runner, string $identifier = 'email'): void

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -82,6 +82,54 @@ class MakeResetPasswordTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_tests' => [$this->createMakerTest()
+            // Needed to assertEmails && NotCompromisedPassword
+            ->addExtraDependencies('symfony/mailer', 'symfony/http-client')
+            // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
+            ->setSkippedPhpVersions(80100, 80109)
+            ->preRun(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-reset-password/src/Controller/FixtureController.php',
+                    'src/Controller/FixtureController.php'
+                );
+            })
+            ->run(function (MakerTestRunner $runner) {
+                $this->makeUser($runner);
+
+                $output = $runner->runMaker([
+                    'app_home',
+                    'jr@rushlow.dev',
+                    'SymfonyCasts',
+                    'y',
+                ]);
+
+                $this->assertStringContainsString('Success', $output);
+
+                $generatedFiles = [
+                    'tests/ResetPasswordControllerTest.php',
+                ];
+
+                foreach ($generatedFiles as $file) {
+                    $this->assertFileExists($runner->getPath($file));
+                }
+
+                $runner->writeFile(
+                    'config/packages/mailer.yaml',
+                    Yaml::dump(['framework' => [
+                        'mailer' => ['dsn' => 'null://null'],
+                    ]])
+                );
+
+                $runner->copy(
+                    'make-reset-password/tests/it_generates_with_normal_setup.php',
+                    'tests/ResetPasswordFunctionalTest.php'
+                );
+
+                $runner->configureDatabase();
+                $runner->runTests();
+            }),
+        ];
+
         yield 'it_generates_with_uuid' => [$this->createMakerTest()
             ->setSkippedPhpVersions(80100, 80109)
             ->addExtraDependencies('symfony/uid')

--- a/tests/fixtures/make-reset-password/src/Controller/FixtureController.php
+++ b/tests/fixtures/make-reset-password/src/Controller/FixtureController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+class FixtureController extends AbstractController
+{
+    #[Route(name: 'app_home')]
+    public function index(): JsonResponse
+    {
+        return $this->json(['message' => 'success']);
+    }
+}


### PR DESCRIPTION
_This feature is experimental - generated code is likely to change significantly between point releases._

Adds the ability to pass `--with-tests` to `make:registration`, `make:reset-password`, & `make:crud` and maker will generate a new PHPUnit test tailored for the specific functionality of that maker. If `--with-tests` is _not_ passed as an argument, MakerBundle will ask the user `Do you want to generate PHPUnit tests? [Experimental]`. 

This PR introduces a new internal `CanGenerateTestsTrait` that can be added to any Maker command. The method naming is intended to be intuitive - e.g. `configureCommandWithTestsOption()` should be called from `configureCommand()`, `interactSetGenerateTests()` called in `interact()`, & `shouldGenerateTests()` is used in the `generate()` method in a conditional to determine if the command should generate test code.

The userland tests we generate are run against the code generated by their respective makers in _our_ test suite. This should be the case for any tests created going forward. 

The tests are created under the `App\Tests` namespace and created in the `tests/` dir. Possibly in the future we can customize this behavior - but for now - attempting to guess the correct test dir structure && keep everyone happy is outside the scope of this PR :stuck_out_tongue_winking_eye: 

- [x] `make:reset-password`
- [x] `make:registration`
- [x] `make:registration` w/ VerifyEmail
- [x] ~`make:security:form-login`~ - PR #1515 
- [x] `make:crud` - refactor to use `canGenerateTests` trait
- [x] ~`make:controller`~ - Diff PR
- [x] ~ensure we handle https://github.com/SymfonyCasts/verify-email-bundle/issues/149 if able~ - outside the scope of this pr