### PR TITLE
[make:event] Add command for making Event class

### DIFF
--- a/src/Maker/MakeEvent.php
+++ b/src/Maker/MakeEvent.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
-use DateTime;
-use DateTimeImmutable;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
@@ -24,7 +22,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Contracts\EventDispatcher\Event;
-use function in_array;
 
 /**
  * @author Ippei Sumida <ippey.s@gmail.com>
@@ -89,7 +86,7 @@ class MakeEvent extends AbstractMaker
             };
             if (
                 $useClass
-                && !in_array($useClass, $useClasses, true)
+                && !\in_array($useClass, $useClasses, true)
             ) {
                 $useClasses[] = $useClass;
             }
@@ -127,7 +124,7 @@ class MakeEvent extends AbstractMaker
         }
 
         $question = new Question('Field type (e.g. <fg=yellow>string</>)', 'string');
-        $autocompleteValues = ['string', 'int', 'float', 'bool', 'array', 'object', 'callable', 'iterable', 'void', DateTime::class, DateTimeImmutable::class];
+        $autocompleteValues = ['string', 'int', 'float', 'bool', 'array', 'object', 'callable', 'iterable', 'void', \DateTime::class, \DateTimeImmutable::class];
         $autocompleteValues = array_merge($autocompleteValues, $this->doctrineHelper->getEntitiesForAutocomplete());
         $question->setAutocompleterValues($autocompleteValues);
         $question->setValidator([Validator::class, 'notBlank']);

--- a/src/Maker/MakeEvent.php
+++ b/src/Maker/MakeEvent.php
@@ -13,12 +13,14 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -26,6 +28,11 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class MakeEvent extends AbstractMaker
 {
+    public function __construct(
+        private readonly DoctrineHelper $doctrineHelper,
+    ) {
+    }
+
     public static function getCommandName(): string
     {
         return 'make:event';
@@ -63,11 +70,30 @@ class MakeEvent extends AbstractMaker
             'Event'
         );
 
+        $fields = [];
+        $useClasses = [];
+        while (true) {
+            $newField = $this->askForNextField($io);
+            if (null === $newField) {
+                break;
+            }
+            $fields[] = $newField;
+            if (
+                class_exists($this->doctrineHelper->getEntityNamespace().'\\'.$newField['type'])
+                && !\in_array($this->doctrineHelper->getEntityNamespace().'\\'.$newField['type'], $useClasses, true)
+            ) {
+                $useClasses[] = $this->doctrineHelper->getEntityNamespace().'\\'.$newField['type'];
+            }
+        }
+
+        asort($useClasses);
         $generator->generateClass(
             $eventClassNameDetails->getFullName(),
             'event/Event.tpl.php',
             [
                 'event_class_name' => $eventClassNameDetails->getShortName(),
+                'fields' => $fields,
+                'useClasses' => $useClasses,
             ]
         );
 
@@ -79,5 +105,31 @@ class MakeEvent extends AbstractMaker
             'Next: Open your event and add your logic.',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/event_dispatcher.html</>',
         ]);
+    }
+
+    /**
+     * @return array{'name': string, 'type': string, 'nullable': bool}|null
+     */
+    public function askForNextField(ConsoleStyle $io): ?array
+    {
+        $fieldName = $io->ask('Field name (press <fg=yellow>enter</> to stop adding fields)', null);
+        if (null === $fieldName) {
+            return null;
+        }
+
+        $question = new Question('Field type (e.g. <fg=yellow>string</>)', 'string');
+        $autocompleteValues = ['string', 'int', 'float', 'bool', 'array', 'object', 'callable', 'iterable', 'void'];
+        $autocompleteValues = array_merge($autocompleteValues, $this->doctrineHelper->getEntitiesForAutocomplete());
+        $question->setAutocompleterValues($autocompleteValues);
+        $question->setValidator([Validator::class, 'notBlank']);
+        $fieldType = $io->askQuestion($question);
+
+        $nullable = $io->confirm('Can this field be null (nullable)', false);
+
+        return [
+            'name' => $fieldName,
+            'type' => $fieldType,
+            'nullable' => $nullable,
+        ];
     }
 }

