### PR TITLE
[make:controller] add ability to create controller with tests

### DIFF
--- a/src/Resources/skeleton/controller/test/Test.tpl.php
+++ b/src/Resources/skeleton/controller/test/Test.tpl.php
@@ -1,0 +1,16 @@
+<?= "<?php\n" ?>
+
+namespace <?= $class_data->getNamespace(); ?>;
+
+<?= $class_data->getUseStatements(); ?>
+
+<?= $class_data->getClassDeclaration(); ?>
+{
+    public function testIndex(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '<?= $route_path; ?>');
+
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/Maker/MakeControllerTest.php
+++ b/tests/Maker/MakeControllerTest.php
@@ -47,6 +47,24 @@ class MakeControllerTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_a_controller-with-tests' => [$this->createMakerTest()
+            ->addExtraDependencies('symfony/test-pack')
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([
+                    'FooBar', // controller class name
+                    'y', // create tests
+                ]);
+
+                $this->assertStringContainsString('src/Controller/FooBarController.php', $output);
+                $this->assertStringContainsString('tests/Controller/FooBarControllerTest.php', $output);
+
+                $this->assertFileExists($runner->getPath('src/Controller/FooBarController.php'));
+                $this->assertFileExists($runner->getPath('tests/Controller/FooBarControllerTest.php'));
+
+                $this->runControllerTest($runner, 'it_generates_a_controller.php');
+            }),
+        ];
+
         yield 'it_generates_a_controller__no_input' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([], 'FooBar');


### PR DESCRIPTION
_This feature is experimental - generated code is likely to change significantly between point releases._

Adds the ability to pass `--with-tests` to `make:controller` and maker will generate a new PHPUnit test tailored for the specific functionality of that maker. If `--with-tests` is _not_ passed as an argument, MakerBundle will ask the user `Do you want to generate PHPUnit tests? [Experimental]`. 