### PR TITLE
[debug] null string literal to null for process timeout

### DIFF
--- a/src/Test/MakerTestProcess.php
+++ b/src/Test/MakerTestProcess.php
@@ -46,6 +46,10 @@ final class MakerTestProcess
     public function run($allowToFail = false, array $envVars = []): self
     {
         if (false !== ($timeout = getenv('MAKER_PROCESS_TIMEOUT'))) {
+            if ('null' === $timeout) {
+                $timeout = null;
+            }
+
             // Setting a value of null allows for step debugging
             $this->process->setTimeout($timeout);
         }


### PR DESCRIPTION
The timeout for a test process can only be a `float` || `null`. Currently, the suggested `MAKER_PROCESS_TIMEOUT` "null" value is cast as a string. This fixes the exception that is ultimately thrown when attempting to set the timeout as `null` via the env.

_This only affects MakerBundle internal development, specifically, step debugging_