--- a/src/Maker/MakeEvent.php
+++ b/src/Maker/MakeEvent.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Ippei Sumida <ippey.s@gmail.com>
+ */
+class MakeEvent extends AbstractMaker
+{
+    public static function getCommandName(): string
+    {
+        return 'make:event';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Create a event class.';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    {
+        $command
+            ->addArgument('name', InputArgument::OPTIONAL, 'The name of the event class (e.g. <fg=yellow>OrderPlacedEvent</>)')
+            ->setHelp(file_get_contents(__DIR__.'/../Resources/help/MakeEvent.txt'))
+        ;
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies)
+    {
+        $dependencies
+            ->addClassDependency(Event::class, 'event-dispatcher')
+        ;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    {
+        $eventClassNameDetails = $generator->createClassNameDetails(
+            $input->getArgument('name'),
+            'Event\\',
+            'Event'
+        );
+
+        $generator->generateClass(
+            $eventClassNameDetails->getFullName(),
+            'event/Event.tpl.php',
+            [
+                'event_class_name' => $eventClassNameDetails->getShortName(),
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text([
+            'Next: Open your event and add your logic.',
+            'Find the documentation at <fg=yellow>https://symfony.com/doc/current/event_dispatcher.html</>',
+        ]);
+    }
+}

--- a/src/Maker/MakeEvent.php
+++ b/src/Maker/MakeEvent.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -52,8 +53,12 @@ class MakeEvent extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
+        $name = $input->getArgument('name');
+        if (null === $name) {
+            $name = $io->ask('Event class name (e.g. <fg=yellow>OrderPlacedEvent</>)', null, [Validator::class, 'notBlank']);
+        }
         $eventClassNameDetails = $generator->createClassNameDetails(
-            $input->getArgument('name'),
+            $name,
             'Event\\',
             'Event'
         );

--- a/src/Maker/MakeEvent.php
+++ b/src/Maker/MakeEvent.php
@@ -36,7 +36,7 @@ class MakeEvent extends AbstractMaker
         return 'Create a event class.';
     }
 
-    public function configureCommand(Command $command, InputConfiguration $inputConfig)
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the event class (e.g. <fg=yellow>OrderPlacedEvent</>)')
@@ -44,14 +44,14 @@ class MakeEvent extends AbstractMaker
         ;
     }
 
-    public function configureDependencies(DependencyBuilder $dependencies)
+    public function configureDependencies(DependencyBuilder $dependencies): void
     {
         $dependencies
             ->addClassDependency(Event::class, 'event-dispatcher')
         ;
     }
 
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $name = $input->getArgument('name');
         if (null === $name) {

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -171,8 +171,7 @@
                 <tag name="maker.command" />
             </service>
             <service id="maker.maker.make_event" class="Symfony\Bundle\MakerBundle\Maker\MakeEvent">
-                <argument type="service" id="maker.file_manager" />
-                <argument type="service" id="maker.generator" />
+                <argument type="service" id="maker.doctrine_helper" />
                 <tag name="maker.command" />
             </service>
         </services>

--- a/src/Resources/config/makers.xml
+++ b/src/Resources/config/makers.xml
@@ -170,5 +170,10 @@
                 <argument type="service" id="maker.generator" />
                 <tag name="maker.command" />
             </service>
+            <service id="maker.maker.make_event" class="Symfony\Bundle\MakerBundle\Maker\MakeEvent">
+                <argument type="service" id="maker.file_manager" />
+                <argument type="service" id="maker.generator" />
+                <tag name="maker.command" />
+            </service>
         </services>
 </container>

--- a/src/Resources/help/MakeEvent.txt
+++ b/src/Resources/help/MakeEvent.txt
@@ -1,0 +1,5 @@
+The <info>%command.name%</info> command generates a new event:
+
+<info>php %command.full_name% OrderPlacedEvent</info>
+
+If the argument is missing, the command will ask for the class name interactively.

--- a/src/Resources/skeleton/event/Event.tpl.php
+++ b/src/Resources/skeleton/event/Event.tpl.php
@@ -11,7 +11,7 @@ final class <?= $class_name ?> extends Event
 {
     public function __construct(
     <?php foreach ($fields as $field): ?>
-        public readonly <?php if ($field['nullable']): ?>?<?php endif; ?><?= $field['type'] ?> $<?= $field['name'] ?>,
+        <?= $field['visibility'] ?> readonly <?php if ($field['nullable']): ?>?<?php endif; ?><?= $field['type'] ?> $<?= $field['name'] ?>,
     <?php endforeach; ?>
     ) {}
 }

--- a/src/Resources/skeleton/event/Event.tpl.php
+++ b/src/Resources/skeleton/event/Event.tpl.php
@@ -3,8 +3,15 @@
 namespace <?= $namespace; ?>;
 
 use Symfony\Contracts\EventDispatcher\Event;
+<?php foreach ($useClasses as $useClass): ?>
+use <?= $useClass; ?>;
+<?php endforeach; ?>
 
 final class <?= $class_name ?> extends Event
 {
-    public function __construct() {}
+    public function __construct(
+    <?php foreach ($fields as $field): ?>
+        public readonly <?php if ($field['nullable']): ?>?<?php endif; ?><?= $field['type'] ?> $<?= $field['name'] ?>,
+    <?php endforeach; ?>
+    ) {}
 }

--- a/src/Resources/skeleton/event/Event.tpl.php
+++ b/src/Resources/skeleton/event/Event.tpl.php
@@ -1,0 +1,10 @@
+<?= "<?php\n" ?>
+
+namespace <?= $namespace; ?>;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class <?= $class_name ?> extends Event
+{
+    public function __construct() {}
+}

--- a/tests/Maker/MakeEventTest.php
+++ b/tests/Maker/MakeEventTest.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 class MakeEventTest extends MakerTestCase
 {
     private const EXPECTED_EVENT_PATH = __DIR__.'/../../tests/fixtures/make-event/tests/Event/';
+
     protected function getMakerClass(): string
     {
         return MakeEvent::class;

--- a/tests/Maker/MakeEventTest.php
+++ b/tests/Maker/MakeEventTest.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 
 class MakeEventTest extends MakerTestCase
 {
+    private const EXPECTED_EVENT_PATH = __DIR__.'/../../tests/fixtures/make-event/tests/Event/';
     protected function getMakerClass(): string
     {
         return MakeEvent::class;
@@ -30,7 +31,25 @@ class MakeEventTest extends MakerTestCase
                     [
                         // event class name
                         'FooEvent',
+                        // first property name
+                        'id',
+                        // first property type
+                        'int',
+                        // first property nullable
+                        'no',
+                        // second property name
+                        'name',
+                        // second property type
+                        'string',
+                        // second property nullable
+                        'yes',
+                        '',
                     ]
+                );
+
+                self::assertFileEquals(
+                    self::EXPECTED_EVENT_PATH.'FooEvent.php',
+                    $runner->getPath('src/Event/FooEvent.php')
                 );
             }),
         ];

--- a/tests/Maker/MakeEventTest.php
+++ b/tests/Maker/MakeEventTest.php
@@ -36,14 +36,26 @@ class MakeEventTest extends MakerTestCase
                         'id',
                         // first property type
                         'int',
+                        // first property visibility
+                        'public',
                         // first property nullable
                         'no',
                         // second property name
                         'name',
                         // second property type
                         'string',
+                        // second property visibility
+                        'private',
                         // second property nullable
                         'yes',
+                        // third property name
+                        'createdAt',
+                        // third property type
+                        'DateTimeInterface',
+                        // third property visibility
+                        'protected',
+                        // third property nullable
+                        'no',
                         '',
                     ]
                 );

