### PR TITLE
[make:security:form-login] fix remember me label

### DIFF
--- a/src/Resources/skeleton/security/formLogin/login_form.tpl.php
+++ b/src/Resources/skeleton/security/formLogin/login_form.tpl.php
@@ -31,9 +31,8 @@
             See https://symfony.com/doc/current/security/remember_me.html
 
             <div class="checkbox mb-3">
-                <label>
-                    <input type="checkbox" name="_remember_me"> Remember me
-                </label>
+                <input type="checkbox" name="_remember_me" id="_remember_me">
+                <label for="_remember_me">Remember me</label>
             </div>
         #}
 

--- a/tests/fixtures/security/make-form-login/expected/login.html.twig
+++ b/tests/fixtures/security/make-form-login/expected/login.html.twig
@@ -29,9 +29,8 @@
             See https://symfony.com/doc/current/security/remember_me.html
 
             <div class="checkbox mb-3">
-                <label>
-                    <input type="checkbox" name="_remember_me"> Remember me
-                </label>
+                <input type="checkbox" name="_remember_me" id="_remember_me">
+                <label for="_remember_me">Remember me</label>
             </div>
         #}
 

--- a/tests/fixtures/security/make-form-login/expected/login_no_logout.html.twig
+++ b/tests/fixtures/security/make-form-login/expected/login_no_logout.html.twig
@@ -23,9 +23,8 @@
             See https://symfony.com/doc/current/security/remember_me.html
 
             <div class="checkbox mb-3">
-                <label>
-                    <input type="checkbox" name="_remember_me"> Remember me
-                </label>
+                <input type="checkbox" name="_remember_me" id="_remember_me">
+                <label for="_remember_me">Remember me</label>
             </div>
         #}
 


### PR DESCRIPTION
This allows for the text literal "Remember Me" to be clickable in addition to the check box that we generate - which is consistent with other input label's we generate.