### PR TITLE
[make:entity] fix creating wrong type when a class name is specified as an argument

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -123,8 +123,6 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             return;
         }
 
-        $this->checkIsUsingUid($input);
-
         $argument = $command->getDefinition()->getArgument('name');
         $question = $this->createEntityClassQuestion($argument->getDescription());
         $entityClassName ??= $io->askQuestion($question);
@@ -171,6 +169,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        $this->checkIsUsingUid($input);
         $overwrite = $input->getOption('overwrite');
 
         // the regenerate option has entirely custom behavior

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -161,6 +161,24 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_creates_a_new_class_with_uuid_and_class_name' => [$this->createMakeEntityTest()
+            ->addExtraDependencies('symfony/uid')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker([
+                    // add not additional fields
+                    '',
+                ], 'User --with-uuid');
+
+                $this->assertFileExists($runner->getPath('src/Entity/User.php'));
+
+                $content = file_get_contents($runner->getPath('src/Entity/User.php'));
+                $this->assertStringContainsString('use Symfony\Component\Uid\Uuid;', $content);
+                $this->assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.uuid_generator\')]', $content);
+
+                $this->runEntityTest($runner);
+            }),
+        ];
+
         yield 'it_creates_a_new_class_with_ulid' => [$this->createMakeEntityTest()
             ->addExtraDependencies('symfony/uid')
             ->run(function (MakerTestRunner $runner) {


### PR DESCRIPTION
related #1577 

`make:entity` generated `id` property as an int type when a class name is specified as an argument.
So, I adjusted `checkIsUsingUid()` call timing.
