### PR TITLE
[doc] make:entity requires Doctrine

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,9 @@ optional arguments and options. Check them out with the ``--help`` option:
 
     $ php bin/console make:controller --help
 
+.. caution::
+
+    ``make:entity`` requires ``doctrine/orm`` to be installed and configured. This maker support only ORM, not ODM.
 
 Linting Generated Code
 ______________________


### PR DESCRIPTION
Someone on Stack Overflow asked (question is not published yet) if `make:entity` can be used without Doctrine.

It looks like MakerBundle can only manage Doctrine entities, so I added it in the docs, hopefully that is true. Otherwise we'll have to change or close this PR.