### PR TITLE
[release] v1.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [v1.60.0](https://github.com/symfony/maker-bundle/releases/tag/v1.60.0)
+
+*June 10th, 2024*
+
+### Feature
+
+- [#1534](https://github.com/symfony/maker-bundle/pull/1534) [make:entity] add enum support - *@loicsapone*
+- [#1543](https://github.com/symfony/maker-bundle/pull/1543) [dx] make it easier to use tooling for devs - *@jrushlow*
+- [#1544](https://github.com/symfony/maker-bundle/pull/1544) [make:webhook] phpstan types and single quotes - *@seb-jean*
+- [#1546](https://github.com/symfony/maker-bundle/pull/1546) [make:message] phpstan types - *@seb-jean*
+- [#1545](https://github.com/symfony/maker-bundle/pull/1545) 1545 [make:crud] use getString() instead of get() for csrf token - *@seb-jean*
+- [#1568](https://github.com/symfony/maker-bundle/pull/1568) [make:schedule] Add transport name for attribute - *@NicolasJourdan* 
+- [#1574](https://github.com/symfony/maker-bundle/pull/1547) [make:validator] phpstan types - *@seb-jean*
+
+### Bug
+
+- [#1496](https://github.com/symfony/maker-bundle/pull/1496) [make:entity] confirm to allow non-ascii char's in entity names - *@Fan2Shrek*
+- [#1533](https://github.com/symfony/maker-bundle/pull/1533) make:security:form-login] fix remember me label - *@jrushlow*
+- [#1535](https://github.com/symfony/maker-bundle/pull/1535) [make:entity] Update ux-turbo package name to have proper suggestion - *@nfragnet*
+- [#1559](https://github.com/symfony/maker-bundle/pull/1559) [make:entity] fix indentation in broadcast_twig_template.tpl.php - *@seb-jean*
+- [#1569](https://github.com/symfony/maker-bundle/pull/1569) Fix generated twig file location - *@IndraGunawan*
+
 ## [v1.59.1](https://github.com/symfony/maker-bundle/releases/tag/v1.59.1)
 
 *May 5th, 2024*


### PR DESCRIPTION
## [v1.60.0](https://github.com/symfony/maker-bundle/releases/tag/v1.60.0)

*June 10th, 2024*

### Feature

- [#1534](https://github.com/symfony/maker-bundle/pull/1534) [make:entity] add enum support - *@loicsapone*
- [#1543](https://github.com/symfony/maker-bundle/pull/1543) [dx] make it easier to use tooling for devs - *@jrushlow*
- [#1544](https://github.com/symfony/maker-bundle/pull/1544) [make:webhook] phpstan types and single quotes - *@seb-jean*
- [#1546](https://github.com/symfony/maker-bundle/pull/1546) [make:message] phpstan types - *@seb-jean*
- [#1545](https://github.com/symfony/maker-bundle/pull/1545) 1545 [make:crud] use getString() instead of get() for csrf token - *@seb-jean*
- [#1568](https://github.com/symfony/maker-bundle/pull/1568) [make:schedule] Add transport name for attribute - *@NicolasJourdan* 
- [#1574](https://github.com/symfony/maker-bundle/pull/1547) [make:validator] phpstan types - *@seb-jean*

### Bug

- [#1496](https://github.com/symfony/maker-bundle/pull/1496) [make:entity] confirm to allow non-ascii char's in entity names - *@Fan2Shrek*
- [#1533](https://github.com/symfony/maker-bundle/pull/1533) make:security:form-login] fix remember me label - *@jrushlow*
- [#1535](https://github.com/symfony/maker-bundle/pull/1535) [make:entity] Update ux-turbo package name to have proper suggestion - *@nfragnet*
- [#1559](https://github.com/symfony/maker-bundle/pull/1559) [make:entity] fix indentation in broadcast_twig_template.tpl.php - *@seb-jean*
- [#1569](https://github.com/symfony/maker-bundle/pull/1569) Fix generated twig file location - *@IndraGunawan*
