### PR TITLE
[ci] allow template linter tests on OSX (Darwin)

### DIFF
--- a/src/Util/TemplateLinter.php
+++ b/src/Util/TemplateLinter.php
@@ -59,7 +59,7 @@ final class TemplateLinter
             $templateFilePath = [$templateFilePath];
         }
 
-        $isWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
+        $isWindows = \defined('PHP_WINDOWS_VERSION_MAJOR');
         $ignoreEnv = $isWindows ? 'set PHP_CS_FIXER_IGNORE_ENV=1& ' : 'PHP_CS_FIXER_IGNORE_ENV=1 ';
 
         $cmdPrefix = $this->needsPhpCmdPrefix ? 'php ' : '';

--- a/src/Util/TemplateLinter.php
+++ b/src/Util/TemplateLinter.php
@@ -59,7 +59,8 @@ final class TemplateLinter
             $templateFilePath = [$templateFilePath];
         }
 
-        $ignoreEnv = str_starts_with(strtolower(\PHP_OS), 'win') ? 'set PHP_CS_FIXER_IGNORE_ENV=1& ' : 'PHP_CS_FIXER_IGNORE_ENV=1 ';
+        $isWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
+        $ignoreEnv = $isWindows ? 'set PHP_CS_FIXER_IGNORE_ENV=1& ' : 'PHP_CS_FIXER_IGNORE_ENV=1 ';
 
         $cmdPrefix = $this->needsPhpCmdPrefix ? 'php ' : '';
 

--- a/tests/Util/TemplateLinterTest.php
+++ b/tests/Util/TemplateLinterTest.php
@@ -40,9 +40,7 @@ final class TemplateLinterTest extends TestCase
 
     public function testPhpCsFixerVersion(): void
     {
-        if (str_contains(strtolower(\PHP_OS), 'win')) {
-            $this->markTestSkipped('Test only runs on linux.');
-        }
+        $this->markTestSkippedOnWindows();
 
         $fixerPath = sprintf('%s/src/Resources/bin/php-cs-fixer-v%s.phar', \dirname(__DIR__, 2), TemplateLinter::BUNDLED_PHP_CS_FIXER_VERSION);
 
@@ -51,5 +49,14 @@ final class TemplateLinterTest extends TestCase
         $process->run();
 
         self::assertStringContainsString(TemplateLinter::BUNDLED_PHP_CS_FIXER_VERSION, $process->getOutput());
+    }
+
+    private function markTestSkippedOnWindows(): void
+    {
+        $isOnWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
+
+        if ($isOnWindows) {
+            $this->markTestSkipped('Test only runs on linux.');
+        }
     }
 }

--- a/tests/Util/TemplateLinterTest.php
+++ b/tests/Util/TemplateLinterTest.php
@@ -53,7 +53,7 @@ final class TemplateLinterTest extends TestCase
 
     private function markTestSkippedOnWindows(): void
     {
-        $isOnWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
+        $isOnWindows = \defined('PHP_WINDOWS_VERSION_MAJOR');
 
         if ($isOnWindows) {
             $this->markTestSkipped('Test only runs on linux.');


### PR DESCRIPTION
See https://github.com/symfony/maker-bundle/pull/1429/files#r1653262959.

---
Edited by @jrushlow

Uses the `PHP_WINDOWS_VERSION_MAJOR` constant to determine if the OS is Windows based. Rather than doing a string `win` comparison with `\PHP_OS`. The `PHP_WINDOWS_VERSION_*` constants are only available in the Windows environment. https://www.php.net/manual/en/info.constants.php#constant.php-windows-version-major

Linter tests are still skipped on windows based CI.