### PR TITLE
replace deprecated method call

### DIFF
--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -41,7 +41,7 @@ class <?= $class_name; ?><?= "\n" ?>
      */
     public function handleEmailConfirmation(Request $request, UserInterface $user): void
     {
-        $this->verifyEmailHelper->validateEmailConfirmation($request->getUri(), $user-><?= $id_getter ?>(), $user-><?= $email_getter?>());
+        $this->verifyEmailHelper->validateEmailConfirmationFromRequest($request, $user-><?= $id_getter ?>(), $user-><?= $email_getter?>());
 
         $user->setIsVerified(true);
 


### PR DESCRIPTION
Version 2 of the helper uses validateEmailConfirmationFromRequest, this PR makes the correct call to avoid the deprecation warning.