### PR TITLE
[make:*] add docBlock return types for non-internal makers

### DIFF
--- a/src/Maker/MakeFixtures.php
+++ b/src/Maker/MakeFixtures.php
@@ -39,6 +39,7 @@ final class MakeFixtures extends AbstractMaker
         return 'Create a new class to load Doctrine fixtures';
     }
 
+    /** @return void */
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
@@ -47,6 +48,7 @@ final class MakeFixtures extends AbstractMaker
         ;
     }
 
+    /** @return void */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         $fixturesClassNameDetails = $generator->createClassNameDetails(
@@ -78,6 +80,7 @@ final class MakeFixtures extends AbstractMaker
         ]);
     }
 
+    /** @return void */
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -77,6 +77,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         ;
     }
 
+    /** @return void */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         $options = ['doctrine:migrations:diff'];
@@ -145,7 +146,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         ]);
     }
 
-    private function noChangesMessage(ConsoleStyle $io)
+    private function noChangesMessage(ConsoleStyle $io): void
     {
         $io->warning([
             'No database changes were detected.',
@@ -156,6 +157,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         ]);
     }
 
+    /** @return void */
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -37,6 +37,7 @@ final class MakeValidator extends AbstractMaker
         return 'Create a new validator and constraint class';
     }
 
+    /** @return void */
     public function configureCommand(Command $command, InputConfiguration $inputConf)
     {
         $command
@@ -45,6 +46,7 @@ final class MakeValidator extends AbstractMaker
         ;
     }
 
+    /** @return void */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         $validatorClassNameDetails = $generator->createClassNameDetails(
@@ -79,6 +81,7 @@ final class MakeValidator extends AbstractMaker
         ]);
     }
 
+    /** @return void */
     public function configureDependencies(DependencyBuilder $dependencies)
     {
         $dependencies->addClassDependency(


### PR DESCRIPTION
- `make:fixtures`
- `make:migration`
- `make:validator`

add `@return` to public method docblocks that do not have return types. The @return type declaration will be converted to an actual method return type in v2.

refs #1498
