### PR TITLE
[make:entity] Simplify repository PHPDoc removes method annotations

### DIFF
--- a/src/Resources/skeleton/doctrine/Repository.tpl.php
+++ b/src/Resources/skeleton/doctrine/Repository.tpl.php
@@ -6,11 +6,6 @@ namespace <?= $namespace; ?>;
 
 /**
  * @extends ServiceEntityRepository<<?= $entity_class_name; ?>>
- *
- * @method <?= $entity_class_name; ?>|null find($id, $lockMode = null, $lockVersion = null)
- * @method <?= $entity_class_name; ?>|null findOneBy(array $criteria, array $orderBy = null)
- * @method <?= $entity_class_name; ?>[]    findAll()
- * @method <?= $entity_class_name; ?>[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class <?= $class_name; ?> extends ServiceEntityRepository<?= $with_password_upgrade ? " implements PasswordUpgraderInterface\n" : "\n" ?>
 {

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/UserRepository.php
@@ -8,11 +8,6 @@ use Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity\UserXml;
 
 /**
  * @extends ServiceEntityRepository<UserXml>
- *
- * @method UserXml|null find($id, $lockMode = null, $lockVersion = null)
- * @method UserXml|null findOneBy(array $criteria, array $orderBy = null)
- * @method UserXml[]    findAll()
- * @method UserXml[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class UserRepository extends ServiceEntityRepository
 {

--- a/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
+++ b/tests/Doctrine/fixtures/expected_xml/src/Repository/XOtherRepository.php
@@ -8,11 +8,6 @@ use Symfony\Bundle\MakerBundle\Tests\tmp\current_project_xml\src\Entity\XOther;
 
 /**
  * @extends ServiceEntityRepository<XOther>
- *
- * @method XOther|null find($id, $lockMode = null, $lockVersion = null)
- * @method XOther|null findOneBy(array $criteria, array $orderBy = null)
- * @method XOther[]    findAll()
- * @method XOther[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class XOtherRepository extends ServiceEntityRepository
 {

--- a/tests/fixtures/make-crud/SweetFoodRepository.php
+++ b/tests/fixtures/make-crud/SweetFoodRepository.php
@@ -8,11 +8,6 @@ use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @extends ServiceEntityRepository<SweetFood>
- *
- * @method SweetFood|null find($id, $lockMode = null, $lockVersion = null)
- * @method SweetFood|null findOneBy(array $criteria, array $orderBy = null)
- * @method SweetFood[]    findAll()
- * @method SweetFood[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  */
 class SweetFoodRepository extends ServiceEntityRepository
 {


### PR DESCRIPTION
I removed theses from project project, and my IDE (vscode) and PHPStan are okay with that.
It works, because doctrine has already templated the methods
