### PR TITLE
[make:auth] deprecate command

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -54,7 +54,11 @@ use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
 use Symfony\Component\Yaml\Yaml;
 
+trigger_deprecation('symfony/maker-bundle', 'v1.59.0', 'The "%s" class is deprecated, use any of the Security\Make* commands instead.', MakeAuthenticator::class);
+
 /**
+ * @deprecated since MakerBundle v1.59.0, use any of the Security/Make* instead.
+ *
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  * @author Jesse Rushlow <jr@rushlow.dev>
  *
@@ -95,6 +99,8 @@ final class MakeAuthenticator extends AbstractMaker
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
+        $io->caution('"make:auth" is deprecated, use any of the "make:security" commands instead.');
+
         if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
             throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. PHP & XML configuration formats are currently not supported.');
         }

--- a/tests/Maker/MakeAuthenticatorTest.php
+++ b/tests/Maker/MakeAuthenticatorTest.php
@@ -16,6 +16,9 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
+/**
+ * @group legacy
+ */
 class MakeAuthenticatorTest extends MakerTestCase
 {
     protected function getMakerClass(): string


### PR DESCRIPTION
The `make:auth` command has been superseded by `make:security:form-login` (#1244) and `make:security:custom` (#1522).

Originally written to create login form authentication back in the days of "Guard Authenticators" - this command has reached it's EOL with the existence of the new Symfony Security System that was introduced in Symfony 5.x.

Although the command class itself is `@internal` - we'll:
- deprecate the command in `v1.59.0` maintaining its existing functionality
- remove the existing functionality _after_ the `v1.59.0` release
- remove the command completely sometime after that. 

I think this will give plenty of time to get the docs & book updated and "gently" push users to `make:security:*`

- [x] Symfony Book 6.4 - Published

cc @fabpot - Symfony Book