### PR TITLE
[make:security:form-login] Tweak login forms to enable double-submit CSRF protection

### DIFF
--- a/templates/authenticator/login_form.tpl.php
+++ b/templates/authenticator/login_form.tpl.php
@@ -21,10 +21,7 @@
     <input type="<?= $username_is_email ? 'email' : 'text'; ?>" value="{{ last_username }}" name="<?= $username_field; ?>" id="input<?= ucfirst($username_field); ?>" class="form-control" autocomplete="<?= $username_is_email ? 'email' : 'username'; ?>" required autofocus>
     <label for="inputPassword">Password</label>
     <input type="password" name="password" id="inputPassword" class="form-control" autocomplete="current-password" required>
-
-    <input type="hidden" name="_csrf_token"
-           value="{{ csrf_token('authenticate') }}"
-    >
+    <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="{{ csrf_token('authenticate') }}">
 <?php if($support_remember_me && !$always_remember_me): ?>
 
     <div class="checkbox mb-3">

--- a/templates/security/formLogin/login_form.tpl.php
+++ b/templates/security/formLogin/login_form.tpl.php
@@ -21,10 +21,7 @@
         <input type="<?= $username_is_email ? 'email' : 'text'; ?>" value="{{ last_username }}" name="_username" id="username" class="form-control" autocomplete="<?= $username_is_email ? 'email' : 'username'; ?>" required autofocus>
         <label for="password">Password</label>
         <input type="password" name="_password" id="password" class="form-control" autocomplete="current-password" required>
-
-        <input type="hidden" name="_csrf_token"
-               value="{{ csrf_token('authenticate') }}"
-        >
+        <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="{{ csrf_token('authenticate') }}">
 
         {#
             Uncomment this section and add a remember_me option below your firewall to activate remember me functionality.

--- a/tests/fixtures/security/make-form-login/expected/login.html.twig
+++ b/tests/fixtures/security/make-form-login/expected/login.html.twig
@@ -19,10 +19,7 @@
         <input type="email" value="{{ last_username }}" name="_username" id="username" class="form-control" autocomplete="email" required autofocus>
         <label for="password">Password</label>
         <input type="password" name="_password" id="password" class="form-control" autocomplete="current-password" required>
-
-        <input type="hidden" name="_csrf_token"
-               value="{{ csrf_token('authenticate') }}"
-        >
+        <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="{{ csrf_token('authenticate') }}">
 
         {#
             Uncomment this section and add a remember_me option below your firewall to activate remember me functionality.

--- a/tests/fixtures/security/make-form-login/expected/login_no_logout.html.twig
+++ b/tests/fixtures/security/make-form-login/expected/login_no_logout.html.twig
@@ -13,10 +13,7 @@
         <input type="email" value="{{ last_username }}" name="_username" id="username" class="form-control" autocomplete="email" required autofocus>
         <label for="password">Password</label>
         <input type="password" name="_password" id="password" class="form-control" autocomplete="current-password" required>
-
-        <input type="hidden" name="_csrf_token"
-               value="{{ csrf_token('authenticate') }}"
-        >
+        <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="{{ csrf_token('authenticate') }}">
 
         {#
             Uncomment this section and add a remember_me option below your firewall to activate remember me functionality.


### PR DESCRIPTION
Will be leveraged by https://github.com/symfony/symfony/pull/58095
Does no harm being enabled regardless of the Symfony version in use.

---
Waiting on: 
- [x] https://github.com/symfony/symfony/pull/58095