### PR TITLE
[make:validator] generate final classes

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -77,6 +77,36 @@ class Generator
     }
 
     /**
+     * Future replacement for generateClass().
+     *
+     * @internal
+     *
+     * @param string $templateName Template name in Resources/skeleton to use
+     * @param array  $variables    Array of variables to pass to the template
+     *
+     * @return string The path where the file will be created
+     *
+     * @throws \Exception
+     */
+    final public function generateClassFromClassData(ClassData $classData, string $templateName, array $variables = []): string
+    {
+        $classData = $this->templateComponentGenerator->configureClass($classData);
+        $targetPath = $this->fileManager->getRelativePathForFutureClass($classData->getFullClassName());
+
+        if (null === $targetPath) {
+            throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "\\My\\Full\\Namespace\\%s"', $classData->getFullClassName(), $classData->getClassName()));
+        }
+
+        $variables = array_merge($variables, [
+            'class_data' => $classData,
+        ]);
+
+        $this->addOperation($targetPath, $templateName, $variables);
+
+        return $targetPath;
+    }
+
+    /**
      * Generate a normal file from a template.
      *
      * @return void

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -16,9 +16,12 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Validation;
 
 /**
@@ -49,26 +52,35 @@ final class MakeValidator extends AbstractMaker
     /** @return void */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
-        $validatorClassNameDetails = $generator->createClassNameDetails(
-            $input->getArgument('name'),
-            'Validator\\',
-            'Validator'
+        $validatorClassData = ClassData::create(
+            class: \sprintf('Validator\\%s', $input->getArgument('name')),
+            suffix: 'Validator',
+            extendsClass: ConstraintValidator::class,
+            useStatements: [
+                Constraint::class,
+            ],
         );
 
-        $constraintFullClassName = Str::removeSuffix($validatorClassNameDetails->getFullName(), 'Validator');
+        $constraintDataClass = ClassData::create(
+            class: \sprintf('Validator\\%s', Str::removeSuffix($validatorClassData->getClassName(), 'Validator')),
+            extendsClass: Constraint::class,
+        );
 
         $generator->generateClass(
-            $validatorClassNameDetails->getFullName(),
+            $validatorClassData->getFullClassName(),
             'validator/Validator.tpl.php',
             [
-                'constraint_class_name' => Str::getShortClassName($constraintFullClassName),
+                'class_data' => $validatorClassData,
+                'constraint_class_name' => $constraintDataClass->getClassName(),
             ]
         );
 
         $generator->generateClass(
-            $constraintFullClassName,
+            $constraintDataClass->getFullClassName(),
             'validator/Constraint.tpl.php',
-            []
+            [
+                'class_data' => $constraintDataClass,
+            ]
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -66,21 +66,17 @@ final class MakeValidator extends AbstractMaker
             extendsClass: Constraint::class,
         );
 
-        $generator->generateClass(
-            $validatorClassData->getFullClassName(),
+        $generator->generateClassFromClassData(
+            $validatorClassData,
             'validator/Validator.tpl.php',
             [
-                'class_data' => $validatorClassData,
                 'constraint_class_name' => $constraintDataClass->getClassName(),
             ]
         );
 
-        $generator->generateClass(
-            $constraintDataClass->getFullClassName(),
+        $generator->generateClassFromClassData(
+            $constraintDataClass,
             'validator/Constraint.tpl.php',
-            [
-                'class_data' => $constraintDataClass,
-            ]
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -60,10 +60,9 @@ final class MakeVoter extends AbstractMaker
             ]
         );
 
-        $generator->generateClass(
-            $voterClassData->getFullClassName(),
+        $generator->generateClassFromClassData(
+            $voterClassData,
             'security/Voter.tpl.php',
-            ['class_data' => $voterClassData]
         );
 
         $generator->writeChanges();

--- a/src/Resources/skeleton/validator/Constraint.tpl.php
+++ b/src/Resources/skeleton/validator/Constraint.tpl.php
@@ -1,11 +1,11 @@
 <?= "<?php\n" ?>
 
-namespace <?= $namespace; ?>;
+namespace <?= $class_data->getNamespace(); ?>;
 
-use Symfony\Component\Validator\Constraint;
+<?= $class_data->getUseStatements(); ?>
 
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-class <?= $class_name ?> extends Constraint
+<?= $class_data->getClassDeclaration(); ?>
 {
     public string $message = 'The string "{{ string }}" contains an illegal character: it can only contain letters or numbers.';
 

--- a/tests/Maker/MakeValidatorTest.php
+++ b/tests/Maker/MakeValidatorTest.php
@@ -32,6 +32,18 @@ class MakeValidatorTest extends MakerTestCase
                         'FooBar',
                     ]
                 );
+
+                // Validator
+                $expectedVoterPath = \dirname(__DIR__).'/fixtures/make-validator/expected/FooBarValidator.php';
+                $generatedVoter = $runner->getPath('src/Validator/FooBarValidator.php');
+
+                self::assertSame(file_get_contents($expectedVoterPath), file_get_contents($generatedVoter));
+
+                // Constraint
+                $expectedVoterPath = \dirname(__DIR__).'/fixtures/make-validator/expected/FooBar.php';
+                $generatedVoter = $runner->getPath('src/Validator/FooBar.php');
+
+                self::assertSame(file_get_contents($expectedVoterPath), file_get_contents($generatedVoter));
             }),
         ];
     }

--- a/tests/fixtures/make-validator/expected/FooBar.php
+++ b/tests/fixtures/make-validator/expected/FooBar.php
@@ -4,16 +4,18 @@ namespace App\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
- */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class FooBar extends Constraint
 {
-    /*
-     * Any public properties become valid options for the annotation.
-     * Then, use these in your validator class.
-     */
-    public string $message = 'The value "{{ value }}" is not valid.';
+    public string $message = 'The string "{{ string }}" contains an illegal character: it can only contain letters or numbers.';
+
+    // You can use #[HasNamedArguments] to make some constraint options required.
+    // All configurable options must be passed to the constructor.
+    public function __construct(
+        public string $mode = 'strict',
+        ?array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 }

--- a/tests/fixtures/make-validator/expected/FooBar.php
+++ b/tests/fixtures/make-validator/expected/FooBar.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class FooBar extends Constraint
+{
+    /*
+     * Any public properties become valid options for the annotation.
+     * Then, use these in your validator class.
+     */
+    public string $message = 'The value "{{ value }}" is not valid.';
+}

--- a/tests/fixtures/make-validator/expected/FooBarValidator.php
+++ b/tests/fixtures/make-validator/expected/FooBarValidator.php
@@ -1,14 +1,15 @@
-<?= "<?php\n" ?>
+<?php
 
-namespace <?= $class_data->getNamespace(); ?>;
+namespace App\Validator;
 
-<?= $class_data->getUseStatements(); ?>
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
 
-<?= $class_data->getClassDeclaration(); ?>
+final class FooBarValidator extends ConstraintValidator
 {
     public function validate(mixed $value, Constraint $constraint): void
     {
-        /** @var <?= $constraint_class_name ?> $constraint */
+        /* @var FooBar $constraint */
 
         if (null === $value || '' === $value) {
             return;


### PR DESCRIPTION
generates `final` classes for the generated validator and constraint based on MakerBundle's config preferences

- adds generated file comparison to test suite
- adds a new internal generator method to create classes from `ClassData` objects - this will replace the existing `generateClass()` method in the future.
- adds test fixture to compare generated code to our template