### PR TITLE
[common] add missing class header

### DIFF
--- a/src/Maker/Common/InstallDependencyTrait.php
+++ b/src/Maker/Common/InstallDependencyTrait.php
@@ -14,6 +14,11 @@ namespace Symfony\Bundle\MakerBundle\Maker\Common;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Component\Process\Process;
 
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
 trait InstallDependencyTrait
 {
     /**


### PR DESCRIPTION
This header was omitted on accident and the trait was meant to be internal.

https://github.com/symfony/maker-bundle/pull/1491/commits/64622cfcfdc6960549d0ce061540d4a2c6269417