### PR TITLE
fix: Update ux-turbo package name to have proper suggestion in MakeEntity command

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -333,7 +333,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (null !== $input && $input->getOption('broadcast')) {
             $dependencies->addClassDependency(
                 Broadcast::class,
-                'ux-turbo'
+                'symfony/ux-turbo'
             );
         }
 


### PR DESCRIPTION
Hi 👋

I tried to create an entity using `bin/console make:entity --broadcast` and got an error message suggesting a command to install the missing dependency. I think the command isn't working because the flex alias does not exist.

<img width="1679" alt="Capture d’écran 2024-05-04 à 12 48 04" src="https://github.com/symfony/maker-bundle/assets/5627752/b18d0ba6-a74a-49a0-873c-4088226c7d0b">

I assumed that the correct dependency was `symfony/ux-turbo` and updated the MakeEntity class to declare the correct package name.

