### PR TITLE
[make:registration] add `bool` type to User::isVerified

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -392,7 +392,8 @@ final class MakeRegistrationForm extends AbstractMaker
             $userManipulator->addProperty(
                 name: 'isVerified',
                 defaultValue: false,
-                attributes: [$userManipulator->buildAttributeNode(Column::class, ['type' => 'boolean'], 'ORM')]
+                attributes: [$userManipulator->buildAttributeNode(attributeClass: Column::class, options: [], attributePrefix: 'ORM')],
+                propertyType: 'bool'
             );
             $userManipulator->addAccessorMethod('isVerified', 'isVerified', 'bool', false);
             $userManipulator->addSetter('isVerified', 'bool', false);

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -192,6 +192,10 @@ class MakeRegistrationFormTest extends MakerTestCase
                     $this->assertFileExists($runner->getPath($file));
                 }
 
+                $userContents = file_get_contents($runner->getPath('src/Entity/User.php'));
+
+                $this->assertStringContainsString('private bool $isVerified = false', $userContents);
+
                 $this->runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
             }),
         ];


### PR DESCRIPTION
When creating a registration form and using `verify-email-bundle`, we now add the `bool` property type to `User::isVerified`.

The column `type` definition is dropped - it can be inferred from the property type by doctrine.