### PR TITLE
[ci] implement phpstan for static analysis of the codebase

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -13,49 +13,6 @@ env:
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
 
 jobs:
-    coding-standards:
-        name: "Coding Standards (${{ matrix.php-version }})"
-
-        runs-on: ubuntu-latest
-
-        strategy:
-            fail-fast: false
-            matrix:
-                php-version:
-                    - '8.1'
-
-        steps:
-            -
-                name: Checkout code
-                uses: "actions/checkout@v3"
-
-            -
-                name: Install PHP
-                uses: "shivammathur/setup-php@v2"
-                with:
-                    coverage: "none"
-                    php-version: "${{ matrix.php-version }}"
-
-            -
-                name: Validate composer.json
-                run: "composer validate --strict --no-check-lock"
-
-            -
-                name: Composer install
-                uses: "ramsey/composer-install@v2"
-                with:
-                    composer-options: "--no-scripts"
-
-            -
-                name: Composer install php-cs-fixer
-                uses: "ramsey/composer-install@v2"
-                with:
-                    composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
-
-            -
-                name: Run PHP-CS-Fixer
-                run: "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff"
-
     test:
         name: "PHP ${{ matrix.php-version }} + @${{ matrix.symfony-version }} ${{ matrix.dependency-versions }} deps"
 

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -94,4 +94,4 @@ jobs:
               run: vendor/bin/simple-phpunit --version
 
             - name: Run tests
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }} --version

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -94,4 +94,4 @@ jobs:
               run: vendor/bin/simple-phpunit --version
 
             - name: Run tests
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }} --version
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/.github/workflows/ci-static-analysis.yaml
+++ b/.github/workflows/ci-static-analysis.yaml
@@ -1,0 +1,81 @@
+name: "CI Static Analysis"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - 'main'
+#    schedule:
+#        -   cron: '0 0 * * *'
+
+env:
+    PHPUNIT_FLAGS: "-v"
+    SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
+
+jobs:
+    coding-standards:
+        name: "Coding Standards"
+
+        runs-on: ubuntu-latest
+
+        steps:
+            -
+                name: Checkout code
+                uses: "actions/checkout@v3"
+
+            -
+                name: Install PHP
+                uses: "shivammathur/setup-php@v2"
+
+            -
+                name: Validate composer.json
+                run: "composer validate --strict --no-check-lock"
+
+            -
+                name: Composer install
+                uses: "ramsey/composer-install@v2"
+                with:
+                    composer-options: "--no-scripts"
+
+            -
+                name: Composer install php-cs-fixer
+                uses: "ramsey/composer-install@v2"
+                with:
+                    composer-options: "--no-scripts --working-dir=tools/php-cs-fixer"
+
+            -
+                name: Run PHP-CS-Fixer
+                run: "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff"
+
+    phpstan:
+        name: PHPStan
+
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Checkout
+                uses: "actions/checkout@v4"
+
+            -   name: Install PHP
+                uses: "shivammathur/setup-php@v2"
+
+            -   name: Install Composer Dependencies
+                uses: "ramsey/composer-install@v2"
+                with:
+                    composer-options: "--no-scripts"
+
+            -   name: Install PHPStan
+                uses: "ramsey/composer-install@v2"
+                with:
+                    composer-options: "--no-scripts --working-dir=tools/phpstan"
+
+            -   name: Install Optional Dependencies
+                uses: "ramsey/composer-install@v2"
+                with:
+                    composer-options: "--no-scripts --working-dir=tools/phpstan/includes"
+
+            -   name: Install PHPUnit
+                run: "vendor/bin/simple-phpunit --version"
+
+            -   name: Run PHPStan
+                run: "tools/phpstan/vendor/bin/phpstan analyze --memory-limit=1G --error-format=github"

--- a/.github/workflows/ci-static-analysis.yaml
+++ b/.github/workflows/ci-static-analysis.yaml
@@ -5,8 +5,8 @@ on:
     push:
         branches:
             - 'main'
-#    schedule:
-#        -   cron: '0 0 * * *'
+    schedule:
+        -   cron: '0 0 * * *'
 
 env:
     PHPUNIT_FLAGS: "-v"

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -67,4 +67,4 @@ jobs:
               run: vendor/bin/simple-phpunit --version
 
             - name: Run Tests
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }} --version

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -67,4 +67,4 @@ jobs:
               run: vendor/bin/simple-phpunit --version
 
             - name: Run Tests
