### PR TITLE
[make:entity] helper message with two classes having the same name under different namespaces

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -779,6 +779,12 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         $originalEntityShort = Str::getShortClassName($entityClass);
         $targetEntityShort = Str::getShortClassName($targetEntityClass);
+        if ($originalEntityShort === $targetEntityShort) {
+            [$originalDiscriminator, $targetDiscriminator] = Str::getHumanDiscriminatorBetweenTwoClasses($entityClass, $targetEntityClass);
+            $originalEntityShort = trim($originalDiscriminator.'\\'.$originalEntityShort, '\\');
+            $targetEntityShort = trim($targetDiscriminator.'\\'.$targetEntityShort, '\\');
+        }
+
         $rows = [];
         $rows[] = [
             EntityRelation::MANY_TO_ONE,

--- a/src/Str.php
+++ b/src/Str.php
@@ -129,6 +129,38 @@ final class Str
         return substr($fullClassName, strrpos($fullClassName, '\\') + 1);
     }
 
+    /**
+     * @return array{0: string, 1: string}
+     */
+    public static function getHumanDiscriminatorBetweenTwoClasses(string $className, string $classNameOther): array
+    {
+        $namespace = self::getNamespace($className);
+        $namespaceOther = self::getNamespace($classNameOther);
+        if (empty($namespace) || empty($namespaceOther)) {
+            return [$namespace, $namespaceOther];
+        }
+
+        $namespaceParts = explode('\\', $namespace);
+        $namespacePartsOther = explode('\\', $namespaceOther);
+
+        $min = min(\count($namespaceParts), \count($namespacePartsOther));
+        for ($i = 0; $i < $min; ++$i) {
+            $part = $namespaceParts[$i];
+            $partOther = $namespacePartsOther[$i];
+            if ($part !== $partOther) {
+                break;
+            }
+
+            $namespaceParts[$i] = null;
+            $namespacePartsOther[$i] = null;
+        }
+
+        return [
+            implode('\\', array_filter($namespaceParts)),
+            implode('\\', array_filter($namespacePartsOther)),
+        ];
+    }
+
     public static function getNamespace(string $fullClassName): string
     {
         return substr($fullClassName, 0, strrpos($fullClassName, '\\'));

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -376,6 +376,45 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_adds_many_to_many_between_same_entity_name_different_namespace' => [$this->createMakeEntityTest()
+            ->run(function (MakerTestRunner $runner) {
+                $this->copyEntity($runner, 'User-basic.php');
+                $this->copyEntity($runner, 'Friend/User-sub-namespace.php');
+
+                $output = $runner->runMaker([
+                    // entity class name
+                    'User',
+                    // field name
+                    'friends',
+                    // add a relationship field
+                    'relation',
+                    // the target entity
+                    'Friend\\User',
+                    // relation type
+                    'ManyToMany',
+                    // inverse side?
+                    'y',
+                    // field name on opposite side - use default 'courses'
+                    '',
+                    // finish adding fields
+                    '',
+                ]);
+
+                $this->assertStringContainsString('src/Entity/User.php', $output);
+                $this->assertStringContainsString('src/Entity/Friend/User.php', $output);
+                $this->assertStringContainsString('ManyToOne    Each User relates to (has) one Friend\User.', $output);
+                $this->assertStringContainsString('Each Friend\User can relate to (can have) many User objects.', $output);
+                $this->assertStringContainsString('OneToMany    Each User can relate to (can have) many Friend\User objects.', $output);
+                $this->assertStringContainsString('Each Friend\User relates to (has) one User.', $output);
+                $this->assertStringContainsString('ManyToMany   Each User can relate to (can have) many Friend\User objects.', $output);
+                $this->assertStringContainsString('Each Friend\User can also relate to (can also have) many User objects.', $output);
+                $this->assertStringContainsString('OneToOne     Each User relates to (has) exactly one Friend\User.', $output);
+                $this->assertStringContainsString('Each Friend\User also relates to (has) exactly one User.', $output);
+
+                // $this->runCustomTest($runner, 'it_adds_many_to_many_between_same_entity_name_different_namespace.php');
+            }),
+        ];
+
         yield 'it_adds_one_to_one_simple' => [$this->createMakeEntityTest()
             ->run(function (MakerTestRunner $runner) {
                 $this->copyEntity($runner, 'User-basic.php');

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -186,6 +186,24 @@ class StrTest extends TestCase
     }
 
     /**
+     * @dataProvider getHumanDiscriminatorBetweenTwoClassesTests
+     */
+    public function testHumanDiscriminatorBetweenTwoClasses(string $className, string $classNameOther, array $expected)
+    {
+        $this->assertSame($expected, Str::getHumanDiscriminatorBetweenTwoClasses($className, $classNameOther));
+    }
+
+    public function getHumanDiscriminatorBetweenTwoClassesTests()
+    {
+        yield ['\\User', 'App\\Entity\\User', ['', 'App\\Entity']];
+        yield ['App\\Entity\\User', 'App\\Entity\\Friend\\User', ['', 'Friend']];
+        yield ['App\\Entity\\User', 'Custom\\Entity\\User', ['App\\Entity', 'Custom\\Entity']];
+        yield ['App\\Entity\\User', 'App\\Bundle\\Entity\\User', ['Entity', 'Bundle\\Entity']];
+        yield ['App\\Entity\\User', 'App\\Bundle\\User', ['Entity', 'Bundle']];
+        yield ['App\\Entity\\User', 'Custom\\Bundle\\Friend\\Entity\\User', ['App\\Entity', 'Custom\\Bundle\\Friend\\Entity']];
+    }
+
+    /**
      * @dataProvider asHumanWordsTests
      */
     public function testAsHumanWords(string $original, string $expected)

--- a/tests/fixtures/make-entity/entities/attributes/Friend/User-sub-namespace.php
+++ b/tests/fixtures/make-entity/entities/attributes/Friend/User-sub-namespace.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Entity\Friend;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $firstName = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTimeInterface $createdAt = null;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName)
+    {
+        $this->firstName = $firstName;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeInterface $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+}


### PR DESCRIPTION
As discussed in #1292 this is how I see the feature, let me know what you think about it.

New output when using classes with same name:
```
$ bin/console m:entity Order
 Your entity already exists! So let's add some new fields!

 New property name (press <return> to stop adding fields):
 > orderLogistic

 Field type (enter ? to see all types) [string]:
 > relation

 What class should this entity be related to?:
 > Logistic\Order

What type of relationship is this?
 ------------ ----------------------------------------------------------------------------
  Type         Description
 ------------ ----------------------------------------------------------------------------
  ManyToOne    Each Order relates to (has) one Logistic\Order.
               Each Logistic\Order can relate to (can have) many Order objects.

  OneToMany    Each Order can relate to (can have) many Logistic\Order objects.
               Each Logistic\Order relates to (has) one Order.

  ManyToMany   Each Order can relate to (can have) many Logistic\Order objects.
               Each Logistic\Order can also relate to (can also have) many Order objects.

  OneToOne     Each Order relates to (has) exactly one Logistic\Order.
               Each Logistic\Order also relates to (has) exactly one Order.
 ------------ ----------------------------------------------------------------------------

 Relation type? [ManyToOne, OneToMany, ManyToMany, OneToOne]:
 >
```

fixes #1292 