### PR TITLE
[ci] revert #1598

### DIFF
--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -120,8 +120,6 @@ class MakeEntityTest extends MakerTestCase
         ];
 
         yield 'it_creates_a_new_class_and_api_resource' => [$this->createMakeEntityTest()
-            // @legacy - re-enable test when https://github.com/symfony/recipes/pull/1339 is merged
-            ->skipTest('Waiting for https://github.com/symfony/recipes/pull/1339')
             ->addExtraDependencies('api')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker([
@@ -681,8 +679,6 @@ class MakeEntityTest extends MakerTestCase
         ];
 
         yield 'it_makes_new_entity_no_to_all_extras' => [$this->createMakeEntityTestForMercure()
-            // @legacy - re-enable test when https://github.com/symfony/recipes/pull/1339 is merged
-            ->skipTest('Waiting for https://github.com/symfony/recipes/pull/1339')
             ->addExtraDependencies('api')
             // special setup done in createMakeEntityTestForMercure()
             ->run(function (MakerTestRunner $runner) {


### PR DESCRIPTION
https://github.com/symfony/recipes/pull/1339 is now merged - we dont need to skip these tests anymore.

fixes #1599