-              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }} --version
+              run: vendor/bin/simple-phpunit ${{ env.PHPUNIT_FLAGS }}

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,38 @@
+parameters:
+    level: 6
+    bootstrapFiles:
+        - vendor/autoload.php
+        - tools/phpstan/includes/vendor/autoload.php
+    paths:
+        - src/Maker
+        - tests/Command
+        - tests/Docker
+        - tests/Maker
+    excludePaths:
+        - tests/Doctrine/fixtures
+        - tests/fixtures
+        - tests/Security/fixtures
+        - tests/Security/yaml_fixtures
+        - tests/tmp
+        - tests/Util/fixtures
+        - tests/Util/yaml_fixtures
+    ignoreErrors:
+        -
+            message: '#Property .+phpCompatUtil is never read, only written\.#'
+            path: src/Maker/*
+
+        -
+            message: '#Class Symfony\\Bundle\\MakerBundle\\Maker\\LegacyApiTestCase not found#'
+            path: src/Maker/*
+
+#        - tests
+#    symfony:
+#        containerXmlPath: var/cache/test/App_KernelTestDebugContainer.xml
+#    doctrine:
+#        ormRepositoryClass: App\Repository\AbstractRepository
+#        objectManagerLoader: tests/phpstan-bootstrap.php
+#    ignoreErrors:
+#        -
+#            message: '#Variable \$[a-zA-Z0-9]+ might not be defined\.#'
+##            identifier: variable.undefined // Available in phpstan 1.11.0
+#            path: src/GraphQLRequest/*

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -24,15 +24,3 @@ parameters:
         -
             message: '#Class Symfony\\Bundle\\MakerBundle\\Maker\\LegacyApiTestCase not found#'
             path: src/Maker/*
-
-#        - tests
-#    symfony:
-#        containerXmlPath: var/cache/test/App_KernelTestDebugContainer.xml
-#    doctrine:
-#        ormRepositoryClass: App\Repository\AbstractRepository
-#        objectManagerLoader: tests/phpstan-bootstrap.php
-#    ignoreErrors:
-#        -
-#            message: '#Variable \$[a-zA-Z0-9]+ might not be defined\.#'
-##            identifier: variable.undefined // Available in phpstan 1.11.0
-#            path: src/GraphQLRequest/*

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -306,7 +306,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             }
 
             foreach ($fileManagerOperations as $path => $manipulatorOrMessage) {
-                if (\is_string($manipulatorOrMessage)) {
+                if (\is_string($manipulatorOrMessage)) {     /* @phpstan-ignore-line - https://github.com/symfony/maker-bundle/issues/1509 */
                     $io->comment($manipulatorOrMessage);
                 } else {
                     $this->fileManager->dumpFile($path, $manipulatorOrMessage->getSourceCode());

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -220,6 +220,7 @@ final class MakeUser extends AbstractMaker
         } else {
             $nextSteps[] = sprintf(
                 'Open <info>%s</info> to finish implementing your user provider.',
+                /* @phpstan-ignore-next-line - $customProviderPath is defined in this else statement */
                 $this->fileManager->relativizePath($customProviderPath)
             );
         }

--- a/tests/Maker/FunctionalTest.php
+++ b/tests/Maker/FunctionalTest.php
@@ -24,7 +24,7 @@ class FunctionalTest extends TestCase
      * Smoke test to make sure the DI autowiring works and all makers
      * are registered and have the correct arguments.
      */
-    public function testWiring()
+    public function testWiring(): void
     {
         $kernel = new MakerTestKernel('dev', true);
 

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -673,6 +673,7 @@ class MakeEntityTest extends MakerTestCase
         ];
     }
 
+    /** @param array<string, mixed> $data */
     private function runEntityTest(MakerTestRunner $runner, array $data = []): void
     {
         $runner->renderTemplateFile(

--- a/tests/Maker/MakeFormTest.php
+++ b/tests/Maker/MakeFormTest.php
@@ -22,7 +22,7 @@ class MakeFormTest extends MakerTestCase
         return MakeForm::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_generates_basic_form' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
@@ -204,7 +204,7 @@ class MakeFormTest extends MakerTestCase
         ];
     }
 
-    private function runFormTest(MakerTestRunner $runner, string $filename)
+    private function runFormTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-form/tests/'.$filename,

--- a/tests/Maker/MakeMessageTest.php
+++ b/tests/Maker/MakeMessageTest.php
@@ -40,7 +40,7 @@ class MakeMessageTest extends MakerTestCase
             });
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_generates_basic_message' => [$this->createMakeMessageTest()
             ->run(function (MakerTestRunner $runner) {
@@ -94,7 +94,7 @@ class MakeMessageTest extends MakerTestCase
         ];
     }
 
