### PR TITLE
[make:controller] generate final controller class

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -83,12 +83,15 @@ class Generator
      *
      * @param string $templateName Template name in Resources/skeleton to use
      * @param array  $variables    Array of variables to pass to the template
+     * @param bool   $isController Set to true if generating a Controller that needs
+     *                             access to the TemplateComponentGenerator ("generator") in
+     *                             the twig template. e.g. to create route attributes on the index method
      *
      * @return string The path where the file will be created
      *
      * @throws \Exception
      */
-    final public function generateClassFromClassData(ClassData $classData, string $templateName, array $variables = []): string
+    final public function generateClassFromClassData(ClassData $classData, string $templateName, array $variables = [], bool $isController = false): string
     {
         $classData = $this->templateComponentGenerator->configureClass($classData);
         $targetPath = $this->fileManager->getRelativePathForFutureClass($classData->getFullClassName());
@@ -97,11 +100,13 @@ class Generator
             throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "\\My\\Full\\Namespace\\%s"', $classData->getFullClassName(), $classData->getClassName()));
         }
 
-        $variables = array_merge($variables, [
-            'class_data' => $classData,
-        ]);
+        $globalTemplateVars = ['class_data' => $classData];
 
-        $this->addOperation($targetPath, $templateName, $variables);
+        if ($isController) {
+            $globalTemplateVars['generator'] = $this->templateComponentGenerator;
+        }
+
+        $this->addOperation($targetPath, $templateName, array_merge($variables, $globalTemplateVars));
 
         return $targetPath;
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -85,7 +85,7 @@ class Generator
      * @param array  $variables    Array of variables to pass to the template
      * @param bool   $isController Set to true if generating a Controller that needs
      *                             access to the TemplateComponentGenerator ("generator") in
-     *                             the twig template. e.g. to create route attributes on the index method
+     *                             the twig template. e.g. to create route attributes for a route method
      *
      * @return string The path where the file will be created
      *

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -93,21 +93,29 @@ final class MakeController extends AbstractMaker
             .($isInvokable ? '.html.twig' : '/index.html.twig')
         ;
 
