### PR TITLE
[make:webhook] Rephrase comments to be more explicit + minor improvement of generated code

### DIFF
--- a/src/Resources/skeleton/webhook/RequestParser.tpl.php
+++ b/src/Resources/skeleton/webhook/RequestParser.tpl.php
@@ -26,11 +26,11 @@ final class <?= $class_name ?> extends AbstractRequestParser
      */
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent
     {
-        // Implement your own logic to validate and parse the request, and return a RemoteEvent object.
+        // TODO: Adapt or replace the content of this method to fit your need.
 
         // Validate the request against $secret.
         $authToken = $request->headers->get('X-Authentication-Token');
-        if (is_null($authToken) || $authToken !== $secret) {
+        if ($authToken !== $secret) {
             throw new RejectWebhookException(Response::HTTP_UNAUTHORIZED, 'Invalid authentication token.');
         }
 

--- a/tests/fixtures/make-webhook/RemoteServiceRequestParser.php
+++ b/tests/fixtures/make-webhook/RemoteServiceRequestParser.php
@@ -25,12 +25,11 @@ final class RemoteServiceRequestParser extends AbstractRequestParser
      */
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent
     {
-        // Implement your own logic to validate and parse the request, and return a RemoteEvent object.
+        // TODO: Adapt or replace the content of this method to fit your need.
 
         // Validate the request against $secret.
         $authToken = $request->headers->get('X-Authentication-Token');
-
-        if (null === $authToken || $authToken !== $secret) {
+        if ($authToken !== $secret) {
             throw new RejectWebhookException(Response::HTTP_UNAUTHORIZED, 'Invalid authentication token.');
         }
 
@@ -41,7 +40,7 @@ final class RemoteServiceRequestParser extends AbstractRequestParser
         }
 
         // Parse the request payload and return a RemoteEvent object.
-        $payload = $request->getPayload()->getIterator()->getArrayCopy();
+        $payload = $request->getPayload()->all();
 
         return new RemoteEvent(
             $payload['name'],


### PR DESCRIPTION
Previously, the generated code of `FooRequestParser::doParse` started with `// Implement your own logic to validate and parse the request, and return a RemoteEvent object.`, followed by an empty line, then some code. I think it may be confusing for the developers, some may think the custom logic should live right bellow the comment and that the following code should not be messed with.  
I think that changing this to `// TODO: Adapt or replace the content of this method to fit your need.` might help clear things up.

Additionally I removed an unnecessary check for null  in the generated code + fixed the payload conversion method in the fixture.