### PR TITLE
[make:twig-component] Fix generated twig file location

### DIFF
--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
-use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -66,7 +65,8 @@ final class MakeTwigComponent extends AbstractMaker
             'Twig\\Components',
         );
 
-        $shortName = Str::getShortClassName($factory->getShortName());
+        $templatePath = str_replace('\\', '/', $factory->getRelativeNameWithoutSuffix());
+        $shortName = str_replace('\\', ':', $factory->getRelativeNameWithoutSuffix());
 
         $generator->generateClass(
             $factory->getFullName(),
@@ -76,7 +76,7 @@ final class MakeTwigComponent extends AbstractMaker
             ]
         );
         $generator->generateTemplate(
-            "components/{$shortName}.html.twig",
+            "components/{$templatePath}.html.twig",
             sprintf('%s/../Resources/skeleton/twig/%s', __DIR__, 'component_template.tpl.php')
         );
 

--- a/tests/Maker/MakeTwigComponentTest.php
+++ b/tests/Maker/MakeTwigComponentTest.php
@@ -90,6 +90,24 @@ class MakeTwigComponentTest extends MakerTestCase
                 $runner->runTests();
             }),
         ];
+
+        yield 'it_generates_live_component_on_subdirectory' => [$this->createMakerTest()
+            ->addExtraDependencies('symfony/ux-live-component', 'symfony/twig-bundle')
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker(['Form\Input', 'y']);
+
+                $this->assertStringContainsString('src/Twig/Components/Form/Input.php', $output);
+                $this->assertStringContainsString('templates/components/Form/Input.html.twig', $output);
+                $this->assertStringContainsString('To render the component, use <twig:Form:Input />.', $output);
+
+                $runner->copy(
+                    'make-twig-component/tests/it_generates_live_component.php',
+                    'tests/GeneratedLiveComponentTest.php'
+                );
+                $runner->replaceInFile('tests/GeneratedLiveComponentTest.php', '{name}', 'Form:Input');
+                $runner->runTests();
+            }),
+        ];
     }
 
     protected function getMakerClass(): string


### PR DESCRIPTION
this PR aims to fix generated twig file path if the twig-component created on a subdirectory

## Before

```sh
 symfony console make:twig-component "Form\Input" --live
 created: src/Twig/Components/Form/Input.php
 created: templates/components/Input.html.twig

  Success!

 To render the component, use <twig:Input />.
```

## After

```sh
symfony console make:twig-component "Form\Input" --live
 created: src/Twig/Components/Form/Input.php
 created: templates/components/Form/Input.html.twig

  Success!

 To render the component, use <twig:Form:Input />.
```