-        $controllerPath = $generator->generateController(
-            $controllerClassData->getFullClassName(),
-            'controller/Controller.tpl.php',
-            [
-                'class_data' => $controllerClassData,
-                //                'use_statements' => $useStatements,
-                //                'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
-                'route_name' => Str::AsRouteName($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
-                //                'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
-                'method_name' => $isInvokable ? '__invoke' : 'index',
-                'with_template' => $withTemplate,
-                'template_name' => $templateName,
-            ]
-        );
+        $controllerPath = $generator->generateClassFromClassData($controllerClassData, 'controller/Controller.tpl.php', [
+            'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+            'route_name' => Str::AsRouteName($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+            'method_name' => $isInvokable ? '__invoke' : 'index',
+            'with_template' => $withTemplate,
+            'template_name' => $templateName,
+        ], true);
+
+        //        $controllerPath = $generator->generateController(
+        //            $controllerClassData->getFullClassName(),
+        //            'controller/Controller.tpl.php',
+        //            [
+        //                'class_data' => $controllerClassData,
+        //                //                'use_statements' => $useStatements,
+        //                //                'route_path' => Str::asRoutePath($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
+        //                'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+        //                'route_name' => Str::AsRouteName($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+        //                //                'route_name' => Str::asRouteName($controllerClassNameDetails->getRelativeNameWithoutSuffix()),
+        //                'method_name' => $isInvokable ? '__invoke' : 'index',
+        //                'with_template' => $withTemplate,
+        //                'template_name' => $templateName,
+        //            ]
+        //        );
 
         if ($withTemplate) {
             $generator->generateTemplate(

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -77,9 +77,10 @@ final class MakeController extends AbstractMaker
         $isInvokable = (bool) $input->getOption('invokable');
 
         $controllerClass = $input->getArgument('controller-class');
+        $isAbsolute = '\\' === $controllerClass[0];
 
         $controllerClassData = ClassData::create(
-            class: '\\' === $controllerClass[0] ? substr($controllerClass, 1) : \sprintf('Controller\%s', $input->getArgument('controller-class')),
+            class: $isAbsolute ? substr($controllerClass, 1) : \sprintf('Controller\%s', $input->getArgument('controller-class')),
             suffix: 'Controller',
             extendsClass: AbstractController::class,
             useStatements: [
@@ -88,25 +89,9 @@ final class MakeController extends AbstractMaker
             ]
         );
 
-        //        dd([
-        //            $controllerClassNameDetails,
-        //            $controllerClassNameDetails->getRelativeName(),
-        //            $controllerClassNameDetails->getShortName(),
-        //            $controllerClassNameDetails->getFullName(),
-        //            $controllerClassNameDetails->getRelativeNameWithoutSuffix(),
-        //        ],
-        //            [
-        //                $controllerClassData,
-        //                $controllerClassData->getClassName(relative: true),
-        //                $controllerClassData->getClassName(),
-        //                $controllerClassData->getFullClassName(),
-        //                $controllerClassData->getClassName(relative: true, withoutSuffix: true),
-        //            ]
-        //        );
-
-        //        $templateName = Str::asFilePath($controllerClassNameDetails->getRelativeNameWithoutSuffix())
-        $templateName = Str::asFilePath($controllerClassData->getClassName(relative: true, withoutSuffix: true))
-            .($isInvokable ? '.html.twig' : '/index.html.twig');
+        $templateName = Str::asFilePath($isAbsolute ? $controllerClassData->getFullClassName(withoutRootNamespace: true, withoutSuffix: true) : $controllerClassData->getClassName(relative: true, withoutSuffix: true))
+            .($isInvokable ? '.html.twig' : '/index.html.twig')
+        ;
 
         $controllerPath = $generator->generateController(
             $controllerClassData->getFullClassName(),

--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -1,10 +1,10 @@
 <?= "<?php\n" ?>
 
-namespace <?= $namespace; ?>;
+namespace <?= $class_data->getNamespace(); ?>;
 
-<?= $use_statements; ?>
+<?= $class_data->getUseStatements(); ?>
 
-class <?= $class_name; ?> extends AbstractController
+<?= $class_data->getClassDeclaration(); ?>
 {
 <?= $generator->generateRouteForControllerMethod($route_path, $route_name); ?>
     public function <?= $method_name ?>(): <?php if ($with_template) { ?>Response<?php } else { ?>JsonResponse<?php } ?>

--- a/src/Resources/skeleton/controller/Controller.tpl.php
+++ b/src/Resources/skeleton/controller/Controller.tpl.php
@@ -12,7 +12,7 @@ namespace <?= $class_data->getNamespace(); ?>;
     {
 <?php if ($with_template) { ?>
         return $this->render('<?= $template_name ?>', [
-            'controller_name' => '<?= $class_name ?>',
+            'controller_name' => '<?= $class_data->getClassName() ?>',
         ]);
 <?php } else { ?>
         return $this->json([

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -91,9 +91,23 @@ final class ClassData
         return \sprintf('%s\%s', $this->rootNamespace, $this->namespace);
     }
 
-    public function getFullClassName(): string
+    /**
+     * Get the full class name.
+     *
+     * @param bool $withoutRootNamespace Get the full class name without global root namespace. e.g. "App"
+     * @param bool $withoutSuffix        Get the full class name without the class suffix. e.g. "MyController" instead of "MyControllerController"
+     */
+    public function getFullClassName($withoutRootNamespace = false, $withoutSuffix = false): string
     {
-        return \sprintf('%s\%s', $this->getNamespace(), $this->className);
+        $className = \sprintf('%s\%s', $this->getNamespace(), $withoutSuffix ? Str::removeSuffix($this->className, $this->classSuffix) : $this->className);
+
+        if ($withoutRootNamespace) {
+            if (str_starts_with(haystack: $className, needle: $this->rootNamespace)) {
+                $className = substr_replace(string: $className, replace: '', offset: 0, length: \strlen($this->rootNamespace) + 1);
+            }
+        }
+
+        return $className;
     }
 
     public function setRootNamespace(string $rootNamespace): self

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -88,6 +88,11 @@ final class ClassData
             return $this->rootNamespace;
         }
 
+        // Namespace is already absolute, don't add the rootNamespace.
+        if (str_starts_with($this->namespace, '\\')) {
+            return substr_replace($this->namespace, '', 0, 1);
+        }
+
         return \sprintf('%s\%s', $this->rootNamespace, $this->namespace);
     }
 

--- a/tests/Maker/MakeControllerTest.php
+++ b/tests/Maker/MakeControllerTest.php
@@ -37,8 +37,13 @@ class MakeControllerTest extends MakerTestCase
                 ]);
 
                 $this->assertContainsCount('created: ', $output, 1);
-
                 $this->runControllerTest($runner, 'it_generates_a_controller.php');
+
+                // Ensure the generated controller matches what we expect
+                self::assertSame(
+                    expected: file_get_contents(\dirname(__DIR__).'/fixtures/make-controller/expected/FinalController.php'),
+                    actual: file_get_contents($runner->getPath('src/Controller/FooBarController.php'))
+                );
             }),
         ];
 
@@ -66,6 +71,12 @@ class MakeControllerTest extends MakerTestCase
                 self::assertFileExists($controllerPath);
 
                 $this->runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
+
+                // Ensure the generated controller matches what we expect
+                self::assertSame(
+                    expected: file_get_contents(\dirname(__DIR__).'/fixtures/make-controller/expected/FinalControllerWithTemplate.php'),
+                    actual: file_get_contents($runner->getPath('src/Controller/FooTwigController.php'))
+                );
             }),
         ];
 

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\MakerBundle\Tests\Util\ClassSource;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\MakerBundle\Test\MakerTestKernel;
-use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 
 class ClassDataTest extends TestCase
