### PR TITLE
[tests] Fix double slashes in tmp PHPUnit path

### DIFF
--- a/src/Test/MakerTestRunner.php
+++ b/src/Test/MakerTestRunner.php
@@ -198,7 +198,7 @@ class MakerTestRunner
     public function runTests(): void
     {
         $internalTestProcess = MakerTestProcess::create(
-            \sprintf('php %s', $this->getPath('/bin/phpunit')),
+            \sprintf('php %s', $this->getPath('bin/phpunit')),
             $this->environment->getPath())
             ->run(true)
         ;


### PR DESCRIPTION
## Context
When we run tests from the `./tests/tmp/cache` directory, the built PHPUnit path contains 2 slashes because the [`MakerTestRunner::getPath()`](https://github.com/symfony/maker-bundle/blob/main/src/Test/MakerTestRunner.php#L81) method already prefix with a slash.

## Example
```
                                                                    ⬇️
./tests/tmp/cache/maker_app_7e4ffd082daa1224b6cfdeae54f3e3b2_current//bin/phpunit
```

## Fix
Remove the prefixed slash in `bin/phpunit`
