### PR TITLE
[make:crud]  `methods` option - array to string 

### DIFF
--- a/templates/crud/controller/Controller.tpl.php
+++ b/templates/crud/controller/Controller.tpl.php
@@ -7,7 +7,7 @@ namespace <?= $class_data->getNamespace() ?>;
 #[Route('<?= $route_path ?>')]
 <?= $class_data->getClassDeclaration() ?>
 {
-<?= $generator->generateRouteForControllerMethod('', sprintf('%s_index', $route_name), ['GET']) ?>
+<?= $generator->generateRouteForControllerMethod('', sprintf('%s_index', $route_name), 'GET') ?>
 <?php if (isset($repository_full_class_name)): ?>
     public function index(<?= $repository_class_name ?> $<?= $repository_var ?>): Response
     {
@@ -48,7 +48,7 @@ namespace <?= $class_data->getNamespace() ?>;
         ]);
     }
 
-<?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_show', $route_name), ['GET']) ?>
+<?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_show', $route_name), 'GET') ?>
     public function show(<?= $entity_class_name ?> $<?= $entity_var_singular ?>): Response
     {
         return $this->render('<?= $templates_path ?>/show.html.twig', [
@@ -74,7 +74,7 @@ namespace <?= $class_data->getNamespace() ?>;
         ]);
     }
 
-<?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_delete', $route_name), ['POST']) ?>
+<?= $generator->generateRouteForControllerMethod(sprintf('/{%s}', $entity_identifier), sprintf('%s_delete', $route_name), 'POST') ?>
     public function delete(Request $request, <?= $entity_class_name ?> $<?= $entity_var_singular ?>, EntityManagerInterface $entityManager): Response
     {
         if ($this->isCsrfTokenValid('delete'.$<?= $entity_var_singular ?>->get<?= ucfirst($entity_identifier) ?>(), $request->getPayload()->getString('_token'))) {


### PR DESCRIPTION
The `methods` option can be an array or a string. In this PR I converted array to string when arrays were not needed.