@@ -115,12 +114,9 @@ class ClassDataTest extends TestCase
 
     public function testGetClassNameWithAbsoluteNamespace(): void
     {
-        $this->markTestSkipped();
         $class = ClassData::create(class: '\\Foo\\Bar\\Admin\\Baz', suffix: 'Controller');
         self::assertSame('BazController', $class->getClassName());
-        self::assertSame('Baz', $class->getClassName(relative: false, withoutSuffix: true));
-        //        self::assertSame('Admin\FooController', $class->getClassName(relative: true, withoutSuffix: false));
-        //        self::assertSame('Admin\Baz', $class->getClassName(relative: true, withoutSuffix: true));
+        self::assertSame('Foo\Bar\Admin', $class->getNamespace());
         self::assertSame('Foo\Bar\Admin\BazController', $class->getFullClassName());
     }
 
@@ -147,18 +143,4 @@ class ClassDataTest extends TestCase
         yield ['Controller\MyController', 'Custom', false, true, 'Custom\Controller\My'];
         yield ['Controller\MyController', 'Custom', true, true, 'Controller\My'];
     }
-
-    //    public function testClassNameDetails(): void
-    //    {
-    //        $class = new ClassNameDetails(
-    //            fullClassName: 'Foo',
-    //            namespacePrefix: 'Controller\\',
-    //            suffix: 'Controller',
-    //        );
-    //
-    //        self::assertSame('FooController', $class->getFullName());
-    //        self::assertSame('MyController', $class->getShortName());
-    //        self::assertSame('My', $class->getRelativeNameWithoutSuffix());
-    //        self::assertSame('MyController', $class->getRelativeName());
-    //    }
 }

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Util\ClassSource;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\MakerBundle\Test\MakerTestKernel;
+use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 
 class ClassDataTest extends TestCase
@@ -91,4 +92,48 @@ class ClassDataTest extends TestCase
         yield ['MyController', 'Maker', 'Maker', 'Maker\MyController'];
         yield ['Controller\MyController', 'Maker', 'Maker\Controller', 'Maker\Controller\MyController'];
     }
+
+    public function testGetClassName(): void
+    {
+        $class = ClassData::create(class: 'Controller\\Foo', suffix: 'Controller');
+        self::assertSame('FooController', $class->getClassName());
+        self::assertSame('Foo', $class->getClassName(relative: false, withoutSuffix: true));
+        self::assertSame('FooController', $class->getClassName(relative: true, withoutSuffix: false));
+        self::assertSame('Foo', $class->getClassName(relative: true, withoutSuffix: true));
+        self::assertSame('App\Controller\FooController', $class->getFullClassName());
+    }
+
+    public function testGetClassNameRelativeNamespace(): void
+    {
+        $class = ClassData::create(class: 'Controller\\Admin\\Foo', suffix: 'Controller');
+        self::assertSame('FooController', $class->getClassName());
+        self::assertSame('Foo', $class->getClassName(relative: false, withoutSuffix: true));
+        self::assertSame('Admin\FooController', $class->getClassName(relative: true, withoutSuffix: false));
+        self::assertSame('Admin\Foo', $class->getClassName(relative: true, withoutSuffix: true));
+        self::assertSame('App\Controller\Admin\FooController', $class->getFullClassName());
+    }
+
+    public function testGetClassNameWithAbsoluteNamespace(): void
+    {
+        $class = ClassData::create(class: '\\Foo\\Bar\\Admin\\Baz', suffix: 'Controller');
+        self::assertSame('BazController', $class->getClassName());
+        self::assertSame('Baz', $class->getClassName(relative: false, withoutSuffix: true));
+        //        self::assertSame('Admin\FooController', $class->getClassName(relative: true, withoutSuffix: false));
+        //        self::assertSame('Admin\Baz', $class->getClassName(relative: true, withoutSuffix: true));
+        self::assertSame('Foo\Bar\Admin\BazController', $class->getFullClassName());
+    }
+
+    //    public function testClassNameDetails(): void
+    //    {
+    //        $class = new ClassNameDetails(
+    //            fullClassName: 'Foo',
+    //            namespacePrefix: 'Controller\\',
+    //            suffix: 'Controller',
+    //        );
+    //
+    //        self::assertSame('FooController', $class->getFullName());
+    //        self::assertSame('MyController', $class->getShortName());
+    //        self::assertSame('My', $class->getRelativeNameWithoutSuffix());
+    //        self::assertSame('MyController', $class->getRelativeName());
+    //    }
 }

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -115,12 +115,37 @@ class ClassDataTest extends TestCase
 
     public function testGetClassNameWithAbsoluteNamespace(): void
     {
+        $this->markTestSkipped();
         $class = ClassData::create(class: '\\Foo\\Bar\\Admin\\Baz', suffix: 'Controller');
         self::assertSame('BazController', $class->getClassName());
         self::assertSame('Baz', $class->getClassName(relative: false, withoutSuffix: true));
         //        self::assertSame('Admin\FooController', $class->getClassName(relative: true, withoutSuffix: false));
         //        self::assertSame('Admin\Baz', $class->getClassName(relative: true, withoutSuffix: true));
         self::assertSame('Foo\Bar\Admin\BazController', $class->getFullClassName());
+    }
+
+    /** @dataProvider fullClassNameProvider */
+    public function testGetFullClassName(string $class, ?string $rootNamespace, bool $withoutRootNamespace, bool $withoutSuffix, string $expectedFullClassName): void
+    {
+        $class = ClassData::create($class, suffix: 'Controller');
+
+        if (null !== $rootNamespace) {
+            $class->setRootNamespace($rootNamespace);
+        }
+
+        self::assertSame($expectedFullClassName, $class->getFullClassName(withoutRootNamespace: $withoutRootNamespace, withoutSuffix: $withoutSuffix));
+    }
+
+    public function fullClassNameProvider(): \Generator
+    {
+        yield ['Controller\MyController', null, false, false, 'App\Controller\MyController'];
+        yield ['Controller\MyController', null, true, false, 'Controller\MyController'];
+        yield ['Controller\MyController', null, false, true, 'App\Controller\My'];
+        yield ['Controller\MyController', null, true, true, 'Controller\My'];
+        yield ['Controller\MyController', 'Custom', false, false, 'Custom\Controller\MyController'];
+        yield ['Controller\MyController', 'Custom', true, false, 'Controller\MyController'];
+        yield ['Controller\MyController', 'Custom', false, true, 'Custom\Controller\My'];
+        yield ['Controller\MyController', 'Custom', true, true, 'Controller\My'];
     }
 
     //    public function testClassNameDetails(): void

