### PR TITLE
[make:listener] Match event name against active events class/id

### DIFF
--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -100,6 +101,33 @@ final class MakeListener extends AbstractMaker
             $question->setAutocompleterValues($events);
             $question->setValidator(Validator::notBlank(...));
             $event = $io->askQuestion($question);
+            $input->setArgument('event', $event);
+        }
+
+        $event = $input->getArgument('event');
+        if (null === $this->getEventConstant($event) && null === $this->eventRegistry->getEventClassName($event)) {
+            $eventList = $this->eventRegistry->getAllActiveEvents();
+            $eventFQCNList = array_filter(array_map($this->eventRegistry->getEventClassName(...), $eventList), fn ($eventFQCN) => \is_string($eventFQCN));
+            $eventIdAndFQCNList = array_unique(array_merge($eventList, $eventFQCNList));
+            $suggestionList = [];
+            foreach ($eventIdAndFQCNList as $eventSuggestion) {
+                if (levenshtein($event, Str::getShortClassName($eventSuggestion)) < 3) {
+                    $suggestionList[] = $eventSuggestion;
+                }
+            }
+            if (!$suggestionList) {
+                return;
+            }
+            if (1 === \count($suggestionList)) {
+                $question = new ConfirmationQuestion(sprintf('<fg=green>Did you mean</> <fg=yellow>"%s"</> <fg=green>?</>', $suggestionList[0]), false);
+                $event = $io->askQuestion($question) ? $suggestionList[0] : $event;
+            } else {
+                $io->writeln(' <fg=yellow>Did you mean one of these events?</>');
+                $io->listing($suggestionList);
+                $question = new Question(sprintf(' <fg=green>%s</>', $command->getDefinition()->getArgument('event')->getDescription()), $event);
+                $question->setAutocompleterValues(array_merge($suggestionList, [$event]));
+                $event = $io->askQuestion($question);
+            }
             $input->setArgument('event', $event);
         }
     }

--- a/tests/Maker/MakeListenerTest.php
+++ b/tests/Maker/MakeListenerTest.php
@@ -167,6 +167,82 @@ class MakeListenerTest extends MakerTestCase
                 );
             }),
         ];
+
+        yield 'it_makes_listener_for_known_event_by_id' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'FooListener',
+                        // event name
+                        'kernel.request',
+                        // accept the suggestion
+                        'y',
+                    ]
+                );
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'FooListener.php',
+                    $runner->getPath('src/EventListener/FooListener.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_known_event_by_short_class_name' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'BarListener',
+                        // event name
+                        'RequestEvent',
+                        // accept the suggestion
+                        'y',
+                    ]
+                );
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'BarListener.php',
+                    $runner->getPath('src/EventListener/BarListener.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_known_event_by_id_with_2_letters_typo' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'FooListener',
+                        // event name
+                        'kernem.reques',
+                        // accept the suggestion
+                        'y',
+                    ]
+                );
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'FooListener.php',
+                    $runner->getPath('src/EventListener/FooListener.php')
+                );
+            }),
+        ];
+
+        yield 'it_makes_listener_for_known_event_by_short_class_name_with_2_letters_typo' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        // listener name
+                        'BarListener',
+                        // event name
+                        'RequstEveny',
+                        // accept the suggestion
+                        'y',
+                    ]
+                );
+                self::assertFileEquals(
+                    self::EXPECTED_LISTENER_PATH.'BarListener.php',
+                    $runner->getPath('src/EventListener/BarListener.php')
+                );
+            }),
+        ];
     }
 
     protected function getMakerClass(): string

--- a/tests/fixtures/make-listener/tests/EventListener/BarListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/BarListener.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+final class BarListener
+{
+    #[AsEventListener(event: RequestEvent::class)]
+    public function onRequestEvent(RequestEvent $event): void
+    {
+        // ...
+    }
+}


### PR DESCRIPTION
Closes #1410 

## Description

The goal of this PR is to simplify the usage of the `make:listener` command by adding the following features to the event input :

- Matching of the event name to existing events FQCN.
- Typo detection (using levenshtein distance).

## Example

Matching on class short name :

![image](https://github.com/symfony/maker-bundle/assets/11990607/b48158da-ab26-4a52-a1c7-4d234b837a7d)

Matching on class short name when multiple events match : 

![image](https://github.com/symfony/maker-bundle/assets/11990607/6f2601cf-e362-4d1e-99d6-afc73c83f06a)

Typo detection : 

![image](https://github.com/symfony/maker-bundle/assets/11990607/b697be0e-5621-4b58-bf61-cbf464661cf4)

