### PR TITLE
WIP [ci] disable php windows memory limit

### DIFF
--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -43,6 +43,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php-versions }}
                   extensions: pdo, pdo_sqlite
+                  ini-values: memory_limit=-1
 
             - name: Composer Install
               uses: "ramsey/composer-install@v2"


### PR DESCRIPTION
Windows CI Failing 
```
Run vendor/bin/simple-phpunit -v
  vendor/bin/simple-phpunit -v
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    PHPUNIT_FLAGS: -v
    SYMFONY_PHPUNIT_DIR: $HOME/symfony-bridge/.phpunit
    MAKER_SKIP_MERCURE_TEST: 1
    MAKER_SKIP_PANTHER_TEST: 1
    MAKER_DISABLE_FILE_LINKS: 1
    MAKER_ALLOW_DEV_DEPS_IN_APP: 0
    SYMFONY_VERSION: 7.0.x-dev
    OPENSSL_CONF: C:\Program Files\Common Files\SSL\openssl.cnf
    COMPOSER_PROCESS_TIMEOUT: 0
    COMPOSER_NO_INTERACTION: 1
    COMPOSER_NO_AUDIT: 1
    CACHE_RESTORE_KEY: Windows-php-8.2.23-composer---no-scripts---working-dir=tools/twigcs-locked-

VirtualAlloc() failed: [0x000005af] The paging file is too small for this operation to complete
PHP Fatal error:  Out of memory (allocated 35141976064 bytes) (tried to allocate 262144 bytes) in D:\a\maker-bundle\maker-bundle\vendor\symfony\dependency-injection\ContainerBuilder.php on line 1756
Error: Process completed with exit code 1.
```