### PR TITLE
[ci] temp. skip API Platform tests - recipe conflict

### DIFF
--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -120,6 +120,8 @@ class MakeEntityTest extends MakerTestCase
         ];
 
         yield 'it_creates_a_new_class_and_api_resource' => [$this->createMakeEntityTest()
+            // @legacy - re-enable test when https://github.com/symfony/recipes/pull/1339 is merged
+            ->skipTest('Waiting for https://github.com/symfony/recipes/pull/1339')
             ->addExtraDependencies('api')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker([
@@ -679,6 +681,8 @@ class MakeEntityTest extends MakerTestCase
         ];
 
         yield 'it_makes_new_entity_no_to_all_extras' => [$this->createMakeEntityTestForMercure()
+            // @legacy - re-enable test when https://github.com/symfony/recipes/pull/1339 is merged
+            ->skipTest('Waiting for https://github.com/symfony/recipes/pull/1339')
             ->addExtraDependencies('api')
             // special setup done in createMakeEntityTestForMercure()
             ->run(function (MakerTestRunner $runner) {


### PR DESCRIPTION
Unable to run `make:entity` tests that require `api-platform` as a dependency. API Platform `v3.4` does not allow for `api_platform.keep_legacy_inflector` to be set, but it's automatically included in `<3.4` recipe(s). No recipe exists yet for `>=3.4`.

Skipped Test Cases:
- `it_creates_a_new_class_and_api_resource`
- `it_makes_new_entity_no_to_all_extras`

Tests to be re-enabled once https://github.com/symfony/recipes/pull/1339 is merged.

---

There are more complex ways to restrict these 2 test cases to run on `=<3.3` - but this is the easiest path forward at the moment.