### PR TITLE
[make:user] fix `getPassword()` return type in certain instance with `PasswordAuthenticatedUserInterface`

### DIFF
--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -216,7 +216,7 @@ final class UserClassBuilder
 
             $manipulator->addGetter(
                 'password',
-                'string',
+                '?string',
                 true
             );
 
@@ -231,7 +231,7 @@ final class UserClassBuilder
         $manipulator->addAccessorMethod(
             'password',
             'getPassword',
-            'string',
+            '?string',
             false,
             [
                 '@see PasswordAuthenticatedUserInterface',

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -216,7 +216,7 @@ final class UserClassBuilder
 
             $manipulator->addGetter(
                 'password',
-                '?string',
+                'string',
                 true
             );
 
@@ -231,8 +231,8 @@ final class UserClassBuilder
         $manipulator->addAccessorMethod(
             'password',
             'getPassword',
-            '?string',
-            false,
+            'string',
+            true,
             [
                 '@see PasswordAuthenticatedUserInterface',
             ]

--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -83,7 +83,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see PasswordAuthenticatedUserInterface
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -78,7 +78,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see PasswordAuthenticatedUserInterface
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -78,7 +78,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see PasswordAuthenticatedUserInterface
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }

--- a/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserModelWithEmailAsIdentifier.php
@@ -67,7 +67,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see PasswordAuthenticatedUserInterface
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }

--- a/tests/Security/fixtures/expected/UserModelWithPassword.php
+++ b/tests/Security/fixtures/expected/UserModelWithPassword.php
@@ -62,7 +62,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @see PasswordAuthenticatedUserInterface
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }


### PR DESCRIPTION
---
Edited by: @jrushlow

Improves types in templates to handle PHPStan squawks in userland code