--- a/tests/fixtures/make-controller/expected/FinalController.php
+++ b/tests/fixtures/make-controller/expected/FinalController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FooBarController extends AbstractController
+{
+    #[Route('/foo/bar', name: 'app_foo_bar')]
+    public function index(): JsonResponse
+    {
+        return $this->json([
+            'message' => 'Welcome to your new controller!',
+            'path' => 'src/Controller/FooBarController.php',
+        ]);
+    }
+}

--- a/tests/fixtures/make-controller/expected/FinalControllerWithTemplate.php
+++ b/tests/fixtures/make-controller/expected/FinalControllerWithTemplate.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FooTwigController extends AbstractController
+{
+    #[Route('/foo/twig', name: 'app_foo_twig')]
+    public function index(): Response
+    {
+        return $this->render('foo_twig/index.html.twig', [
+            'controller_name' => 'FooTwigController',
+        ]);
+    }
+}

--- a/tests/fixtures/make-controller/tests/it_generates_a_controller.php
+++ b/tests/fixtures/make-controller/tests/it_generates_a_controller.php
@@ -4,7 +4,7 @@ namespace App\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class GeneratedControllerTest extends WebTestCase
+final class GeneratedControllerTest extends WebTestCase
 {
     public function testController()
     {

--- a/tests/fixtures/make-controller/tests/it_generates_a_controller_with_twig.php
+++ b/tests/fixtures/make-controller/tests/it_generates_a_controller_with_twig.php
@@ -4,7 +4,7 @@ namespace App\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class GeneratedControllerTest extends WebTestCase
+final class GeneratedControllerTest extends WebTestCase
 {
     public function testController()
     {

--- a/tests/fixtures/make-controller/tests/it_generates_an_invokable_controller.php
+++ b/tests/fixtures/make-controller/tests/it_generates_an_invokable_controller.php
@@ -4,7 +4,7 @@ namespace App\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class GeneratedControllerTest extends WebTestCase
+final class GeneratedControllerTest extends WebTestCase
 {
     public function testControllerValidity()
     {


### PR DESCRIPTION
Adds the ability to generate controllers with the `final` PHP class keyword based on MakerBundle's config preferences.

- enhances the `ClassData` object to handle instantiation with absolute class name values. E.g. `\Foo\Bar\Controller` and in turn, calling `getNamespace()` will not include the `root_namespace` e.g. `Foo\Bar`
- adds test assertions to compare the generated controller to a known test fixture (expected controller)
- `Generator`'s `createClassFromClassData()` is able to generate regular classes and controller classes based on the `$isController` method argument. This will eventually replace the existing `Generator::createClass()` && `Generator::createController()` methods.