### PR TITLE
[make:twig-component] Improve `make:twig-component` by reading the configuration file

### DIFF
--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -107,7 +107,7 @@ final class MakeTwigComponent extends AbstractMaker
         if ($this->fileManager->fileExists($path)) {
             $value = Yaml::parse($this->fileManager->getFileContents($path));
 
-            $this->namespace = \substr(\array_key_first($value['twig_component']['defaults']), 4);
+            $this->namespace = substr(array_key_first($value['twig_component']['defaults']), 4);
         }
     }
 }

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -72,7 +72,7 @@ final class MakeTwigComponent extends AbstractMaker
         if ($this->fileManager->fileExists($path)) {
             $value = Yaml::parse($this->fileManager->getFileContents($path));
 
-            $nameSpacePrefix = \array_key_first($value['twig_component']['defaults']);
+            $nameSpacePrefix = \substr(\array_key_first($value['twig_component']['defaults']), 4);
         }
 
         $factory = $generator->createClassNameDetails(

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -115,7 +115,7 @@ final class MakeTwigComponent extends AbstractMaker
             return;
         }
 
-        if (!array_key_exists('twig_component', $value) || !array_key_exists('defaults', $value['twig_component'])) {
+        if (!\array_key_exists('twig_component', $value) || !\array_key_exists('defaults', $value['twig_component'])) {
             return;
         }
 

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -13,12 +13,14 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Yaml\Yaml;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -27,6 +29,10 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
  */
 final class MakeTwigComponent extends AbstractMaker
 {
+    public function __construct(private FileManager $fileManager)
+    {
+    }
+
     public static function getCommandName(): string
     {
         return 'make:twig-component';
@@ -60,9 +66,18 @@ final class MakeTwigComponent extends AbstractMaker
             throw new \RuntimeException('You must install symfony/ux-live-component to create a live component (composer require symfony/ux-live-component)');
         }
 
+        $path = 'config/packages/twig_component.yaml';
+        $nameSpacePrefix = 'Twig\\Components';
+
+        if ($this->fileManager->fileExists($path)) {
+            $value = Yaml::parse($this->fileManager->getFileContents($path));
+
+            $nameSpacePrefix = \array_key_first($value['twig_component']['defaults']);
+        }
+
         $factory = $generator->createClassNameDetails(
             $name,
-            'Twig\\Components',
+            $nameSpacePrefix,
         );
 
         $templatePath = str_replace('\\', '/', $factory->getRelativeNameWithoutSuffix());

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -111,14 +111,9 @@ final class MakeTwigComponent extends AbstractMaker
 
         try {
             $value = Yaml::parse($this->fileManager->getFileContents($path));
-        } catch (ParseException $e) {
+            $this->namespace = substr(array_key_first($value['twig_component']['defaults']), 4);
+        } catch (\Throwable) {
             return;
         }
-
-        if (!\array_key_exists('twig_component', $value) || !\array_key_exists('defaults', $value['twig_component'])) {
-            return;
-        }
-
-        $this->namespace = substr(array_key_first($value['twig_component']['defaults']), 4);
     }
 }

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -104,10 +105,20 @@ final class MakeTwigComponent extends AbstractMaker
 
         $path = 'config/packages/twig_component.yaml';
 
-        if ($this->fileManager->fileExists($path)) {
-            $value = Yaml::parse($this->fileManager->getFileContents($path));
-
-            $this->namespace = substr(array_key_first($value['twig_component']['defaults']), 4);
+        if (!$this->fileManager->fileExists($path)) {
+            return;
         }
+
+        try {
+            $value = Yaml::parse($this->fileManager->getFileContents($path));
+        } catch (ParseException $e) {
+            return;
+        }
+
+        if (!array_key_exists('twig_component', $value) || !array_key_exists('defaults', $value['twig_component'])) {
+            return;
+        }
+
+        $this->namespace = substr(array_key_first($value['twig_component']['defaults']), 4);
     }
 }

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
@@ -105,14 +106,14 @@ final class MakeTwigComponent extends AbstractMaker
         $path = 'config/packages/twig_component.yaml';
 
         if (!$this->fileManager->fileExists($path)) {
-            return;
+            throw new RuntimeCommandException(message: 'Unable to find twig_components.yaml');
         }
 
         try {
             $value = Yaml::parse($this->fileManager->getFileContents($path));
             $this->namespace = substr(array_key_first($value['twig_component']['defaults']), 4);
-        } catch (\Throwable) {
-            return;
+        } catch (\Throwable $throwable) {
+            throw new RuntimeCommandException(message: 'Unable to parse twig_components.yaml', previous: $throwable);
         }
     }
 }

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
@@ -29,6 +30,8 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
  */
 final class MakeTwigComponent extends AbstractMaker
 {
+    private string $namespace = 'Twig\\Components';
+
     public function __construct(private FileManager $fileManager)
     {
     }
@@ -66,18 +69,9 @@ final class MakeTwigComponent extends AbstractMaker
             throw new \RuntimeException('You must install symfony/ux-live-component to create a live component (composer require symfony/ux-live-component)');
         }
 
