### PR TITLE
[dx] make it easier to use tooling for devs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,5 +54,23 @@
         "branch-alias": {
             "dev-main": "1.x-dev"
         }
+    },
+    "scripts": {
+        "tools:upgrade": [
+            "@tools:upgrade:php-cs-fixer",
+            "@tools:upgrade:phpstan",
+            "@tools:upgrade:twigcs"
+        ],
+        "tools:upgrade:php-cs-fixer": "composer upgrade -W -d tools/php-cs-fixer",
+        "tools:upgrade:phpstan": "composer upgrade -W -d tools/phpstan",
+        "tools:upgrade:twigcs": "composer upgrade -W -d tools/twigcs",
+        "tools:run": [
+            "@tools:run:php-cs-fixer",
+            "@tools:run:phpstan",
+            "@tools:run:twigcs"
+        ],
+        "tools:run:php-cs-fixer": "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
+        "tools:run:phpstan": "tools/phpstan/vendor/bin/phpstan --memory-limit=1G",
+        "tools:run:twigcs": "tools/twigcs/vendor/bin/twigcs --config tools/twigcs/.twigcs.dist.php"
     }
 }


### PR DESCRIPTION
- run `composer tools:upgrade` to install / upgrade `php-cs-fixer`, `phpstan`, & `twigcs`
- run `composer tools:upgrade:php-cs-fixer || phpstan || twigcs` to install / upgrade individual tool
- run `composer tools:run` to run all 3 tools against the code base
- run `composer tools:run:php-cs-fixer || phpstan || twigcs` to run an individual tool against the code base

I've started doing this in other projects & it's a nice little bonus the DX when working on the code base... We can always take it out if we run into problems. Feedback welcome!