### PR TITLE
[make:reset-password] improve types for static analysis in userland

### DIFF
--- a/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
+++ b/src/Resources/skeleton/resetPassword/ResetPasswordController.tpl.php
@@ -74,6 +74,7 @@ class <?= $class_name ?> extends AbstractController
         }
 
         try {
+            /** @var <?= $user_class_name ?> $user */
             $user = $this->resetPasswordHelper->validateTokenAndFetchUser($token);
         } catch (ResetPasswordExceptionInterface $e) {
             $this->addFlash('reset_password_error', sprintf(


### PR DESCRIPTION
- use the "User" entity type where possible. Actual type name is derived from the `ClassNameDetails` object
- annotate the "User" type where an interface signature would conflict with using the actual "User" type declaration.