### PR TITLE
[make:serializer:encoder] fix interface signature mismatch in template

### DIFF
--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Serializer;
@@ -61,12 +62,14 @@ final class MakeSerializerEncoder extends AbstractMaker
             EncoderInterface::class,
         ]);
 
+        /* @legacy - Remove "decoder_return_type" when Symfony 6.4 is no longer supported */
         $generator->generateClass(
             $encoderClassNameDetails->getFullName(),
             'serializer/Encoder.tpl.php',
             [
                 'use_statements' => $useStatements,
                 'format' => $format,
+                'use_decoder_return_type' => Kernel::VERSION_ID >= 70000,
             ]
         );
 

--- a/src/Resources/skeleton/serializer/Encoder.tpl.php
+++ b/src/Resources/skeleton/serializer/Encoder.tpl.php
@@ -8,24 +8,24 @@ class <?= $class_name ?> implements EncoderInterface, DecoderInterface
 {
     public const FORMAT = '<?= $format ?>';
 
-    public function encode($data, string $format, array $context = []): string
+    public function encode(mixed $data, string $format, array $context = []): string
     {
         // TODO: return your encoded data
         return '';
     }
 
-    public function supportsEncoding(string $format, array $context = []): bool
+    public function supportsEncoding(string $format): bool
     {
         return self::FORMAT === $format;
     }
 
-    public function decode(string $data, string $format, array $context = [])
+    public function decode(string $data, string $format, array $context = [])<?php if ($use_decoder_return_type): ?>: mixed<?php endif; ?>
     {
         // TODO: return your decoded data
         return '';
     }
 
-    public function supportsDecoding(string $format, array $context = []): bool
+    public function supportsDecoding(string $format): bool
     {
         return self::FORMAT === $format;
     }

--- a/tests/Maker/MakeSerializerEncoderTest.php
+++ b/tests/Maker/MakeSerializerEncoderTest.php
@@ -25,11 +25,6 @@ class MakeSerializerEncoderTest extends MakerTestCase
     public function getTestDetails(): \Generator
     {
         yield 'it_makes_serializer_encoder' => [$this->createMakerTest()
-            // serializer-pack 1.1 requires symfony/property-info >= 5.4
-            // adding symfony/serializer-pack:* as an extra depends allows
-            // us to use serializer-pack < 1.1 which does not conflict with
-            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
-            ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
                 if (70000 >= $runner->getSymfonyVersion()) {
                     $this->markTestSkipped('Legacy Symfony 6.4 Test');
@@ -52,11 +47,6 @@ class MakeSerializerEncoderTest extends MakerTestCase
 
         /* @legacy - Remove when MakerBundle no longer supports Symfony 6.4 */
         yield 'it_makes_serializer_encoder_legacy' => [$this->createMakerTest()
-            // serializer-pack 1.1 requires symfony/property-info >= 5.4
-            // adding symfony/serializer-pack:* as an extra depends allows
-            // us to use serializer-pack < 1.1 which does not conflict with
-            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
-            ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
                 if (70000 < $runner->getSymfonyVersion()) {
                     $this->markTestSkipped('Legacy Symfony 6.4 Test');

--- a/tests/Maker/MakeSerializerEncoderTest.php
+++ b/tests/Maker/MakeSerializerEncoderTest.php
@@ -31,6 +31,9 @@ class MakeSerializerEncoderTest extends MakerTestCase
             // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
             ->addExtraDependencies('symfony/serializer-pack:*')
             ->run(function (MakerTestRunner $runner) {
+                if (70000 >= $runner->getSymfonyVersion()) {
+                    $this->markTestSkipped('Legacy Symfony 6.4 Test');
+                }
                 $runner->runMaker(
                     [
                         // encoder class name
@@ -38,6 +41,38 @@ class MakeSerializerEncoderTest extends MakerTestCase
                         // encoder format
                         'foobar',
                     ]
+                );
+
+                self::assertStringContainsString(
+                    needle: 'public function decode(string $data, string $format, array $context = []): mixed',
+                    haystack: file_get_contents($runner->getPath('src/Serializer/FooBarEncoder.php'))
+                );
+            }),
+        ];
+
+        /* @legacy - Remove when MakerBundle no longer supports Symfony 6.4 */
+        yield 'it_makes_serializer_encoder_legacy' => [$this->createMakerTest()
+            // serializer-pack 1.1 requires symfony/property-info >= 5.4
+            // adding symfony/serializer-pack:* as an extra depends allows
+            // us to use serializer-pack < 1.1 which does not conflict with
+            // property-info < 5.4. E.g. Symfony 5.3 tests. See PR 1063
+            ->addExtraDependencies('symfony/serializer-pack:*')
+            ->run(function (MakerTestRunner $runner) {
+                if (70000 < $runner->getSymfonyVersion()) {
+                    $this->markTestSkipped('Legacy Symfony 6.4 Test');
+                }
+                $runner->runMaker(
+                    [
+                        // encoder class name
+                        'FooBarEncoder',
+                        // encoder format
+                        'foobar',
+                    ]
+                );
+
+                self::assertStringNotContainsString(
+                    needle: 'public function decode(string $data, string $format, array $context = []): mixed',
+                    haystack: file_get_contents($runner->getPath('src/Serializer/FooBarEncoder.php'))
                 );
             }),
         ];


### PR DESCRIPTION
Handles https://github.com/symfony/symfony/pull/47150 which reverted the changes to:
- https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
- https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php

- Adds legacy testcase for `6.4`, `DecoderInterface::decode()` return type `mixed` is added in Symfony `7.0`
- Removes legacy test dependencies introduced in https://github.com/symfony/maker-bundle/pull/1063

Fixes #1050 