### PR TITLE
[make:*] generate test classes properly & fix class name details suffix

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -153,6 +153,10 @@ class Generator
             }
         }
 
+        if (!str_ends_with($className, $suffix)) {
+            $className = sprintf('%s%s', $className, $suffix);
+        }
+
         Validator::validateClassName($className, $validationErrorMessage);
 
         // if this is a custom class, we may be completely different than the namespace prefix

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -243,8 +243,8 @@ final class MakeCrud extends AbstractMaker
 
         if ($this->shouldGenerateTests()) {
             $testClassDetails = $generator->createClassNameDetails(
-                $entityClassDetails->getRelativeNameWithoutSuffix(),
-                'Test\\Controller\\',
+                sprintf('\\App\\Tests\\Controller\\%s', $entityClassDetails->getRelativeNameWithoutSuffix()),
+                'Controller\\',
                 'ControllerTest'
             );
 
@@ -261,8 +261,8 @@ final class MakeCrud extends AbstractMaker
                 $useStatements->addUseStatement(EntityManagerInterface::class);
             }
 
-            $generator->generateFile(
-                'tests/Controller/'.$testClassDetails->getShortName().'.php',
+            $generator->generateClass(
+                $testClassDetails->getFullName(),
                 'crud/test/Test.EntityManager.tpl.php',
                 [
                     'use_statements' => $useStatements,


### PR DESCRIPTION
- When passing a `suffix` to `Generator::createClassNameDetails()`, the suffix is _not_ added to an absolute class name. Our docs say that passing a suffix "...guarantee is on the end of the class". This PR fixes that.

- Generates tests in the proper `App\Tests\` namespace instead of `App\Test\`

---

### Internals

When generating tests (`--with-tests`), I was lazy and used `generateFile()` to create the test class (in part because of the suffix bug) instead of using the correct `generateClass()` method. This PR fixes that. It's also needed to accomplish #1539 with test classes.