### PR TITLE
[make:*] additional type improvements

### DIFF
--- a/src/Maker/AbstractMaker.php
+++ b/src/Maker/AbstractMaker.php
@@ -41,6 +41,7 @@ abstract class AbstractMaker implements MakerInterface
         $io->newLine();
     }
 
+    /** @param array<class-string, string> $dependencies */
     protected function addDependencies(array $dependencies, ?string $message = null): string
     {
         $dependencyBuilder = new DependencyBuilder();

--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -138,6 +138,7 @@ final class MakeListener extends AbstractMaker
         }
     }
 
+    /** @return void */
     public function configureDependencies(DependencyBuilder $dependencies)
     {
     }

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -51,6 +51,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         return 'Create a new migration based on database changes';
     }
 
+    /** @return void */
     public function setApplication(Application $application)
     {
         $this->application = $application;

--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -78,7 +78,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
         ;
     }
 
-    /** @return void */
+    /** @return void|int */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
         $options = ['doctrine:migrations:diff'];

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -182,6 +182,7 @@ final class MakeRegistrationForm extends AbstractMaker
         }
     }
 
+    /** @param array<string, mixed> $securityData */
     private function interactAuthenticatorQuestions(ConsoleStyle $io, InteractiveSecurityHelper $interactiveSecurityHelper, array $securityData): void
     {
         // get list of authenticators

--- a/src/Maker/MakeTest.php
+++ b/src/Maker/MakeTest.php
@@ -56,6 +56,8 @@ final class MakeTest extends AbstractMaker implements InputAwareMakerInterface
 
     /**
      * @deprecated remove this method when removing make:unit-test and make:functional-test
+     *
+     * @return string[]
      */
     public static function getCommandAliases(): iterable
     {


### PR DESCRIPTION
Adds DocBlock type hints to:

_`final` non-`@internal` classes shown below_

### AbstractMaker
```diff
+    /** @param array<class-string, string> $dependencies */
     protected function addDependencies(array $dependencies, ?string $message = null): string
```
### MakeListener
```diff
+   /** @return void */
    public function configureDependencies(DependencyBuilder $dependencies)
```

### MakeMigration
```diff
+    /** @return void */
     public function setApplication(Application $application)

    ...

+    /** @return void|int */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
```

### MakeTest
```diff
+    * @return string[]
     */
     public static function getCommandAliases(): iterable
```

refs #1498