### PR TITLE
[tests] allow dev's to view test process output locally

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,9 @@
         <env name="MAKER_SKIP_PANTHER_TEST" value="false" />
 <!--    Overrides process timeout when step debugging -->
 <!--    <env name="MAKER_PROCESS_TIMEOUT" value="null" /> -->
+<!--    Dump the CLI output for a test runner process immediately after running a test -->
+<!--    You should only set this to true when you need to debug the actual output of a maker command within a test -->
+<!--    <env name="MAKER_TEST_DUMP_OUTPUT" value="false" /> -->
     </php>
 
     <testsuites>

--- a/src/Test/MakerTestRunner.php
+++ b/src/Test/MakerTestRunner.php
@@ -35,7 +35,16 @@ class MakerTestRunner
     {
         $this->executedMakerProcess = $this->environment->runMaker($inputs, $argumentsString, $allowedToFail, $envVars);
 
-        return $this->executedMakerProcess->getOutput();
+        $output = $this->executedMakerProcess->getOutput();
+
+        // Allows for debugging the actual CLI output from within a test process. E.g. Manually viewing the output of the
+        // `make:voter` command that was run within the MakeVoterTest from your local command line.
+        // You should never use this in CI unless you know what you're doing - resource intensive.
+        if ('true' === getenv('MAKER_TEST_DUMP_OUTPUT')) {
+            dump(['Maker Process Output' => $output, 'Maker Process Error Output' => $this->executedMakerProcess->getErrorOutput()]);
+        }
+
+        return $output;
     }
 
     /**


### PR DESCRIPTION
Allows developers to set `MAKER_TEST_DUMP_OUTPUT=true` when running tests to view the raw output of a maker command during testing for local debugging purposes.

---
- The value of `MAKER_TEST_DUMP_OUTPUT` must be the literal `true`. Values other then the string literal `true` are ignored. 
- This should never be used in CI or when running the entire test suite locally
- It is meant to aid developers working on MakerBundle commands that need to see the actual output sub-process output && error output of maker commands that are executed via `MakerTestRunner`'s `runMaker()` method.

## Usage

```bash
MAKER_TEST_DUMP_OUTPUT=true vendor/bin/simple-phpunit --filter MakeVoter
```
![maker-ss](https://github.com/user-attachments/assets/ceb52c3f-9ff5-44bc-bd76-2e20df76e385)

