### PR TITLE
[make:crud] name repository variable with entity prefix when generating tests

### DIFF
--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -9,16 +9,16 @@ namespace <?= $namespace ?>;
 {
     private KernelBrowser $client;
     private EntityManagerInterface $manager;
-    private EntityRepository $repository;
+    private EntityRepository $<?= lcfirst($entity_var_singular); ?>Repository;
     private string $path = '<?= $route_path; ?>/';
 
     protected function setUp(): void
     {
         $this->client = static::createClient();
         $this->manager = static::getContainer()->get('doctrine')->getManager();
-        $this->repository = $this->manager->getRepository(<?= $entity_class_name; ?>::class);
+        $this-><?= lcfirst($entity_var_singular); ?>Repository = $this->manager->getRepository(<?= $entity_class_name; ?>::class);
 
-        foreach ($this->repository->findAll() as $object) {
+        foreach ($this-><?= lcfirst($entity_var_singular); ?>Repository>findAll() as $object) {
             $this->manager->remove($object);
         }
 
@@ -52,7 +52,7 @@ namespace <?= $namespace ?>;
 
         self::assertResponseRedirects($this->path);
 
-        self::assertSame(1, $this->repository->count([]));
+        self::assertSame(1, $this-><?= lcfirst($entity_var_singular); ?>Repository>count([]));
     }
 
     public function testShow(): void
@@ -95,7 +95,7 @@ namespace <?= $namespace ?>;
 
         self::assertResponseRedirects('<?= $route_path; ?>/');
 
-        $fixture = $this->repository->findAll();
+        $fixture = $this-><?= lcfirst($entity_var_singular); ?>Repository>findAll();
 
 <?php foreach ($form_fields as $form_field => $typeOptions): ?>
         self::assertSame('Something New', $fixture[0]->get<?= ucfirst($form_field); ?>());
@@ -117,6 +117,6 @@ namespace <?= $namespace ?>;
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('<?= $route_path; ?>/');
-        self::assertSame(0, $this->repository->count([]));
+        self::assertSame(0, $this-><?= lcfirst($entity_var_singular); ?>Repository>count([]));
     }
 }

--- a/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
+++ b/src/Resources/skeleton/crud/test/Test.EntityManager.tpl.php
@@ -18,7 +18,7 @@ namespace <?= $namespace ?>;
         $this->manager = static::getContainer()->get('doctrine')->getManager();
         $this-><?= lcfirst($entity_var_singular); ?>Repository = $this->manager->getRepository(<?= $entity_class_name; ?>::class);
 
-        foreach ($this-><?= lcfirst($entity_var_singular); ?>Repository>findAll() as $object) {
+        foreach ($this-><?= lcfirst($entity_var_singular); ?>Repository->findAll() as $object) {
             $this->manager->remove($object);
         }
 
@@ -52,7 +52,7 @@ namespace <?= $namespace ?>;
 
         self::assertResponseRedirects($this->path);
 
-        self::assertSame(1, $this-><?= lcfirst($entity_var_singular); ?>Repository>count([]));
+        self::assertSame(1, $this-><?= lcfirst($entity_var_singular); ?>Repository->count([]));
     }
 
     public function testShow(): void
@@ -95,7 +95,7 @@ namespace <?= $namespace ?>;
 
         self::assertResponseRedirects('<?= $route_path; ?>/');
 
-        $fixture = $this-><?= lcfirst($entity_var_singular); ?>Repository>findAll();
+        $fixture = $this-><?= lcfirst($entity_var_singular); ?>Repository->findAll();
 
 <?php foreach ($form_fields as $form_field => $typeOptions): ?>
         self::assertSame('Something New', $fixture[0]->get<?= ucfirst($form_field); ?>());
@@ -117,6 +117,6 @@ namespace <?= $namespace ?>;
         $this->client->submitForm('Delete');
 
         self::assertResponseRedirects('<?= $route_path; ?>/');
-        self::assertSame(0, $this-><?= lcfirst($entity_var_singular); ?>Repository>count([]));
+        self::assertSame(0, $this-><?= lcfirst($entity_var_singular); ?>Repository->count([]));
     }
 }


### PR DESCRIPTION
Use lowercase-first version of entity to name repository variable in the test class

e.g. if entity named “Product” then test class repository variable will be “productRepository” rather than just “repository”

this makes copy-paste of setup code from other test classes simpler, when a related entity needs to be created for test cases