### PR TITLE
[make:registration] use "User" type in `EmailVerifier::class`

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -253,6 +253,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 UserInterface::class,
                 VerifyEmailExceptionInterface::class,
                 VerifyEmailHelperInterface::class,
+                $userClassNameDetails->getFullName(),
             ]);
 
             $generator->generateClass(
@@ -263,6 +264,7 @@ final class MakeRegistrationForm extends AbstractMaker
                     'id_getter' => $this->idGetter,
                     'email_getter' => $this->emailGetter,
                     'verify_email_anonymously' => $this->verifyEmailAnonymously,
+                    'user_class_name' => $userClassNameDetails->getShortName(),
                 ],
                     $userRepoVars
                 )

--- a/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
+++ b/src/Resources/skeleton/verifyEmail/EmailVerifier.tpl.php
@@ -13,14 +13,14 @@ class <?= $class_name; ?><?= "\n" ?>
     ) {
     }
 
-    public function sendEmailConfirmation(string $verifyEmailRouteName, UserInterface $user, TemplatedEmail $email): void
+    public function sendEmailConfirmation(string $verifyEmailRouteName, <?= $user_class_name ?> $user, TemplatedEmail $email): void
     {
         $signatureComponents = $this->verifyEmailHelper->generateSignature(
             $verifyEmailRouteName,
-            $user-><?= $id_getter ?>(),
+            (string) $user-><?= $id_getter ?>(),
 <?php if ($verify_email_anonymously): ?>
             $user-><?= $email_getter ?>(),
-            ['id' => $user->getId()]
+            ['id' => $user-><?= $id_getter ?>()]
 <?php else: ?>
             $user-><?= $email_getter ?>()
 <?php endif; ?>
@@ -39,9 +39,9 @@ class <?= $class_name; ?><?= "\n" ?>
     /**
      * @throws VerifyEmailExceptionInterface
      */
-    public function handleEmailConfirmation(Request $request, UserInterface $user): void
+    public function handleEmailConfirmation(Request $request, <?= $user_class_name ?> $user): void
     {
-        $this->verifyEmailHelper->validateEmailConfirmationFromRequest($request, $user-><?= $id_getter ?>(), $user-><?= $email_getter?>());
+        $this->verifyEmailHelper->validateEmailConfirmationFromRequest($request, (string) $user-><?= $id_getter ?>(), $user-><?= $email_getter?>());
 
         $user->setVerified(true);
 


### PR DESCRIPTION
`sendEmailConfirmation()` && `handleEmailConfirmation()` both have the `$user` type as `UserInterface`. This is pointless other than to ensure we get a "user" object. Seeing as we already know the class details of the "user" object, let's use the class short name instead of `UserInterface` when generating `EmailVerifier`. Improves phpstan in userland.

```diff
// in part

- public function sendEmailConfirmation(UserInterface $user)
+ public function sendEmailConfirmation(<?= $user_class_name ?> $userl)  // generated as "User"
```

- adds `(string)` cast to `getId()` calls on the user object. In cases where the users id is an `int`, this will squash any squawks from phpstan about 

```
Parameter #2 $userId of method SymfonyCasts\Bundle\VerifyEmail\VerifyEmailHelperInterface::generateSignature() expects string, int|null given. 
```

## Edge Case
If the consumer has multiple "user" objects that use these methods (out of scope for MakerBundle), they can change the type manually to either `User|AnotherUser $user` || `CustomUserInterface $user`.