### PR TITLE
[make:crud|voter] generate classes with final keyword

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,6 +24,8 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('root_namespace')->defaultValue('App')->end()
+                ->booleanNode('generate_final_classes')->defaultTrue()->end()
+                ->booleanNode('generate_final_entities')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -49,6 +49,7 @@ class MakerExtension extends Extension
         $componentGeneratorDefinition
             ->replaceArgument(0, $config['generate_final_classes'])
             ->replaceArgument(1, $config['generate_final_entities'])
+            ->replaceArgument(2, $rootNamespace)
         ;
 
         $container->registerForAutoconfiguration(MakerInterface::class)

--- a/src/DependencyInjection/MakerExtension.php
+++ b/src/DependencyInjection/MakerExtension.php
@@ -45,6 +45,12 @@ class MakerExtension extends Extension
         $doctrineHelperDefinition = $container->getDefinition('maker.doctrine_helper');
         $doctrineHelperDefinition->replaceArgument(0, $rootNamespace.'\\Entity');
 
+        $componentGeneratorDefinition = $container->getDefinition('maker.template_component_generator');
+        $componentGeneratorDefinition
+            ->replaceArgument(0, $config['generate_final_classes'])
+            ->replaceArgument(1, $config['generate_final_entities'])
+        ;
+
         $container->registerForAutoconfiguration(MakerInterface::class)
             ->addTag(MakeCommandRegistrationPass::MAKER_TAG);
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -55,14 +55,15 @@ class Generator
      */
     public function generateClass(string $className, string $templateName, array $variables = []): string
     {
+        if (\array_key_exists('class_data', $variables) && $variables['class_data'] instanceof ClassData) {
+            $classData = $this->templateComponentGenerator->configureClass($variables['class_data']);
+            $className = $classData->getFullClassName();
+        }
+
         $targetPath = $this->fileManager->getRelativePathForFutureClass($className);
 
         if (null === $targetPath) {
             throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "\\My\\Full\\Namespace\\%s"', $className, Str::getShortClassName($className)));
-        }
-
-        if (\array_key_exists('class_data', $variables) && $variables['class_data'] instanceof ClassData) {
-            $this->templateComponentGenerator->configureClass($variables['class_data']);
         }
 
         $variables = array_merge($variables, [

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 
@@ -58,6 +59,10 @@ class Generator
 
         if (null === $targetPath) {
             throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "\\My\\Full\\Namespace\\%s"', $className, Str::getShortClassName($className)));
+        }
+
+        if (\array_key_exists('class_data', $variables) && $variables['class_data'] instanceof ClassData) {
+            $this->templateComponentGenerator->configureClass($variables['class_data']);
         }
 
         $variables = array_merge($variables, [

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -148,7 +148,7 @@ final class MakeCrud extends AbstractMaker
         } while (class_exists($formClassDetails->getFullName()));
 
         $controllerClassData = ClassData::create(
-            class: sprintf('Controller\%s', $this->controllerClassName),
+            class: \sprintf('Controller\%s', $this->controllerClassName),
             suffix: 'Controller',
             extendsClass: AbstractController::class,
             useStatements: [
@@ -248,7 +248,7 @@ final class MakeCrud extends AbstractMaker
 
         if ($this->shouldGenerateTests()) {
             $testClassData = ClassData::create(
-                class: sprintf('Tests\Controller\%s', $entityClassDetails->getRelativeNameWithoutSuffix()),
+                class: \sprintf('Tests\Controller\%s', $entityClassDetails->getRelativeNameWithoutSuffix()),
                 suffix: 'ControllerTest',
                 extendsClass: WebTestCase::class,
                 useStatements: [

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -148,7 +148,8 @@ final class MakeCrud extends AbstractMaker
         } while (class_exists($formClassDetails->getFullName()));
 
         $controllerClassData = ClassData::create(
-            class: sprintf('App\Controller\%sController', $this->controllerClassName),
+            class: sprintf('Controller\%s', $this->controllerClassName),
+            suffix: 'Controller',
             extendsClass: AbstractController::class,
             useStatements: [
                 $entityClassDetails->getFullName(),
@@ -175,7 +176,7 @@ final class MakeCrud extends AbstractMaker
         }
 
         $generator->generateController(
-            $controllerClassDetails->getFullName(),
+            $controllerClassData->getFullClassName(),
             'crud/controller/Controller.tpl.php',
             array_merge([
                 'class_data' => $controllerClassData,
@@ -247,7 +248,8 @@ final class MakeCrud extends AbstractMaker
 
         if ($this->shouldGenerateTests()) {
             $testClassData = ClassData::create(
-                class: sprintf('App\Tests\Controller\%sControllerTest', $entityClassDetails->getRelativeNameWithoutSuffix()),
+                class: sprintf('Tests\Controller\%s', $entityClassDetails->getRelativeNameWithoutSuffix()),
+                suffix: 'ControllerTest',
                 extendsClass: WebTestCase::class,
                 useStatements: [
                     $entityClassDetails->getFullName(),
@@ -263,7 +265,7 @@ final class MakeCrud extends AbstractMaker
             }
 
             $generator->generateClass(
-                $testClassData->fullClassName,
+                $testClassData->getFullClassName(),
                 'crud/test/Test.EntityManager.tpl.php',
                 [
                     'class_data' => $testClassData,

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -46,6 +47,11 @@ final class MakeVoter extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        $classMetaData = ClassData::create(
+            class: sprintf('App\Security\Voter\%sVoter', $input->getArgument('name')),
+            extendsClass: Voter::class,
+        );
+
         $voterClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
             'Security\\Voter\\',
@@ -55,7 +61,7 @@ final class MakeVoter extends AbstractMaker
         $generator->generateClass(
             $voterClassNameDetails->getFullName(),
             'security/Voter.tpl.php',
-            []
+            ['class_data' => $classMetaData]
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -19,7 +19,9 @@ use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -47,21 +49,21 @@ final class MakeVoter extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
-        $classMetaData = ClassData::create(
-            class: sprintf('App\Security\Voter\%sVoter', $input->getArgument('name')),
+        $voterClassData = ClassData::create(
+            class: sprintf('Security\Voter\%s', $input->getArgument('name')),
+            suffix: 'Voter',
             extendsClass: Voter::class,
-        );
-
-        $voterClassNameDetails = $generator->createClassNameDetails(
-            $input->getArgument('name'),
-            'Security\\Voter\\',
-            'Voter'
+            useStatements: [
+                TokenInterface::class,
+                Voter::class,
+                UserInterface::class,
+            ]
         );
 
         $generator->generateClass(
-            $voterClassNameDetails->getFullName(),
+            $voterClassData->getFullClassName(),
             'security/Voter.tpl.php',
-            ['class_data' => $classMetaData]
+            ['class_data' => $voterClassData]
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -50,7 +50,7 @@ final class MakeVoter extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $voterClassData = ClassData::create(
-            class: sprintf('Security\Voter\%s', $input->getArgument('name')),
+            class: \sprintf('Security\Voter\%s', $input->getArgument('name')),
             suffix: 'Voter',
             extendsClass: Voter::class,
             useStatements: [

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -80,6 +80,8 @@
             </service>
 
             <service id="maker.template_component_generator" class="Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator">
+               <argument /> <!-- generate_final_classes -->
+               <argument /> <!-- generate_final_entities -->
             </service>
         </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -80,8 +80,9 @@
             </service>
 
             <service id="maker.template_component_generator" class="Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator">
-               <argument /> <!-- generate_final_classes -->
-               <argument /> <!-- generate_final_entities -->
+                <argument /> <!-- generate_final_classes -->
+                <argument /> <!-- generate_final_entities -->
+                <argument /> <!-- root_namespace -->
             </service>
         </services>
 </container>

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -1,6 +1,6 @@
 <?= "<?php\n" ?>
 
-namespace <?= $namespace ?>;
+namespace <?= $class_data->getNamespace() ?>;
 
 <?= $class_data->getUseStatements(); ?>
 

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -2,7 +2,7 @@
 
 namespace <?= $namespace ?>;
 
-<?= $use_statements; ?>
+<?= $class_data->getUseStatements(); ?>
 
 #[Route('<?= $route_path ?>')]
 <?= $class_data->getClassDeclaration() ?>

--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -5,7 +5,7 @@ namespace <?= $namespace ?>;
 <?= $use_statements; ?>
 
 #[Route('<?= $route_path ?>')]
-class <?= $class_name ?> extends AbstractController
+<?= $class_data->getClassDeclaration() ?>
 {
 <?= $generator->generateRouteForControllerMethod('/', sprintf('%s_index', $route_name), ['GET']) ?>
 <?php if (isset($repository_full_class_name)): ?>

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -3,7 +3,7 @@
 
 namespace <?= $namespace ?>;
 
-<?= $use_statements; ?>
+<?= $class_data->getUseStatements(); ?>
 
 <?= $class_data->getClassDeclaration() ?>
 {

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -5,7 +5,7 @@ namespace <?= $namespace ?>;
 
 <?= $use_statements; ?>
 
-class <?= $class_name ?> extends WebTestCase<?= "\n" ?>
+<?= $class_data->getClassDeclaration() ?>
 {
     private KernelBrowser $client;
     private EntityManagerInterface $manager;

--- a/src/Resources/skeleton/security/Voter.tpl.php
+++ b/src/Resources/skeleton/security/Voter.tpl.php
@@ -1,10 +1,8 @@
 <?= "<?php\n" ?>
 
-namespace <?= $namespace; ?>;
+namespace <?= $class_data->getNamespace(); ?>;
 
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Authorization\Voter\Voter;
-use Symfony\Component\Security\Core\User\UserInterface;
+<?= $class_data->getUseStatements(); ?>
 
 <?= $class_data->getClassDeclaration() ?>
 {
@@ -16,7 +14,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
         return in_array($attribute, [self::EDIT, self::VIEW])
-            && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;
+            && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_data->getClassName()) ?>;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Util\ClassSource\Model;
 
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -26,18 +27,26 @@ final class ClassData
         public readonly string $fullClassName,
         public readonly ?string $extends,
         public readonly bool $isEntity,
+        private UseStatementGenerator $useStatementGenerator,
         private bool $isFinal = true,
     ) {
     }
 
-    public static function create(string $class, ?string $extendsClass = null, bool $isEntity = false): self
+    public static function create(string $class, ?string $extendsClass = null, bool $isEntity = false, array $useStatements = []): self
     {
+        $useStatements = new UseStatementGenerator($useStatements);
+
+        if ($extendsClass) {
+            $useStatements->addUseStatement($extendsClass);
+        }
+
         return new self(
             className: Str::getShortClassName($class),
             namespace: Str::getNamespace($class),
             fullClassName: $class,
             extends: null === $extendsClass ? null : Str::getShortClassName($extendsClass),
             isEntity: $isEntity,
+            useStatementGenerator: $useStatements,
         );
     }
 
@@ -61,5 +70,17 @@ final class ClassData
         $this->isFinal = $isFinal;
 
         return $this;
+    }
+
+    public function addUseStatement(array|string $useStatement): self
+    {
+        $this->useStatementGenerator->addUseStatement($useStatement);
+
+        return $this;
+    }
+
+    public function getUseStatements(): string
+    {
+        return (string) $this->useStatementGenerator;
     }
 }

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -37,7 +37,7 @@ final class ClassData
         $className = Str::getShortClassName($class);
 
         if (null !== $suffix && !str_ends_with($className, $suffix)) {
-            $className = Str::asClassName(sprintf('%s%s', $className, $suffix));
+            $className = Str::asClassName(\sprintf('%s%s', $className, $suffix));
         }
 
         $useStatements = new UseStatementGenerator($useStatements);
@@ -66,12 +66,12 @@ final class ClassData
             return $this->rootNamespace;
         }
 
-        return sprintf('%s\%s', $this->rootNamespace, $this->namespace);
+        return \sprintf('%s\%s', $this->rootNamespace, $this->namespace);
     }
 
     public function getFullClassName(): string
     {
-        return sprintf('%s\%s', $this->getNamespace(), $this->className);
+        return \sprintf('%s\%s', $this->getNamespace(), $this->className);
     }
 
     public function setRootNamespace(string $rootNamespace): self
@@ -86,10 +86,10 @@ final class ClassData
         $extendsDeclaration = '';
 
         if (null !== $this->extends) {
-            $extendsDeclaration = sprintf(' extends %s', $this->extends);
+            $extendsDeclaration = \sprintf(' extends %s', $this->extends);
         }
 
-        return sprintf('%sclass %s%s',
+        return \sprintf('%sclass %s%s',
             $this->isFinal ? 'final ' : '',
             $this->className,
             $extendsDeclaration,

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Util\ClassSource\Model;
+
+use Symfony\Bundle\MakerBundle\Str;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ *
+ * @internal
+ */
+final class ClassData
+{
+    private function __construct(
+        public readonly string $className,
+        public readonly string $namespace,
+        public readonly string $fullClassName,
+        public readonly ?string $extends,
+        public readonly bool $isEntity,
+        private bool $isFinal = true,
+    ) {
+    }
+
+    public static function create(string $class, ?string $extendsClass = null, bool $isEntity = false): self
+    {
+        return new self(
+            className: Str::getShortClassName($class),
+            namespace: Str::getNamespace($class),
+            fullClassName: $class,
+            extends: null === $extendsClass ? null : Str::getShortClassName($extendsClass),
+            isEntity: $isEntity,
+        );
+    }
+
+    public function getClassDeclaration(): string
+    {
+        $extendsDeclaration = '';
+
+        if (null !== $this->extends) {
+            $extendsDeclaration = sprintf(' extends %s', $this->extends);
+        }
+
+        return sprintf('%sclass %s%s',
+            $this->isFinal ? 'final ' : '',
+            $this->className,
+            $extendsDeclaration,
+        );
+    }
+
+    public function setIsFinal(bool $isFinal): self
+    {
+        $this->isFinal = $isFinal;
+
+        return $this;
+    }
+}

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -22,18 +22,24 @@ use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 final class ClassData
 {
     private function __construct(
-        public readonly string $className,
-        public readonly string $namespace,
-        public readonly string $fullClassName,
+        private string $className,
+        private string $namespace,
         public readonly ?string $extends,
         public readonly bool $isEntity,
         private UseStatementGenerator $useStatementGenerator,
         private bool $isFinal = true,
+        private string $rootNamespace = 'App',
     ) {
     }
 
-    public static function create(string $class, ?string $extendsClass = null, bool $isEntity = false, array $useStatements = []): self
+    public static function create(string $class, ?string $suffix = null, ?string $extendsClass = null, bool $isEntity = false, array $useStatements = []): self
     {
+        $className = Str::getShortClassName($class);
+
+        if (null !== $suffix && !str_ends_with($className, $suffix)) {
+            $className = Str::asClassName(sprintf('%s%s', $className, $suffix));
+        }
+
         $useStatements = new UseStatementGenerator($useStatements);
 
         if ($extendsClass) {
@@ -41,13 +47,38 @@ final class ClassData
         }
 
         return new self(
-            className: Str::getShortClassName($class),
+            className: Str::asClassName($className),
             namespace: Str::getNamespace($class),
-            fullClassName: $class,
             extends: null === $extendsClass ? null : Str::getShortClassName($extendsClass),
             isEntity: $isEntity,
             useStatementGenerator: $useStatements,
         );
+    }
+
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    public function getNamespace(): string
+    {
+        if (empty($this->namespace)) {
+            return $this->rootNamespace;
+        }
+
+        return sprintf('%s\%s', $this->rootNamespace, $this->namespace);
+    }
+
+    public function getFullClassName(): string
+    {
+        return sprintf('%s\%s', $this->getNamespace(), $this->className);
+    }
+
+    public function setRootNamespace(string $rootNamespace): self
+    {
+        $this->rootNamespace = $rootNamespace;
+
+        return $this;
     }
 
     public function getClassDeclaration(): string

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -23,6 +23,7 @@ final class TemplateComponentGenerator
     public function __construct(
         private bool $generateFinalClasses,
         private bool $generateFinalEntities,
+        private string $rootNamespace,
     ) {
     }
 
@@ -54,6 +55,8 @@ final class TemplateComponentGenerator
 
     public function configureClass(ClassData $classMetadata): ClassData
     {
+        $classMetadata->setRootNamespace($this->rootNamespace);
+
         if ($classMetadata->isEntity) {
             return $classMetadata->setIsFinal($this->generateFinalEntities);
         }

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\MakerBundle\Util;
 
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  *
@@ -18,6 +20,12 @@ namespace Symfony\Bundle\MakerBundle\Util;
  */
 final class TemplateComponentGenerator
 {
+    public function __construct(
+        private bool $generateFinalClasses,
+        private bool $generateFinalEntities,
+    ) {
+    }
+
     public function generateRouteForControllerMethod(string $routePath, string $routeName, array $methods = [], bool $indent = true, bool $trailingNewLine = true): string
     {
         $attribute = \sprintf('%s#[Route(\'%s\', name: \'%s\'', $indent ? '    ' : null, $routePath, $routeName);
@@ -42,5 +50,14 @@ final class TemplateComponentGenerator
     public function getPropertyType(ClassNameDetails $classNameDetails): ?string
     {
         return \sprintf('%s ', $classNameDetails->getShortName());
+    }
+
+    public function configureClass(ClassData $classMetadata): ClassData
+    {
+        if ($classMetadata->isEntity) {
+            return $classMetadata->setIsFinal($this->generateFinalEntities);
+        }
+
+        return $classMetadata->setIsFinal($this->generateFinalClasses);
     }
 }

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -23,6 +23,7 @@ use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
+use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
@@ -99,7 +100,8 @@ class EntityRegeneratorTest extends TestCase
 
         $fileManager = new FileManager($fs, $autoloaderUtil, new MakerFileLinkFormatter(null), $tmpDir);
         $doctrineHelper = new DoctrineHelper('App\\Entity', $container->get('doctrine'));
-        $generator = new Generator($fileManager, 'App\\');
+        $templateComponentGenerator = new TemplateComponentGenerator(false, false);
+        $generator = new Generator(fileManager: $fileManager, namespacePrefix: 'App\\', templateComponentGenerator: $templateComponentGenerator);
         $entityClassGenerator = new EntityClassGenerator($generator, $doctrineHelper);
         $regenerator = new EntityRegenerator(
             $doctrineHelper,

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -100,7 +100,7 @@ class EntityRegeneratorTest extends TestCase
 
         $fileManager = new FileManager($fs, $autoloaderUtil, new MakerFileLinkFormatter(null), $tmpDir);
         $doctrineHelper = new DoctrineHelper('App\\Entity', $container->get('doctrine'));
-        $templateComponentGenerator = new TemplateComponentGenerator(false, false);
+        $templateComponentGenerator = new TemplateComponentGenerator(false, false, 'App');
         $generator = new Generator(fileManager: $fileManager, namespacePrefix: 'App\\', templateComponentGenerator: $templateComponentGenerator);
         $entityClassGenerator = new EntityClassGenerator($generator, $doctrineHelper);
         $regenerator = new EntityRegenerator(

--- a/tests/Maker/MakeVoterTest.php
+++ b/tests/Maker/MakeVoterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 use Symfony\Bundle\MakerBundle\Maker\MakeVoter;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+use Symfony\Component\Yaml\Yaml;
 
 class MakeVoterTest extends MakerTestCase
 {
@@ -32,6 +33,32 @@ class MakeVoterTest extends MakerTestCase
                         'FooBar',
                     ]
                 );
+
+                $expectedVoterPath = \dirname(__DIR__).'/fixtures/make-voter/expected/FooBarVoter.php';
+                $generatedVoter = $runner->getPath('src/Security/Voter/FooBarVoter.php');
+
+                self::assertSame(file_get_contents($expectedVoterPath), file_get_contents($generatedVoter));
+            }),
+        ];
+
+        yield 'it_makes_voter_not_final' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->writeFile(
+                    'config/packages/dev/maker.yaml',
+                    Yaml::dump(['when@dev' => ['maker' => ['generate_final_classes' => false]]])
+                );
+
+                $runner->runMaker(
+                    [
+                        // voter class name
+                        'FooBar',
+                    ]
+                );
+
+                $expectedVoterPath = \dirname(__DIR__).'/fixtures/make-voter/expected/not_final_FooBarVoter.php';
+                $generatedVoter = $runner->getPath('src/Security/Voter/FooBarVoter.php');
+
+                self::assertSame(file_get_contents($expectedVoterPath), file_get_contents($generatedVoter));
             }),
         ];
     }

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -25,9 +25,9 @@ class ClassDataTest extends TestCase
         // Sanity check in case Maker's NS changes
         self::assertSame('Symfony\Bundle\MakerBundle\MakerBundle', MakerBundle::class);
 
-        self::assertSame('MakerBundle', $meta->className);
-        self::assertSame('Symfony\Bundle\MakerBundle', $meta->namespace);
-        self::assertSame('Symfony\Bundle\MakerBundle\MakerBundle', $meta->fullClassName);
+        self::assertSame('MakerBundle', $meta->getClassName());
+        self::assertSame('App\Symfony\Bundle\MakerBundle', $meta->getNamespace());
+        self::assertSame('App\Symfony\Bundle\MakerBundle\MakerBundle', $meta->getFullClassName());
     }
 
     public function testGetClassDeclaration(): void
@@ -54,5 +54,41 @@ class ClassDataTest extends TestCase
         $meta = ClassData::create(class: MakerBundle::class, extendsClass: MakerTestKernel::class);
 
         self::assertSame('final class MakerBundle extends MakerTestKernel', $meta->getClassDeclaration());
+    }
+
+    /** @dataProvider suffixDataProvider */
+    public function testSuffix(?string $suffix, string $expectedResult): void
+    {
+        $data = ClassData::create(class: MakerBundle::class, suffix: $suffix);
+
+        self::assertSame($expectedResult, $data->getClassName());
+    }
+
+    public function suffixDataProvider(): \Generator
+    {
+        yield [null, 'MakerBundle'];
+        yield ['Testing', 'MakerBundleTesting'];
+        yield ['Bundle', 'MakerBundle'];
+    }
+
+    /** @dataProvider namespaceDataProvider */
+    public function testNamespace(string $class, ?string $rootNamespace, string $expectedNamespace, string $expectedFullClassName): void
+    {
+        $class = ClassData::create($class);
+
+        if (null !== $rootNamespace) {
+            $class->setRootNamespace($rootNamespace);
+        }
+
+        self::assertSame($expectedNamespace, $class->getNamespace());
+        self::assertSame($expectedFullClassName, $class->getFullClassName());
+    }
+
+    public function namespaceDataProvider(): \Generator
+    {
+        yield ['MyController', null, 'App', 'App\MyController'];
+        yield ['Controller\MyController', null, 'App\Controller', 'App\Controller\MyController'];
+        yield ['MyController', 'Maker', 'Maker', 'Maker\MyController'];
+        yield ['Controller\MyController', 'Maker', 'Maker\Controller', 'Maker\Controller\MyController'];
     }
 }

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Util\ClassSource;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\MakerBundle;
+use Symfony\Bundle\MakerBundle\Test\MakerTestKernel;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+
+class ClassDataTest extends TestCase
+{
+    public function testStaticConstructor(): void
+    {
+        $meta = ClassData::create(MakerBundle::class);
+
+        // Sanity check in case Maker's NS changes
+        self::assertSame('Symfony\Bundle\MakerBundle\MakerBundle', MakerBundle::class);
+
+        self::assertSame('MakerBundle', $meta->className);
+        self::assertSame('Symfony\Bundle\MakerBundle', $meta->namespace);
+        self::assertSame('Symfony\Bundle\MakerBundle\MakerBundle', $meta->fullClassName);
+    }
+
+    public function testGetClassDeclaration(): void
+    {
+        $meta = ClassData::create(MakerBundle::class);
+
+        self::assertSame('final class MakerBundle', $meta->getClassDeclaration());
+    }
+
+    public function testIsFinal(): void
+    {
+        $meta = ClassData::create(MakerBundle::class);
+
+        // Default - isFinal - true
+        self::assertSame('final class MakerBundle', $meta->getClassDeclaration());
+
+        // Not Final - isFinal - false
+        $meta->setIsFinal(false);
+        self::assertSame('class MakerBundle', $meta->getClassDeclaration());
+    }
+
+    public function testGetClassDeclarationWithExtends(): void
+    {
+        $meta = ClassData::create(class: MakerBundle::class, extendsClass: MakerTestKernel::class);
+
+        self::assertSame('final class MakerBundle extends MakerTestKernel', $meta->getClassDeclaration());
+    }
+}

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\MakerBundle;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 
 /**
@@ -94,10 +96,13 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testGetFinalClassDeclaration(bool $finalClass, bool $finalEntity, bool $isEntity, string $expectedResult): void
     {
-        $this->markTestIncomplete('We wont need this...');
         $generator = new TemplateComponentGenerator($finalClass, $finalEntity);
 
-        self::assertSame($expectedResult, $generator->getFinalDeclaration($isEntity));
+        $classData = ClassData::create(MakerBundle::class, isEntity: $isEntity);
+
+        $generator->configureClass($classData);
+
+        self::assertSame(sprintf('%sclass MakerBundle', $expectedResult), $classData->getClassDeclaration());
     }
 
     public function finalClassDataProvider(): \Generator

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -102,7 +102,7 @@ class TemplateComponentGeneratorTest extends TestCase
 
         $generator->configureClass($classData);
 
-        self::assertSame(sprintf('%sclass MakerBundle', $expectedResult), $classData->getClassDeclaration());
+        self::assertSame(\sprintf('%sclass MakerBundle', $expectedResult), $classData->getClassDeclaration());
     }
 
     public function finalClassDataProvider(): \Generator

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\TemplateComponentGenerator;
 
 /**
@@ -22,7 +21,7 @@ class TemplateComponentGeneratorTest extends TestCase
 {
     public function testRouteAttributes(): void
     {
-        $generator = new TemplateComponentGenerator($this->createMock(PhpCompatUtil::class));
+        $generator = new TemplateComponentGenerator(false, false);
 
         $expected = "    #[Route('/', name: 'app_home')]\n";
 
@@ -34,7 +33,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteMethods(string $expected, array $methods): void
     {
-        $generator = new TemplateComponentGenerator($this->createMock(PhpCompatUtil::class));
+        $generator = new TemplateComponentGenerator(false, false);
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -54,7 +53,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteIndentation(string $expected): void
     {
-        $generator = new TemplateComponentGenerator($this->createMock(PhpCompatUtil::class));
+        $generator = new TemplateComponentGenerator(false, false);
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -74,7 +73,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteTrailingNewLine(string $expected): void
     {
-        $generator = new TemplateComponentGenerator($this->createMock(PhpCompatUtil::class));
+        $generator = new TemplateComponentGenerator(false, false);
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -88,5 +87,28 @@ class TemplateComponentGeneratorTest extends TestCase
     public function routeTrailingNewLineDataProvider(): \Generator
     {
         yield ["#[Route('/', name: 'app_home')]", true];
+    }
+
+    /**
+     * @dataProvider finalClassDataProvider
+     */
+    public function testGetFinalClassDeclaration(bool $finalClass, bool $finalEntity, bool $isEntity, string $expectedResult): void
+    {
+        $this->markTestIncomplete('We wont need this...');
+        $generator = new TemplateComponentGenerator($finalClass, $finalEntity);
+
+        self::assertSame($expectedResult, $generator->getFinalDeclaration($isEntity));
+    }
+
+    public function finalClassDataProvider(): \Generator
+    {
+        yield 'Not Final Class' => [false, false, false, ''];
+        yield 'Not Final Class w/ Entity' => [false, true, false, ''];
+        yield 'Final Class' => [true, false, false, 'final '];
+        yield 'Final Class w/ Entity' => [true, true, false, 'final '];
+        yield 'Not Final Entity' => [false, false, true, ''];
+        yield 'Not Final Entity w/ Class' => [true, false, true, ''];
+        yield 'Final Entity' => [false, true, true, 'final '];
+        yield 'Final Entity w/ Class' => [true, true, true, 'final '];
     }
 }

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -23,7 +23,7 @@ class TemplateComponentGeneratorTest extends TestCase
 {
     public function testRouteAttributes(): void
     {
-        $generator = new TemplateComponentGenerator(false, false);
+        $generator = new TemplateComponentGenerator(false, false, 'App');
 
         $expected = "    #[Route('/', name: 'app_home')]\n";
 
@@ -35,7 +35,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteMethods(string $expected, array $methods): void
     {
-        $generator = new TemplateComponentGenerator(false, false);
+        $generator = new TemplateComponentGenerator(false, false, 'App');
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -55,7 +55,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteIndentation(string $expected): void
     {
-        $generator = new TemplateComponentGenerator(false, false);
+        $generator = new TemplateComponentGenerator(false, false, 'App');
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -75,7 +75,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testRouteTrailingNewLine(string $expected): void
     {
-        $generator = new TemplateComponentGenerator(false, false);
+        $generator = new TemplateComponentGenerator(false, false, 'App');
 
         self::assertSame($expected, $generator->generateRouteForControllerMethod(
             '/',
@@ -96,7 +96,7 @@ class TemplateComponentGeneratorTest extends TestCase
      */
     public function testGetFinalClassDeclaration(bool $finalClass, bool $finalEntity, bool $isEntity, string $expectedResult): void
     {
-        $generator = new TemplateComponentGenerator($finalClass, $finalEntity);
+        $generator = new TemplateComponentGenerator($finalClass, $finalEntity, 'App');
 
         $classData = ClassData::create(MakerBundle::class, isEntity: $isEntity);
 
@@ -115,5 +115,16 @@ class TemplateComponentGeneratorTest extends TestCase
         yield 'Not Final Entity w/ Class' => [true, false, true, ''];
         yield 'Final Entity' => [false, true, true, 'final '];
         yield 'Final Entity w/ Class' => [true, true, true, 'final '];
+    }
+
+    public function testConfiguresClassDataWithRootNamespace(): void
+    {
+        $generator = new TemplateComponentGenerator(false, false, 'MakerTest');
+
+        $classData = ClassData::create(MakerBundle::class);
+
+        $generator->configureClass($classData);
+
+        self::assertSame('MakerTest\Symfony\Bundle\MakerBundle', $classData->getNamespace());
     }
 }

--- a/tests/fixtures/make-crud/expected/WithCustomRepository.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepository.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/sweet/food')]
-class SweetFoodController extends AbstractController
+final class SweetFoodController extends AbstractController
 {
     #[Route('/', name: 'app_sweet_food_index', methods: ['GET'])]
     public function index(SweetFoodRepository $sweetFoodRepository): Response

--- a/tests/fixtures/make-voter/expected/FooBarVoter.php
+++ b/tests/fixtures/make-voter/expected/FooBarVoter.php
@@ -1,12 +1,12 @@
-<?= "<?php\n" ?>
+<?php
 
-namespace <?= $namespace; ?>;
+namespace App\Security\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-<?= $class_data->getClassDeclaration() ?>
+final class FooBarVoter extends Voter
 {
     public const EDIT = 'POST_EDIT';
     public const VIEW = 'POST_VIEW';
@@ -16,12 +16,13 @@ use Symfony\Component\Security\Core\User\UserInterface;
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
         return in_array($attribute, [self::EDIT, self::VIEW])
-            && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;
+            && $subject instanceof \App\Entity\FooBar;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
+
         // if the user is anonymous, do not grant access
         if (!$user instanceof UserInterface) {
             return false;
@@ -33,6 +34,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
                 // logic to determine if the user can EDIT
                 // return true or false
                 break;
+
             case self::VIEW:
                 // logic to determine if the user can VIEW
                 // return true or false

--- a/tests/fixtures/make-voter/expected/not_final_FooBarVoter.php
+++ b/tests/fixtures/make-voter/expected/not_final_FooBarVoter.php
@@ -1,12 +1,12 @@
-<?= "<?php\n" ?>
+<?php
 
-namespace <?= $namespace; ?>;
+namespace App\Security\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-<?= $class_data->getClassDeclaration() ?>
+class FooBarVoter extends Voter
 {
     public const EDIT = 'POST_EDIT';
     public const VIEW = 'POST_VIEW';
@@ -16,12 +16,13 @@ use Symfony\Component\Security\Core\User\UserInterface;
         // replace with your own logic
         // https://symfony.com/doc/current/security/voters.html
         return in_array($attribute, [self::EDIT, self::VIEW])
-            && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_name) ?>;
+            && $subject instanceof \App\Entity\FooBar;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
+
         // if the user is anonymous, do not grant access
         if (!$user instanceof UserInterface) {
             return false;
@@ -33,6 +34,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
                 // logic to determine if the user can EDIT
                 // return true or false
                 break;
+
             case self::VIEW:
                 // logic to determine if the user can VIEW
                 // return true or false


### PR DESCRIPTION
- introduces 2 new configuration values:
    - `generate_final_classes`: Defaults to `true` - When true, all non-entity classes generated by MakerBundle will be final.
    - `generate_final_entities`: Defaults to `false` - When true, all entity classes generated by MakerBundle will be final.

- introduces an internal `ClassData` object that represents all of the meta data needed to generate a class from a template. It combines parts of `ClassNameDetails` & `UseStatementGenerator, while adding logic to generate a class declaration conditionally including the `final` keyword & `extends` class.

- `ClassData` is configured by `TemplateComponentGenerator` to handle `root_namespace`, `generate_final_classes`, & `generate_final_entities` if passed as a template `class_data` variable to `Generator::createClass()`. The idea being we don't have to modify the constructor for the "non-internal" `Generator::class`

- reduces the complexity of our `.tpl.php` templates. The `ClassData` object is accessible from within the templates (Crud & Voter for now). `$class_data->getClassDeclaration()` generates `final class SomeClass extends XyzClass`

- To keep the PR's "reviewable" this PR only adds the new functionality for `make:crud` & `make:voter`. To be implemented in additional makers in subsequent PR's.

- [x] fix test fixtures to use `final`
- [x] update _this_ description to include all of the proposed changes

fixes #1536 

---

I think instead of one massive PR, we will merge this PR first to include `make:voter` & `make:crud` -> create subsequent PR's for makers that touch entities (1 pr) and the rest of the makers (1 pr). I say this because _this_ PR is actually adding a handful of new features (mostly internal) in order to generate `final` classes. 