### PR TITLE
[make:schedule] Add transport name for attribute

### DIFF
--- a/src/Maker/MakeSchedule.php
+++ b/src/Maker/MakeSchedule.php
@@ -37,6 +37,7 @@ final class MakeSchedule extends AbstractMaker
 {
     private string $scheduleName;
     private ?string $message = null;
+    private ?string $transportName = null;
 
     public function __construct(
         private FileManager $fileManager,
@@ -82,6 +83,8 @@ final class MakeSchedule extends AbstractMaker
             }
         }
 
+        $this->transportName = $io->ask('What should we call the new transport? (To be used for the attribute #[AsSchedule(name)])');
+
         $scheduleNameHint = 'MainSchedule';
 
         // If the count is 1, no other messages were found - don't ask to create a message
@@ -126,6 +129,8 @@ final class MakeSchedule extends AbstractMaker
                 'use_statements' => $useStatements,
                 'has_custom_message' => null !== $this->message,
                 'message_class_name' => $this->message,
+                'has_transport_name' => null !== $this->transportName,
+                'transport_name' => $this->transportName,
             ],
         );
 

--- a/src/Resources/skeleton/scheduler/Schedule.tpl.php
+++ b/src/Resources/skeleton/scheduler/Schedule.tpl.php
@@ -4,7 +4,11 @@ namespace <?= $namespace; ?>;
 
 <?= $use_statements; ?>
 
+<?php if ($has_transport_name): ?>
+#[AsSchedule('<?= $transport_name; ?>')]
+<?php else: ?>
 #[AsSchedule]
+<?php endif ?>
 final class <?= $class_name; ?> implements ScheduleProviderInterface
 {
     public function __construct(

--- a/src/Resources/skeleton/scheduler/Schedule.tpl.php
+++ b/src/Resources/skeleton/scheduler/Schedule.tpl.php
@@ -4,11 +4,7 @@ namespace <?= $namespace; ?>;
 
 <?= $use_statements; ?>
 
-<?php if ($has_transport_name): ?>
-#[AsSchedule('<?= $transport_name; ?>')]
-<?php else: ?>
-#[AsSchedule]
-<?php endif ?>
+#[AsSchedule<?php if ($has_transport_name): ?>('<?= $transport_name; ?>')<?php endif ?>]
 final class <?= $class_name; ?> implements ScheduleProviderInterface
 {
     public function __construct(

--- a/tests/Maker/MakeScheduleTest.php
+++ b/tests/Maker/MakeScheduleTest.php
@@ -24,9 +24,26 @@ class MakeScheduleTest extends MakerTestCase
 
     public function getTestDetails(): \Generator
     {
+        yield 'it_generates_a_schedule_with_transport_name' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([
+                    'dummy', // use transport name "dummy"
+                    '', // use default schedule name "MainSchedule"
+                ]);
+
+                $this->assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-schedule/expected/DefaultScheduleWithTransportName.php',
+                    $runner->getPath('src/Scheduler/MainSchedule.php')
+                );
+            }),
+        ];
+
         yield 'it_generates_a_schedule' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
+                    '', // use default transport name
                     '', // use default schedule name "MainSchedule"
                 ]);
 
@@ -48,6 +65,7 @@ class MakeScheduleTest extends MakerTestCase
             })
             ->run(function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
+                    '', // Use the default transport name
                     0,  // Select "Empty Schedule"
                     'MySchedule', // Go with the default name "MainSchedule"
                 ]);
@@ -70,6 +88,7 @@ class MakeScheduleTest extends MakerTestCase
             })
             ->run(function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
+                    '', // Use the default transport name
                     1,  // Select "MyMessage" from choice
                     '', // Go with the default name "MessageFixtureSchedule"
                 ]);

--- a/tests/fixtures/make-schedule/expected/DefaultScheduleWithTransportName.php
+++ b/tests/fixtures/make-schedule/expected/DefaultScheduleWithTransportName.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Scheduler;
+
+use Symfony\Component\Scheduler\Attribute\AsSchedule;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+#[AsSchedule('dummy')]
+final class MainSchedule implements ScheduleProviderInterface
+{
+    public function __construct(
+        private CacheInterface $cache,
+    ) {
+    }
+
+    public function getSchedule(): Schedule
+    {
+        return (new Schedule())
+            ->add(
+                // @TODO - Create a Message to schedule
+                // RecurringMessage::every('1 hour', new App\Message\Message()),
+            )
+            ->stateful($this->cache)
+        ;
+    }
+}


### PR DESCRIPTION
Hey ! 👋 

I often use the command `make:schedule` and I wanted to add this new feature : Ask for the `name` used in the attribute `#[AsSchedule]`. 

## Without name 
Console : 
<img width="828" alt="Capture d’écran 2024-06-01 à 11 49 48" src="https://github.com/symfony/maker-bundle/assets/17028390/844f16f8-6249-444e-8bba-d0d6ba508476">

Generated class : 

```php
<?php

namespace App\Scheduler;

use Symfony\Component\Scheduler\Attribute\AsSchedule;
use Symfony\Component\Scheduler\RecurringMessage;
use Symfony\Component\Scheduler\Schedule;
use Symfony\Component\Scheduler\ScheduleProviderInterface;
use Symfony\Contracts\Cache\CacheInterface;

#[AsSchedule]
final class MainSchedule implements ScheduleProviderInterface
{
    public function __construct(
        private CacheInterface $cache,
    ) {
    }

    public function getSchedule(): Schedule
    {
        return (new Schedule())
        ->add(
            // @TODO - Create a Message to schedule
            // RecurringMessage::every('1 hour', new App\Message\Message()),
        )
        ->stateful($this->cache)
        ;
    }
}
```

## With `dummy` name

Console : 
<img width="828" alt="Capture d’écran 2024-06-01 à 11 50 01" src="https://github.com/symfony/maker-bundle/assets/17028390/61e53391-1446-4402-9016-7bbf08743b79">

Generated class : 

```php
<?php

namespace App\Scheduler;

use Symfony\Component\Scheduler\Attribute\AsSchedule;
use Symfony\Component\Scheduler\RecurringMessage;
use Symfony\Component\Scheduler\Schedule;
use Symfony\Component\Scheduler\ScheduleProviderInterface;
use Symfony\Contracts\Cache\CacheInterface;

#[AsSchedule('dummy')]
final class MainSchedule implements ScheduleProviderInterface
{
    public function __construct(
        private CacheInterface $cache,
    ) {
    }

    public function getSchedule(): Schedule
    {
        return (new Schedule())
        ->add(
            // @TODO - Create a Message to schedule
            // RecurringMessage::every('1 hour', new App\Message\Message()),
        )
        ->stateful($this->cache)
        ;
    }
}
```