-    private function runMessageTest(MakerTestRunner $runner, string $filename)
+    private function runMessageTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-message/tests/'.$filename,
@@ -104,7 +104,7 @@ class MakeMessageTest extends MakerTestCase
         $runner->runTests();
     }
 
-    private function configureTransports(MakerTestRunner $runner)
+    private function configureTransports(MakerTestRunner $runner): void
     {
         $runner->writeFile(
             'config/packages/messenger.yaml',

--- a/tests/Maker/MakeMessengerMiddlewareTest.php
+++ b/tests/Maker/MakeMessengerMiddlewareTest.php
@@ -22,7 +22,7 @@ class MakeMessengerMiddlewareTest extends MakerTestCase
         return MakeMessengerMiddleware::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_generates_messenger_middleware' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {

--- a/tests/Maker/MakeSerializerEncoderTest.php
+++ b/tests/Maker/MakeSerializerEncoderTest.php
@@ -22,7 +22,7 @@ class MakeSerializerEncoderTest extends MakerTestCase
         return MakeSerializerEncoder::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_makes_serializer_encoder' => [$this->createMakerTest()
             // serializer-pack 1.1 requires symfony/property-info >= 5.4

--- a/tests/Maker/MakeTwigExtensionTest.php
+++ b/tests/Maker/MakeTwigExtensionTest.php
@@ -22,7 +22,7 @@ class MakeTwigExtensionTest extends MakerTestCase
         return MakeTwigExtension::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_makes_twig_extension' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {

--- a/tests/Maker/MakeUnitTestTest.php
+++ b/tests/Maker/MakeUnitTestTest.php
@@ -25,7 +25,7 @@ class MakeUnitTestTest extends MakerTestCase
         return MakeUnitTest::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_makes_unit_test' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {

--- a/tests/Maker/MakeValidatorTest.php
+++ b/tests/Maker/MakeValidatorTest.php
@@ -22,7 +22,7 @@ class MakeValidatorTest extends MakerTestCase
         return MakeValidator::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_makes_validator' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {

--- a/tests/Maker/MakeVoterTest.php
+++ b/tests/Maker/MakeVoterTest.php
@@ -22,7 +22,7 @@ class MakeVoterTest extends MakerTestCase
         return MakeVoter::class;
     }
 
-    public function getTestDetails()
+    public function getTestDetails(): \Generator
     {
         yield 'it_makes_voter' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,14 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1.10",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan-symfony": "^1.3",
+        "phpstan/phpstan-doctrine": "^1.3",
+        "phpstan/phpstan-phpunit": "^1.3"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
+    }
+}

--- a/tools/phpstan/includes/.gitignore
+++ b/tools/phpstan/includes/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!composer.json

--- a/tools/phpstan/includes/composer.json
+++ b/tools/phpstan/includes/composer.json
@@ -1,0 +1,22 @@
+{
+    "require": {
+        "api-platform/core": "^3.2",
+        "doctrine/doctrine-bundle": "^2.12",
+        "doctrine/doctrine-fixtures-bundle": "^3.5",
+        "symfony/form": "^7.0",
+        "symfony/mailer": "^7.0",
+        "symfony/messenger": "^7.0",
+        "symfony/orm-pack": "^2.4",
+        "symfony/scheduler": "^7.0",
+        "symfony/security-bundle": "^7.0",
+        "symfony/test-pack": "^1.1",
+        "symfony/twig-bundle": "^7.0",
+        "symfony/ux-live-component": "^2.16",
+        "symfony/ux-turbo": "^2.16",
+        "symfony/validator": "^7.0",
+        "symfonycasts/reset-password-bundle": "^1.21",
+        "symfonycasts/verify-email-bundle": "^1.17",
+        "symfony/webpack-encore-bundle": "^2.1",
+        "symfony/panther": "^2.1"
+    }
+}


### PR DESCRIPTION
- uses PHPStan to help catch bugs

We'll start with the scope below and slowly open it up as the code base is updated to the desired PHPStan level. 

### Scope
- `src/Maker`
- `tests/Command`
- `tests/Docker`
- `tests/Maker`

--- 
## Optional Maker Dependencies - `tools/phpstan/includes`

In our root `composer.json`, we don't `require --dev` packages that are not specifically needed for MakerBundle to function. e.g. `api-platform`. But we _do_ still need those packages for phpstan. for now, the `composer.json` in the `includes` dir will satisfy that need and gives MakerBundle dev's the added benefit of code completion in the IDE.

We currently do not require those "maker specific" packages in our root `composer.json` because it would have adverse side effects in some of our tests. I _think_ in MakerBundle 2.x and/or #1466 - we'll change how we manage dependencies. 