-        $path = 'config/packages/twig_component.yaml';
-        $nameSpacePrefix = 'Twig\\Components';
-
-        if ($this->fileManager->fileExists($path)) {
-            $value = Yaml::parse($this->fileManager->getFileContents($path));
-
-            $nameSpacePrefix = \substr(\array_key_first($value['twig_component']['defaults']), 4);
-        }
-
         $factory = $generator->createClassNameDetails(
             $name,
-            $nameSpacePrefix,
+            $this->namespace,
         );
 
         $templatePath = str_replace('\\', '/', $factory->getRelativeNameWithoutSuffix());
@@ -107,6 +101,14 @@ final class MakeTwigComponent extends AbstractMaker
     {
         if (!$input->getOption('live')) {
             $input->setOption('live', $io->confirm('Make this a live component?', false));
+        }
+
+        $path = 'config/packages/twig_component.yaml';
+
+        if ($this->fileManager->fileExists($path)) {
+            $value = Yaml::parse($this->fileManager->getFileContents($path));
+
+            $this->namespace = \substr(\array_key_first($value['twig_component']['defaults']), 4);
         }
     }
 }

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -22,6 +22,7 @@
 
             <service id="maker.maker.make_twig_component" class="Symfony\Bundle\MakerBundle\Maker\MakeTwigComponent">
                 <tag name="maker.command" />
+                <argument type="service" id="maker.file_manager" />
             </service>
 
             <service id="maker.maker.make_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeController">

--- a/tests/Maker/MakeTwigComponentTest.php
+++ b/tests/Maker/MakeTwigComponentTest.php
@@ -47,7 +47,7 @@ class MakeTwigComponentTest extends MakerTestCase
                 $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
 
                 $runner->copy(
-                    'make-twig-component/tests/custom_twig_component.yaml',
+                    'make-twig-component/custom_twig_component.yaml',
                     'config/packages/twig_component.yaml'
                 );
                 $runner->copy(

--- a/tests/Maker/MakeTwigComponentTest.php
+++ b/tests/Maker/MakeTwigComponentTest.php
@@ -40,16 +40,17 @@ class MakeTwigComponentTest extends MakerTestCase
         yield 'it_generates_twig_component_in_non_default_namespace' => [$this->createMakerTest()
             ->addExtraDependencies('symfony/ux-twig-component', 'symfony/twig-bundle')
             ->run(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-twig-component/custom_twig_component.yaml',
+                    'config/packages/twig_component.yaml'
+                );
+
                 $output = $runner->runMaker(['Alert']);
 
                 $this->assertStringContainsString('src/Site/Twig/Components/Alert.php', $output);
                 $this->assertStringContainsString('templates/components/Alert.html.twig', $output);
                 $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
 
-                $runner->copy(
-                    'make-twig-component/custom_twig_component.yaml',
-                    'config/packages/twig_component.yaml'
-                );
                 $runner->copy(
                     'make-twig-component/tests/it_generates_twig_component.php',
                     'tests/GeneratedTwigComponentTest.php'

--- a/tests/Maker/MakeTwigComponentTest.php
+++ b/tests/Maker/MakeTwigComponentTest.php
@@ -37,6 +37,28 @@ class MakeTwigComponentTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_twig_component_in_non_default_namespace' => [$this->createMakerTest()
+            ->addExtraDependencies('symfony/ux-twig-component', 'symfony/twig-bundle')
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker(['Alert']);
+
+                $this->assertStringContainsString('src/Site/Twig/Components/Alert.php', $output);
+                $this->assertStringContainsString('templates/components/Alert.html.twig', $output);
+                $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
+
+                $runner->copy(
+                    'make-twig-component/tests/custom_twig_component.yaml',
+                    'config/packages/twig_component.yaml'
+                );
+                $runner->copy(
+                    'make-twig-component/tests/it_generates_twig_component.php',
+                    'tests/GeneratedTwigComponentTest.php'
+                );
+                $runner->replaceInFile('tests/GeneratedTwigComponentTest.php', '{name}', 'Alert');
+                $runner->runTests();
+            }),
+        ];
+
         yield 'it_generates_pascal_case_twig_component' => [$this->createMakerTest()
             ->addExtraDependencies('symfony/ux-twig-component', 'symfony/twig-bundle')
             ->run(function (MakerTestRunner $runner) {

--- a/tests/fixtures/make-twig-component/custom_twig_component.yaml
+++ b/tests/fixtures/make-twig-component/custom_twig_component.yaml
@@ -1,0 +1,5 @@
+twig_component:
+    anonymous_template_directory: 'components/'
+    defaults:
+        # Namespace & directory for components
+        App\Site\Twig\Components\: 'components/'


### PR DESCRIPTION
Small change in the way `make:twig-component` works when determining the namespace of the class to create.

In before, the namespace was hard coded. This is still good, but in cases where your Twig Component class namespace may have changed (i.e. your website is divided into `src/Admin` and `src/Site` and you've modified your `twig_component.yaml` so that your TwigComponents live under `src/Site/Twig/Components`), the component class would be still created under `src/Twig/Components`.

I've improved the command to read this config and automatically create the component under the first entry in this file. If no config is found, then we can use the old default.

TODOS:
- [x] Can a test be made with a special config file?