### PR TITLE
[make:validator] drop annotation support in constraint

### DIFF
--- a/src/Resources/skeleton/validator/Constraint.tpl.php
+++ b/src/Resources/skeleton/validator/Constraint.tpl.php
@@ -4,17 +4,18 @@ namespace <?= $namespace; ?>;
 
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @Annotation
- *
- * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
- */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class <?= $class_name ?> extends Constraint
 {
-    /*
-     * Any public properties become valid options for the annotation.
-     * Then, use these in your validator class.
-     */
-    public string $message = 'The value "{{ value }}" is not valid.';
+    public string $message = 'The string "{{ string }}" contains an illegal character: it can only contain letters or numbers.';
+
+    // You can use #[HasNamedArguments] to make some constraint options required.
+    // All configurable options must be passed to the constructor.
+    public function __construct(
+        public string $mode = 'strict',
+        ?array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
 }


### PR DESCRIPTION
- drops the previously generated annotations in the constraint
- sync generated constraint with symfony docs