### PR TITLE
[make:security] Add throttling support to authenticator maker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "doctrine/orm": "^2.15|^3",
         "symfony/http-client": "^6.4|^7.0",
         "symfony/phpunit-bridge": "^6.4.1|^7.0",
+        "symfony/rate-limiter": "^6.4|^7.0",
         "symfony/security-core": "^6.4|^7.0",
         "symfony/yaml": "^6.4|^7.0",
         "twig/twig": "^3.0|^4.x-dev"

--- a/src/Security/SecurityConfigUpdater.php
+++ b/src/Security/SecurityConfigUpdater.php
@@ -69,7 +69,7 @@ final class SecurityConfigUpdater
         return $contents;
     }
 
-    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe): string
+    public function updateForAuthenticator(string $yamlSource, string $firewallName, $chosenEntryPoint, string $authenticatorClass, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe, bool $supportThrottling): string
     {
         $this->createYamlSourceManipulator($yamlSource);
 
@@ -143,6 +143,10 @@ final class SecurityConfigUpdater
             } else {
                 $firewall['remember_me'][] = $this->manipulator->createCommentLine('always_remember_me: true');
             }
+        }
+
+        if ($supportThrottling) {
+            $firewall['throttling'] = null;
         }
 
         $newData['security']['firewalls'][$firewallName] = $firewall;

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -104,13 +104,13 @@ class SecurityConfigUpdaterTest extends TestCase
     /**
      * @dataProvider getAuthenticatorTests
      */
-    public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe): void
+    public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe, bool $supportThrottling): void
     {
         $this->createLogger();
 
         $updater = new SecurityConfigUpdater($this->ysmLogger);
         $source = file_get_contents(__DIR__.'/yaml_fixtures/source/'.$startingSourceFilename);
-        $actualSource = $updater->updateForAuthenticator($source, $firewallName, $entryPoint, 'App\\Security\\AppCustomAuthenticator', $logoutSetup, $supportRememberMe, $alwaysRememberMe);
+        $actualSource = $updater->updateForAuthenticator($source, $firewallName, $entryPoint, 'App\\Security\\AppCustomAuthenticator', $logoutSetup, $supportRememberMe, $alwaysRememberMe, $supportThrottling);
         $expectedSource = file_get_contents(__DIR__.'/yaml_fixtures/expected_authenticator/'.$expectedSourceFilename);
 
         $this->assertSame($expectedSource, $actualSource);
@@ -126,6 +126,7 @@ class SecurityConfigUpdaterTest extends TestCase
             false,
             false,
             false,
+            false,
         ];
 
         yield 'simple_security' => [
@@ -133,6 +134,7 @@ class SecurityConfigUpdaterTest extends TestCase
             null,
             'simple_security_source.yaml',
             'simple_security.yaml',
+            false,
             false,
             false,
             false,
@@ -146,6 +148,7 @@ class SecurityConfigUpdaterTest extends TestCase
             false,
             false,
             false,
+            false,
         ];
 
         yield 'simple_security_with_firewalls_and_authenticator' => [
@@ -153,6 +156,7 @@ class SecurityConfigUpdaterTest extends TestCase
             'App\\Security\\AppCustomAuthenticator',
             'simple_security_with_firewalls_and_authenticator.yaml',
             'simple_security_with_firewalls_and_authenticator.yaml',
+            false,
             false,
             false,
             false,
@@ -166,6 +170,7 @@ class SecurityConfigUpdaterTest extends TestCase
             true,
             false,
             false,
+            false,
         ];
 
         yield 'security_52_with_multiple_authenticators' => [
@@ -173,6 +178,7 @@ class SecurityConfigUpdaterTest extends TestCase
             'App\\Security\\AppCustomAuthenticator',
             'multiple_authenticators.yaml',
             'multiple_authenticators.yaml',
+            false,
             false,
             false,
             false,
@@ -186,6 +192,7 @@ class SecurityConfigUpdaterTest extends TestCase
             false,
             true,
             false,
+            false,
         ];
 
         yield 'simple_security_with_firewalls_and_always_remember_me' => [
@@ -194,6 +201,18 @@ class SecurityConfigUpdaterTest extends TestCase
             'simple_security_with_firewalls_and_always_remember_me.yaml',
             'simple_security.yaml',
             false,
+            true,
+            true,
+            false,
+        ];
+
+        yield 'simple_security_with_firewalls_always_remember_me_and_throttling' => [
+            'main',
+            null,
+            'simple_security_with_firewalls_always_remember_me_and_throttling.yaml',
+            'simple_security.yaml',
+            false,
+            true,
             true,
             true,
         ];

--- a/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_always_remember_me_and_throttling.yaml
+++ b/tests/Security/yaml_fixtures/expected_authenticator/simple_security_with_firewalls_always_remember_me_and_throttling.yaml
@@ -1,0 +1,19 @@
+security:
+    enable_authenticator_manager: true
+
+    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
+    providers:
+        in_memory: { memory: ~ }
+
+    firewalls:
+        dev: ~
+        main:
+            lazy: true
+            custom_authenticator: App\Security\AppCustomAuthenticator
+
+            remember_me:
+                secret: '%kernel.secret%'
+                lifetime: 604800
+                path: /
+                always_remember_me: true
+            throttling: null


### PR DESCRIPTION
Reopening #1406
In the MakeAuthenticator class, a new optional argument 'support-throttling' was added. This allows the user to specify if they want to enable throttling protection during the authentication generation process. If 'support-throttling' is enabled, the LimiterInterface dependency is added and the 'throttling' node is set in the firewall configuration.