--- a/tests/Maker/MakeEventTest.php
+++ b/tests/Maker/MakeEventTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeEvent;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+
+class MakeEventTest extends MakerTestCase
+{
+    protected function getMakerClass(): string
+    {
+        return MakeEvent::class;
+    }
+
+    public function getTestDetails(): \Generator
+    {
+        yield 'it_makes_event' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // event class name
+                        'FooEvent',
+                    ]
+                );
+            }),
+        ];
+    }
+}

--- a/tests/fixtures/make-event/tests/Event/FooEvent.php
+++ b/tests/fixtures/make-event/tests/Event/FooEvent.php
@@ -8,7 +8,8 @@ final class FooEvent extends Event
 {
     public function __construct(
         public readonly int $id,
-        public readonly ?string $name,
+        private readonly ?string $name,
+        protected readonly DateTimeInterface $createdAt,
     ) {
     }
 }

--- a/tests/fixtures/make-event/tests/Event/FooEvent.php
+++ b/tests/fixtures/make-event/tests/Event/FooEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class FooEvent extends Event
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly ?string $name,
+    ) {
+    }
+}


### PR DESCRIPTION
I think adding "make:event" that makes `Event` class is good, although that is a small feature.
So, I wrote a simple make command.

```
php bin/console make:event


 The name of the event class (e.g. OrderPlacedEvent):
 > ItemCreatedEvent

 Field name (press enter to stop adding fields):
 > id

 Field type (e.g. string) [string]:
 > int

 Field visibility (public, protected, private) [public]:
  [0] public
  [1] private
  [2] protected
 > public

 Can this field be null (nullable) (yes/no) [no]:
 > no

 Field name (press enter to stop adding fields):
 > 
```

It makes bellow

```php
<?php

namespace App\Event;

use Symfony\Contracts\EventDispatcher\Event;

final class ItemCreatedEvent extends Event
{
    public function __construct(
        public readonly int $id,
    ) {
    }
}
```