### PR TITLE
[make:controller] add tests to confirm twig templates generated

### DIFF
--- a/src/Resources/help/MakeController.txt
+++ b/src/Resources/help/MakeController.txt
@@ -4,6 +4,11 @@ The <info>%command.name%</info> command generates a new controller class.
 
 If the argument is missing, the command will ask for the controller class name interactively.
 
+If you have the <info>symfony/twig-bundle</info> installed, a Twig template will also be
+generated for the controller.
+
+<info>composer require symfony/twig-bundle</info>
+
 You can also generate the controller alone, without template with this option:
 
 <info>php %command.full_name% --no-template</info>

--- a/tests/Maker/MakeControllerTest.php
+++ b/tests/Maker/MakeControllerTest.php
@@ -45,6 +45,9 @@ class MakeControllerTest extends MakerTestCase
                     'FooTwig',
                 ]);
 
+                $controllerPath = $runner->getPath('templates/foo_twig/index.html.twig');
+                self::assertFileExists($controllerPath);
+
                 $this->runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
             }),
         ];
@@ -58,6 +61,9 @@ class MakeControllerTest extends MakerTestCase
                     // controller class name
                     'FooTwig',
                 ]);
+
+                $controllerPath = $runner->getPath('templates/foo_twig/index.html.twig');
+                self::assertFileExists($controllerPath);
 
                 $this->runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
             }),
@@ -100,6 +106,9 @@ class MakeControllerTest extends MakerTestCase
                    'Admin\\FooBar',
                ]);
 
+               $controllerPath = $runner->getPath('templates/admin/foo_bar/index.html.twig');
+               self::assertFileExists($controllerPath);
+
                $this->assertFileExists($runner->getPath('templates/admin/foo_bar/index.html.twig'));
            }),
         ];
@@ -111,6 +120,9 @@ class MakeControllerTest extends MakerTestCase
                      // controller class name
                      '\App\Foo\Bar\CoolController',
                  ]);
+
+                 $controllerPath = $runner->getPath('templates/foo/bar/cool/index.html.twig');
+                 self::assertFileExists($controllerPath);
 
                  $this->assertStringContainsString('src/Foo/Bar/CoolController.php', $output);
                  $this->assertStringContainsString('templates/foo/bar/cool/index.html.twig', $output);
@@ -125,6 +137,9 @@ class MakeControllerTest extends MakerTestCase
                     'FooInvokable',
                 ], '--invokable');
 
+                $controllerPath = $runner->getPath('templates/foo_invokable.html.twig');
+                self::assertFileExists($controllerPath);
+
                 $this->assertStringContainsString('src/Controller/FooInvokableController.php', $output);
                 $this->assertStringContainsString('templates/foo_invokable.html.twig', $output);
                 $this->runControllerTest($runner, 'it_generates_an_invokable_controller.php');
@@ -138,6 +153,9 @@ class MakeControllerTest extends MakerTestCase
                     // controller class name
                     'Admin\\FooInvokable',
                 ], '--invokable');
+
+                $controllerPath = $runner->getPath('templates/admin/foo_invokable.html.twig');
+                self::assertFileExists($controllerPath);
 
                 $this->assertStringContainsString('src/Controller/Admin/FooInvokableController.php', $output);
                 $this->assertStringContainsString('templates/admin/foo_invokable.html.twig', $output);


### PR DESCRIPTION
- updates the help doc (`bin/console make:controller --help`) to reference `symfony/twig-bundle` is needed to generate twig templates for the controller.

fixes #1066 