### PR TITLE
[make:crud] Remove `/` from from index action URL

### DIFF
--- a/src/Resources/skeleton/crud/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/crud/controller/Controller.tpl.php
@@ -7,7 +7,7 @@ namespace <?= $class_data->getNamespace() ?>;
 #[Route('<?= $route_path ?>')]
 <?= $class_data->getClassDeclaration() ?>
 {
-<?= $generator->generateRouteForControllerMethod('/', sprintf('%s_index', $route_name), ['GET']) ?>
+<?= $generator->generateRouteForControllerMethod('', sprintf('%s_index', $route_name), ['GET']) ?>
 <?php if (isset($repository_full_class_name)): ?>
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>): Response
     {

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -27,6 +27,7 @@ namespace <?= $namespace ?>;
 
     public function testIndex(): void
     {
+        $this->client->followRedirects();
         $crawler = $this->client->request('GET', $this->path);
 
         self::assertResponseStatusCodeSame(200);

--- a/src/Util/TemplateComponentGenerator.php
+++ b/src/Util/TemplateComponentGenerator.php
@@ -27,9 +27,16 @@ final class TemplateComponentGenerator
     ) {
     }
 
-    public function generateRouteForControllerMethod(string $routePath, string $routeName, array $methods = [], bool $indent = true, bool $trailingNewLine = true): string
+    /**
+     * @param string|null $routePath passing an empty string/null will create a route attribute without the "path" argument
+     */
+    public function generateRouteForControllerMethod(?string $routePath, string $routeName, array $methods = [], bool $indent = true, bool $trailingNewLine = true): string
     {
-        $attribute = \sprintf('%s#[Route(\'%s\', name: \'%s\'', $indent ? '    ' : null, $routePath, $routeName);
+        if (!empty($routePath)) {
+            $path = \sprintf('\'%s\', ', $routePath);
+        }
+
+        $attribute = \sprintf('%s#[Route(%sname: \'%s\'', $indent ? '    ' : null, $path ?? null, $routeName);
 
         if (!empty($methods)) {
             $attribute .= ', methods: [';

--- a/tests/fixtures/make-crud/expected/WithCustomRepository.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepository.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route('/sweet/food')]
 final class SweetFoodController extends AbstractController
 {
-    #[Route('/', name: 'app_sweet_food_index', methods: ['GET'])]
+    #[Route(name: 'app_sweet_food_index', methods: ['GET'])]
     public function index(SweetFoodRepository $sweetFoodRepository): Response
     {
         return $this->render('sweet_food/index.html.twig', [

--- a/tests/fixtures/make-crud/tests/it_generates_basic_crud.php
+++ b/tests/fixtures/make-crud/tests/it_generates_basic_crud.php
@@ -9,7 +9,7 @@ class GeneratedCrudControllerTest extends WebTestCase
     public function testIndexAction()
     {
         $client = self::createClient();
-        $crawler = $client->request('GET', '/sweet/food/');
+        $crawler = $client->request('GET', '/sweet/food');
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertStringContainsString('<!DOCTYPE html>', $client->getResponse()->getContent());
         $this->assertStringContainsString('SweetFood index', $client->getResponse()->getContent());

--- a/tests/fixtures/make-crud/tests/it_generates_crud_with_custom_controller.php
+++ b/tests/fixtures/make-crud/tests/it_generates_crud_with_custom_controller.php
@@ -9,7 +9,7 @@ class GeneratedCrudControllerTest extends WebTestCase
     public function testIndexAction()
     {
         $client = self::createClient();
-        $crawler = $client->request('GET', '/sweet/food/admin/');
+        $crawler = $client->request('GET', '/sweet/food/admin');
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertStringContainsString('<!DOCTYPE html>', $client->getResponse()->getContent());
         $this->assertStringContainsString('SweetFood index', $client->getResponse()->getContent());

--- a/tests/fixtures/make-crud/tests/it_generates_crud_with_custom_root_namespace.php
+++ b/tests/fixtures/make-crud/tests/it_generates_crud_with_custom_root_namespace.php
@@ -9,7 +9,7 @@ class GeneratedCrudControllerTest extends WebTestCase
     public function testIndexAction()
     {
         $client = self::createClient();
-        $crawler = $client->request('GET', '/sweet/food/');
+        $crawler = $client->request('GET', '/sweet/food');
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertStringContainsString('<!DOCTYPE html>', $client->getResponse()->getContent());
         $this->assertStringContainsString('SweetFood index', $client->getResponse()->getContent());


### PR DESCRIPTION
I propose to remove the `/` from the index action URL because all other URLs in the [src/Resources/skeleton/crud/controller/Controller.tpl.php](https://github.com/seb-jean/maker-bundle/blob/main/src/Resources/skeleton/crud/controller/Controller.tpl.php) file do not end with a `/`. This is more consistent.