### PR TITLE
[make:decorator] Add new maker to create decorator

### DIFF
--- a/config/help/MakeDecorator.txt
+++ b/config/help/MakeDecorator.txt
@@ -1,0 +1,10 @@
+The <info>%command.name%</info> command generates a new service decorator class.
+
+<info>php %command.full_name%</info>
+<info>php %command.full_name% My\Decorated\Service\Class</info>
+<info>php %command.full_name% My\Decorated\Service\Class MyServiceDecorator</info>
+<info>php %command.full_name% My\Decorated\Service\Class Service\MyServiceDecorator</info>
+<info>php %command.full_name% my_decorated.service.id MyServiceDecorator</info>
+<info>php %command.full_name% my_decorated.service.id MyServiceDecorator</info>
+
+If one argument is missing, the command will ask for it interactively.

--- a/config/makers.xml
+++ b/config/makers.xml
@@ -36,8 +36,7 @@
             </service>
 
             <service id="maker.maker.make_decorator" class="Symfony\Bundle\MakerBundle\Maker\MakeDecorator">
-                <argument /> <!-- Service locator of all existing services -->
-                <argument /> <!-- Array of services' ids -->
+                <argument type="service" id="maker.decorator_helper" />
                 <tag name="maker.command" />
             </service>
 

--- a/config/makers.xml
+++ b/config/makers.xml
@@ -35,6 +35,12 @@
                 <tag name="maker.command" />
             </service>
 
+            <service id="maker.maker.make_decorator" class="Symfony\Bundle\MakerBundle\Maker\MakeDecorator">
+                <argument /> <!-- Service locator of all existing services -->
+                <argument /> <!-- Array of services' ids -->
+                <tag name="maker.command" />
+            </service>
+
             <service id="maker.maker.make_docker_database" class="Symfony\Bundle\MakerBundle\Maker\MakeDockerDatabase">
                 <argument type="service" id="maker.file_manager" />
                 <tag name="maker.command" />

--- a/config/services.xml
+++ b/config/services.xml
@@ -40,6 +40,12 @@
                 <argument type="service" id="doctrine" on-invalid="ignore" />
             </service>
 
+            <service id="maker.decorator_helper" class="Symfony\Bundle\MakerBundle\DependencyInjection\DecoratorHelper">
+                <argument /> <!-- Service locator -->
+                <argument /> <!-- Services ids -->
+                <argument /> <!-- ShortName map of services -->
+            </service>
+
             <service id="maker.template_linter" class="Symfony\Bundle\MakerBundle\Util\TemplateLinter">
                 <argument type="service" id="maker.file_manager" />
                 <argument>%env(default::string:MAKER_PHP_CS_FIXER_BINARY_PATH)%</argument>

--- a/src/DependencyInjection/CompilerPass/MakeDecoratorPass.php
+++ b/src/DependencyInjection/CompilerPass/MakeDecoratorPass.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Benjamin Georgeault <git@wedgesama.fr>
+ */
+class MakeDecoratorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('maker.maker.make_decorator')) {
+            return;
+        }
+
+        $container->getDefinition('maker.maker.make_decorator')
+            ->replaceArgument(0, ServiceLocatorTagPass::register($container, $ids = $container->getServiceIds()))
+            ->replaceArgument(1, $ids)
+        ;
+    }
+}

--- a/src/DependencyInjection/DecoratorHelper.php
+++ b/src/DependencyInjection/DecoratorHelper.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\DependencyInjection;
+
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+
+/**
+ * @author Benjamin Georgeault <git@wedgesama.fr>
+ *
+ * @internal
+ */
+final class DecoratorHelper
+{
+    /**
+     * @param array<string>           $ids
+     * @param array<string, string>   $serviceClasses
+     * @param array<string, string[]> $shortNameMap
+     */
+    public function __construct(
+        private readonly array $ids,
+        private readonly array $serviceClasses,
+        private readonly array $shortNameMap,
+    ) {
+    }
+
+    public function suggestIds(): array
+    {
+        return [
+            ...array_keys($this->shortNameMap),
+            ...$this->ids,
+        ];
+    }
+
+    public function getRealId(string $id): ?string
+    {
+        if (\in_array($id, $this->ids)) {
+            return $id;
+        }
+
+        if (\array_key_exists($id, $this->shortNameMap) && 1 === \count($this->shortNameMap[$id])) {
+            return $this->shortNameMap[$id][0];
+        }
+
+        return null;
+    }
+
+    public function guessRealIds(string $id): array
+    {
+        $guessTypos = [];
+        foreach ($this->shortNameMap as $shortName => $ids) {
+            if (levenshtein($id, $shortName) < 3) {
+                $guessTypos = [
+                    ...$guessTypos,
+                    ...$ids,
+                ];
+            }
+        }
+
+        foreach ($this->ids as $suggestId) {
+            if (levenshtein($id, $suggestId) < 3) {
+                $guessTypos[] = $suggestId;
+            }
+        }
+
+        return $guessTypos;
+    }
+
+    /**
+     * @return class-string
+     */
+    public function getClass(string $id): string
+    {
+        if (class_exists($id) || interface_exists($id)) {
+            return $id;
+        }
+
+        if (\array_key_exists($id, $this->serviceClasses)) {
+            return $this->serviceClasses[$id];
+        }
+
+        throw new RuntimeCommandException(\sprintf('Cannot getClass for id "%s".', $id));
+    }
+}

--- a/src/Maker/MakeDecorator.php
+++ b/src/Maker/MakeDecorator.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\DecoratorInfo;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+
+/**
+ * @author Benjamin Georgeault <git@wedgesama.fr>
+ */
+final class MakeDecorator extends AbstractMaker
+{
+    /**
+     * @param array<string> $ids
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly array $ids,
+    ) {
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:decorator';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Create CRUD for Doctrine entity class';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->addArgument('id', InputArgument::OPTIONAL, 'The ID of the service to decorate.')
+            ->addArgument('decorator-class', InputArgument::OPTIONAL, \sprintf('The class name of the service to create (e.g. <fg=yellow>%sDecorator</>)', Str::asClassName(Str::getRandomTerm())))
+            ->setHelp($this->getHelpFileContents('MakeDecorator.txt'))
+        ;
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+        $dependencies->addClassDependency(
+            AsDecorator::class,
+            'dependency-injection',
+        );
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        // Ask for service id.
+        if (null === $input->getArgument('id')) {
+            $argument = $command->getDefinition()->getArgument('id');
+
+            ($question = new Question($argument->getDescription()))
+                ->setAutocompleterValues($this->ids)
+                ->setValidator(fn ($answer) => Validator::serviceExists($answer, $this->ids))
+                ->setMaxAttempts(3);
+
+            $input->setArgument('id', $io->askQuestion($question));
+        }
+
+        $id = $input->getArgument('id');
+
+        // Ask for decorator classname.
+        if (null === $input->getArgument('decorator-class')) {
+            $argument = $command->getDefinition()->getArgument('decorator-class');
+
+            $basename = Str::getShortClassName(match (true) {
+                interface_exists($id) => Str::removeSuffix($id, 'Interface'),
+                class_exists($id) => $id,
+                default => Str::asClassName($id),
+            });
+
+            $defaultClass = Str::asClassName(\sprintf('%s Decorator', $basename));
+
+            ($question = new Question($argument->getDescription(), $defaultClass))
+                ->setValidator(fn ($answer) => Validator::validateClassName(Validator::classDoesNotExist($answer)))
+                ->setMaxAttempts(3);
+
+            $input->setArgument('decorator-class', $io->askQuestion($question));
+        }
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $id = $input->getArgument('id');
+
+        $classNameDetails = $generator->createClassNameDetails(
+            Validator::validateClassName(Validator::classDoesNotExist($input->getArgument('decorator-class'))),
+            '',
+        );
+
+        $decoratedInfo = $this->createDecoratorInfo($id, $classNameDetails->getFullName());
+        $classData = $decoratedInfo->getClassData();
+
+        $generator->generateClassFromClassData(
+            $classData,
+            'decorator/Decorator.tpl.php',
+            [
+                'decorated_info' => $decoratedInfo,
+            ],
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+    }
+
+    private function createDecoratorInfo(string $id, string $decoratorClass): DecoratorInfo
+    {
+        return new DecoratorInfo(
+            $decoratorClass,
+            match (true) {
+                class_exists($id), interface_exists($id) => $id,
+                default => $this->container->get($id)::class,
+            },
+            $id,
+        );
+    }
+}

--- a/src/MakerBundle.php
+++ b/src/MakerBundle.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle;
 
 use Symfony\Bundle\MakerBundle\DependencyInjection\CompilerPass\MakeCommandRegistrationPass;
+use Symfony\Bundle\MakerBundle\DependencyInjection\CompilerPass\MakeDecoratorPass;
 use Symfony\Bundle\MakerBundle\DependencyInjection\CompilerPass\RemoveMissingParametersPass;
 use Symfony\Bundle\MakerBundle\DependencyInjection\CompilerPass\SetDoctrineAnnotatedPrefixesPass;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -69,6 +70,7 @@ class MakerBundle extends AbstractBundle
     {
         // add a priority so we run before the core command pass
         $container->addCompilerPass(new MakeCommandRegistrationPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
+        $container->addCompilerPass(new MakeDecoratorPass());
         $container->addCompilerPass(new RemoveMissingParametersPass());
         $container->addCompilerPass(new SetDoctrineAnnotatedPrefixesPass());
     }

--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -183,4 +183,9 @@ final class ClassData
     {
         return $this->useStatementGenerator->hasUseStatement($className);
     }
+
+    public function hasExtends(): bool
+    {
+        return null !== $this->extends;
+    }
 }

--- a/src/Util/ClassSource/Model/ClassMethod.php
+++ b/src/Util/ClassSource/Model/ClassMethod.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Util\ClassSource\Model;
+
+/**
+ * @author Benjamin Georgeault <git@wedgesama.fr>
+ *
+ * @internal
+ */
+final class ClassMethod
+{
+    /**
+     * @param MethodArgument[] $arguments
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly array $arguments = [],
+        private readonly ?string $returnType = null,
+        private readonly bool $isStatic = false,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isReturnVoid(): bool
+    {
+        return 'void' === $this->returnType;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->isStatic;
+    }
+
+    public function getDeclaration(): string
+    {
+        return \sprintf('public %sfunction %s(%s)%s',
+            $this->isStatic ? 'static ' : '',
+            $this->name,
+            implode(', ', array_map(fn (MethodArgument $arg) => $arg->getDeclaration(), $this->arguments)),
+            $this->returnType ? ': '.$this->returnType : '',
+        );
+    }
+
+    public function getArgumentsUse(): string
+    {
+        return implode(', ', array_map(fn (MethodArgument $arg) => $arg->getVariable(), $this->arguments));
+    }
+}

--- a/src/Util/ClassSource/Model/MethodArgument.php
+++ b/src/Util/ClassSource/Model/MethodArgument.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Util\ClassSource\Model;
+
+/**
+ * @author Benjamin Georgeault<git@wedgesama.fr>
+ *
+ * @internal
+ */
+final class MethodArgument
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly ?string $type = null,
+        private readonly ?string $default = null,
+    ) {
+    }
+
+    public function getDeclaration(): string
+    {
+        return ($this->type ?? '').
+            ($this->type ? ' ' : '').
+            $this->getVariable().
+            ($this->default ? ' = ' : '').
+            ($this->default ?? '')
+        ;
+    }
+
+    public function getVariable(): string
+    {
+        return '$'.$this->name;
+    }
+}

--- a/src/Util/DecoratorInfo.php
+++ b/src/Util/DecoratorInfo.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Util;
+
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassMethod;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\MethodArgument;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+
+/**
+ * @internal
+ */
+final class DecoratorInfo
+{
+    private readonly ClassData $classData;
+
+    private readonly array $methods;
+
+    private readonly array $decoratedClassOrInterfaces;
+
+    private readonly string $decoratedIdDeclaration;
+
+    /**
+     * @param class-string $decoratorClassName
+     * @param class-string $decoratedClassOrInterface
+     */
+    public function __construct(
+        private readonly string $decoratorClassName,
+        string $decoratedId,
+        string $decoratedClassOrInterface,
+    ) {
+        $decoratedTypeRef = new \ReflectionClass($decoratedClassOrInterface);
+
+        // Try implements
+        $interfaces = match (true) {
+            interface_exists($decoratedClassOrInterface) => [$decoratedClassOrInterface],
+            self::isClassEquivalentToItsInterfaces($decoratedTypeRef) => array_values(class_implements($decoratedClassOrInterface)),
+            default => null,
+        };
+
+        // Try extends if cannot implements.
+        $extends = (null === $interfaces) ? match (true) {
+            self::isClassEquivalentToItsParentClass($decoratedTypeRef) => get_parent_class($decoratedClassOrInterface),
+            !$decoratedTypeRef->isFinal() => $decoratedClassOrInterface,
+            default => throw new RuntimeCommandException(\sprintf('Cannot decorate "%s", its class does not have any interface, parent class and its final.', $decoratedClassOrInterface)),
+        } : null;
+
+        $this->classData = ClassData::create(
+            class: $this->decoratorClassName,
+            extendsClass: $extends,
+            useStatements: [
+                AsDecorator::class,
+                AutowireDecorated::class,
+            ],
+            implements: $interfaces,
+        );
+
+        // Use interfaces or extends as decorated type
+        $this->decoratedClassOrInterfaces = $interfaces ?? [$extends];
+
+        // Handle decorated service's id.
+        if (class_exists($decoratedId) || interface_exists($decoratedId)) {
+            if (!$this->classData->hasUseStatement($decoratedId)) {
+                $this->classData->addUseStatement($decoratedId, 'Service');
+            }
+
+            $this->decoratedIdDeclaration = \sprintf('%s::class', $this->classData->getUseStatementShortName($decoratedId));
+        } else {
+            $this->decoratedIdDeclaration = \sprintf('\'%s\'', $decoratedId);
+        }
+
+        // Trigger methods parsing to register methods arguments type in use statement.
+        $this->methods = $this->doGetPublicMethods();
+    }
+
+    /**
+     * @return array<ClassMethod>
+     */
+    public function getPublicMethods(): array
+    {
+        return $this->methods;
+    }
+
+    public function getClassData(): ClassData
+    {
+        return $this->classData;
+    }
+
+    public function getDecoratedIdDeclaration(): string
+    {
+        return $this->decoratedIdDeclaration;
+    }
+
+    public function getShortNameInnerType(): string
+    {
+        return implode('&', array_map($this->classData->getUseStatementShortName(...), $this->decoratedClassOrInterfaces));
+    }
+
+    /**
+     * @return array<class-string, ClassMethod>
+     */
+    private function doGetPublicMethods(): array
+    {
+        $methods = [];
+        foreach ($this->decoratedClassOrInterfaces as $classOrInterface) {
+            $ref = new \ReflectionClass($classOrInterface);
+
+            foreach ($ref->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->isFinal() || \array_key_exists($method->getName(), $methods)) {
+                    continue;
+                }
+
+                $methods[$method->getName()] = new ClassMethod(
+                    $method->getName(),
+                    [...$this->doParseArguments($method)],
+                    $this->parseType($method->getReturnType()),
+                    $method->isStatic(),
+                );
+            }
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @return iterable<MethodArgument>
+     */
+    private function doParseArguments(\ReflectionMethod $method): iterable
+    {
+        foreach ($method->getParameters() as $parameter) {
+            $default = null;
+            if ($parameter->isOptional()) {
+                if ($parameter->isDefaultValueConstant()) {
+                    $default = $parameter->getDefaultValueConstantName();
+                } elseif ($parameter->isDefaultValueAvailable()) {
+                    $defaultValue = $parameter->getDefaultValue();
+
+                    if (\is_string($defaultValue)) {
+                        $default = '\''.str_replace('\'', '\\\'', $defaultValue).'\'';
+                    } elseif (\is_scalar($defaultValue)) {
+                        $default = $defaultValue;
+                    } elseif (\is_array($defaultValue)) {
+                        $default = '[]';
+                    } elseif (null === $defaultValue) {
+                        $default = 'null';
+                    }
+                }
+
+                if (!empty($default)) {
+                    $default = ' = '.$default;
+                }
+            }
+
+            yield new MethodArgument(
+                $parameter->getName(),
+                $this->parseType($parameter->getType()),
+                $default,
+            );
+        }
+    }
+
+    private function parseType(?\ReflectionType $type): ?string
+    {
+        if (null === $type) {
+            return null;
+        }
+
+        if ($type instanceof \ReflectionNamedType) {
+            if (class_exists($type->getName()) || interface_exists($type->getName())) {
+                $this->classData->addUseStatement($type->getName(), 'Arg');
+
+                return $this->classData->getUseStatementShortName($type->getName());
+            }
+
+            return $type->getName();
+        }
+
+        if ($type instanceof \ReflectionUnionType) {
+            return implode('|', array_map($this->parseType(...), $type->getTypes()));
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            return implode('&', array_map($this->parseType(...), $type->getTypes()));
+        }
+
+        throw new RuntimeCommandException('Should never be reach.');
+    }
+
+    private static function isClassEquivalentToItsInterfaces(\ReflectionClass $classRef): bool
+    {
+        if (empty($interfaceRefs = $classRef->getInterfaces())) {
+            return false;
+        }
+
+        $methodCount = array_sum(array_map(
+            fn (\ReflectionClass $ref) => \count($ref->getMethods(\ReflectionMethod::IS_PUBLIC)),
+            $interfaceRefs,
+        ));
+
+        return $methodCount === \count($classRef->getMethods(\ReflectionMethod::IS_PUBLIC));
+    }
+
+    private static function isClassEquivalentToItsParentClass(\ReflectionClass $classRef): bool
+    {
+        if (false === $parentClassRef = $classRef->getParentClass()) {
+            return false;
+        }
+
+        return \count($classRef->getMethods(\ReflectionMethod::IS_PUBLIC))
+            === \count($parentClassRef->getMethods(\ReflectionMethod::IS_PUBLIC));
+    }
+}

--- a/src/Util/DecoratorInfo.php
+++ b/src/Util/DecoratorInfo.php
@@ -156,10 +156,6 @@ final class DecoratorInfo
                         $default = 'null';
                     }
                 }
-
-                if (!empty($default)) {
-                    $default = ' = '.$default;
-                }
             }
 
             yield new MethodArgument(

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -255,4 +255,37 @@ final class Validator
 
         return $backedEnum;
     }
+
+    public static function serviceExists(string $id, array $ids = []): string
+    {
+        self::notBlank($id);
+
+        if (!\in_array($id, $ids)) {
+            throw new RuntimeCommandException(\sprintf('Service "%s" doesn\'t exist; please enter an existing one.', $id));
+        }
+
+        return $id;
+    }
+
+    /**
+     * @param class-string $interface
+     */
+    public static function allowedInterface(string $interface, array $interfaces): string
+    {
+        self::notBlank($interface);
+
+        if (empty($interfaces)) {
+            throw new RuntimeCommandException('Please give interfaces to check.');
+        }
+
+        if (!interface_exists($interface)) {
+            throw new RuntimeCommandException(\sprintf('The interface "%s" doesn\'t exist.', $interface));
+        }
+
+        if (!\in_array($interface, $interfaces)) {
+            throw new RuntimeCommandException(\sprintf('The interface "%s" is not allowed.', $interface));
+        }
+
+        return $interface;
+    }
 }

--- a/templates/decorator/Decorator.tpl.php
+++ b/templates/decorator/Decorator.tpl.php
@@ -1,0 +1,24 @@
+<?= "<?php\n" ?>
+
+namespace <?= $class_data->getNamespace() ?>;
+
+<?= $class_data->getUseStatements(); ?>
+
+#[AsDecorator(<?= $decorated_info->getDecoratedIdDeclaration(); ?>)]
+<?= $class_data->getClassDeclaration(); ?>
+
+{
+    public function __construct(
+        #[AutowireDecorated]
+        private readonly <?= $decorated_info->getShortNameInnerType(); ?> $inner,
+    ) {
+    }
+<?php foreach ($decorated_info->getPublicMethods() as $method): ?>
+
+    <?= $method->getDeclaration() ?>
+
+    {
+        <?php if (!$method->isReturnVoid()): ?>return <?php endif; ?><?= ($method->isStatic()) ? 'parent::' : '$this->inner->' ; ?><?php echo $method->getName() ?>(<?= $method->getArgumentsUse() ?>);
+    }
+<?php endforeach; ?>
+}

--- a/templates/decorator/Decorator.tpl.php
+++ b/templates/decorator/Decorator.tpl.php
@@ -4,7 +4,8 @@ namespace <?= $class_data->getNamespace() ?>;
 
 <?= $class_data->getUseStatements(); ?>
 
-#[AsDecorator(<?= $decorated_info->getDecoratedIdDeclaration(); ?>)]
+<?= $decorated_info->getDecorateAttributeDeclaration(); ?>
+
 <?= $class_data->getClassDeclaration(); ?>
 
 {
@@ -18,7 +19,9 @@ namespace <?= $class_data->getNamespace() ?>;
     <?= $method->getDeclaration() ?>
 
     {
-        <?php if (!$method->isReturnVoid()): ?>return <?php endif; ?><?= ($method->isStatic()) ? 'parent::' : '$this->inner->' ; ?><?php echo $method->getName() ?>(<?= $method->getArgumentsUse() ?>);
+        <?php if ($method->isStatic() && !$class_data->hasExtends()): ?>// @TODO Implements this static method<?php endif; ?>
+
+        <?php if ($method->isStatic() && !$class_data->hasExtends()): ?>// <?php endif; ?><?php if (!$method->isReturnVoid()): ?>return <?php endif; ?><?= ($method->isStatic()) ? 'parent::' : '$this->inner->' ; ?><?php echo $method->getName() ?>(<?= $method->getArgumentsUse() ?>);
     }
 <?php endforeach; ?>
 }

--- a/tests/DependencyInjection/DecoratorHelperTest.php
+++ b/tests/DependencyInjection/DecoratorHelperTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\DependencyInjection\DecoratorHelper;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceA;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceD;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceE;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceF;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceInterface;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\Sub\ServiceA as SubServiceA;
+
+class DecoratorHelperTest extends TestCase
+{
+    public function testSuggestIds()
+    {
+        $this->assertSame([
+            'ServiceA',
+            'ServiceD',
+            'ServiceE',
+            'ServiceF',
+            'ServiceInterface',
+            'bar.service_d',
+            'foo.service_e',
+            ServiceInterface::class,
+            ServiceF::class,
+            ServiceA::class,
+            SubServiceA::class,
+        ], $this->getHelper()->suggestIds());
+    }
+
+    /** @dataProvider realIdsProvider */
+    public function testGetRealIds(string $id, ?string $expected)
+    {
+        $this->assertSame($expected, $this->getHelper()->getRealId($id));
+    }
+
+    public function realIdsProvider(): \Generator
+    {
+        yield ['bar.service_d', 'bar.service_d'];
+        yield ['foo.service_e', 'foo.service_e'];
+        yield [ServiceInterface::class, ServiceInterface::class];
+        yield [ServiceF::class, ServiceF::class];
+        yield [ServiceA::class, ServiceA::class];
+        yield [SubServiceA::class, SubServiceA::class];
+        yield ['ServiceA', null];
+        yield ['ServiceD', 'bar.service_d'];
+        yield ['ServiceE', 'foo.service_e'];
+        yield ['ServiceF', ServiceF::class];
+        yield ['ServiceInterface', ServiceInterface::class];
+        yield ['ServiceeeInterface', null];
+        yield ['NotExisting', null];
+    }
+
+    /** @dataProvider guessRealIdsProvider */
+    public function testGuessRealIds(string $id, array $expected)
+    {
+        $this->assertSame($expected, $this->getHelper()->guessRealIds($id));
+    }
+
+    public function guessRealIdsProvider(): \Generator
+    {
+        yield [
+            'ServiceA',
+            [
+                ServiceA::class,
+                SubServiceA::class,
+                'bar.service_d',
+                'foo.service_e',
+                ServiceF::class,
+            ],
+        ];
+
+        yield ['ServiceeeInterface', [ServiceInterface::class]];
+        yield ['baar.servicce_d', ['bar.service_d']];
+        yield ['baaaaaar.servicce_d', []];
+        yield ['NotExisting', []];
+    }
+
+    /** @dataProvider classProvider */
+    public function testGetClass(string $id, string $expected)
+    {
+        $this->assertSame($expected, $this->getHelper()->getClass($id));
+    }
+
+    public function classProvider(): \Generator
+    {
+        yield ['bar.service_d', ServiceD::class];
+        yield ['foo.service_e', ServiceE::class];
+        yield [ServiceF::class, ServiceF::class];
+        yield [ServiceA::class, ServiceA::class];
+        yield [SubServiceA::class, SubServiceA::class];
+    }
+
+    public function testInvalidGetClass()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('Cannot getClass for id "NotExisting".');
+        $this->getHelper()->getClass('NotExisting');
+    }
+
+    private function getHelper(): DecoratorHelper
+    {
+        return new DecoratorHelper(
+            [
+                'bar.service_d',
+                'foo.service_e',
+                ServiceInterface::class,
+                ServiceF::class,
+                ServiceA::class,
+                SubServiceA::class,
+            ], [
+                'bar.service_d' => ServiceD::class,
+                'foo.service_e' => ServiceE::class,
+                ServiceInterface::class => ServiceA::class,
+            ], [
+                'ServiceA' => [
+                    ServiceA::class,
+                    SubServiceA::class,
+                ],
+                'ServiceD' => [
+                    'bar.service_d',
+                ],
+                'ServiceE' => [
+                    'foo.service_e',
+                ],
+                'ServiceF' => [
+                    ServiceF::class,
+                ],
+                'ServiceInterface' => [
+                    ServiceInterface::class,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/DependencyInjection/Fixtures/OtherServiceInterface.php
+++ b/tests/DependencyInjection/Fixtures/OtherServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+interface OtherServiceInterface
+{
+}

--- a/tests/DependencyInjection/Fixtures/ServiceA.php
+++ b/tests/DependencyInjection/Fixtures/ServiceA.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+class ServiceA implements ServiceInterface
+{
+    public function getName(): string
+    {
+        return 'service_a';
+    }
+
+    public function getDefault(string $mode = self::MODE_FOO): ?string
+    {
+        return $this->getName();
+    }
+}

--- a/tests/DependencyInjection/Fixtures/ServiceB.php
+++ b/tests/DependencyInjection/Fixtures/ServiceB.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+class ServiceB extends ServiceA
+{
+    public function getName(): string
+    {
+        return 'service_b';
+    }
+
+    public function getFoo(): bool
+    {
+        return true;
+    }
+
+    public static function getStaticValue(string $default = ''): ServiceInterface|string|null
+    {
+        return 'service_b';
+    }
+}

--- a/tests/DependencyInjection/Fixtures/ServiceC.php
+++ b/tests/DependencyInjection/Fixtures/ServiceC.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+class ServiceC
+{
+    public function getFoo(): string
+    {
+        return 'foo';
+    }
+}

--- a/tests/DependencyInjection/Fixtures/ServiceD.php
+++ b/tests/DependencyInjection/Fixtures/ServiceD.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+class ServiceD extends ServiceA
+{
+    public function getDefault(string $mode = self::MODE_FOO): ?string
+    {
+        return parent::getDefault($mode);
+    }
+}

--- a/tests/DependencyInjection/Fixtures/ServiceE.php
+++ b/tests/DependencyInjection/Fixtures/ServiceE.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+final class ServiceE extends ServiceA
+{
+}

--- a/tests/DependencyInjection/Fixtures/ServiceF.php
+++ b/tests/DependencyInjection/Fixtures/ServiceF.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+final class ServiceF implements ServiceInterface, OtherServiceInterface
+{
+    public function getName(): string
+    {
+        return 'service_f';
+    }
+
+    public function getDefault(string $mode = self::MODE_FOO): ?string
+    {
+        return 'service_f';
+    }
+}

--- a/tests/DependencyInjection/Fixtures/ServiceInterface.php
+++ b/tests/DependencyInjection/Fixtures/ServiceInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+interface ServiceInterface
+{
+    public const MODE_FOO = 'foo';
+
+    public function getName(): string;
+
+    public function getDefault(string $mode = self::MODE_FOO): ?string;
+}

--- a/tests/DependencyInjection/Fixtures/ServiceZ.php
+++ b/tests/DependencyInjection/Fixtures/ServiceZ.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures;
+
+final class ServiceZ
+{
+}

--- a/tests/DependencyInjection/Fixtures/Sub/ServiceA.php
+++ b/tests/DependencyInjection/Fixtures/Sub/ServiceA.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\Sub;
+
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceInterface;
+
+class ServiceA implements ServiceInterface
+{
+    public function getName(): string
+    {
+        return 'FOO';
+    }
+
+    public function getDefault(string $mode = self::MODE_FOO): ?string
+    {
+        return null;
+    }
+}

--- a/tests/DependencyInjection/Fixtures/Sub/ServiceB.php
+++ b/tests/DependencyInjection/Fixtures/Sub/ServiceB.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\Sub;
+
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceB as BaseService;
+
+class ServiceB extends BaseService
+{
+}

--- a/tests/DependencyInjection/Fixtures/Sub/ServiceD.php
+++ b/tests/DependencyInjection/Fixtures/Sub/ServiceD.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\Sub;
+
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceD as BaseService;
+
+class ServiceD extends BaseService
+{
+    public function blabla(): void
+    {
+    }
+}

--- a/tests/Maker/MakeDecoratorTest.php
+++ b/tests/Maker/MakeDecoratorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeDecorator;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+
+class MakeDecoratorTest extends MakerTestCase
+{
+    protected function getMakerClass(): string
+    {
+        return MakeDecorator::class;
+    }
+
+    protected function createMakerTest(): MakerTestDetails
+    {
+        return parent::createMakerTest()
+            ->preRun(function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-decorator/basic_setup',
+                    ''
+                );
+
+                $runner->modifyYamlFile('config/services.yaml', function (array $config) {
+                    $config['services']['App\\Service\\'] = [
+                        'resource' => '../src/Service',
+                        'public' => true,
+                    ];
+
+                    return $config;
+                });
+            });
+    }
+
+    public function getTestDetails(): \Generator
+    {
+        yield 'it_generates_basic_implements' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker([
+                    'App\\Service\\FooService',
+                    'GeneratedServiceDecorator',
+                ]);
+
+                $this->runFormTest($runner, 'it_generates_basic_implements.php');
+            }),
+        ];
+
+        yield 'it_generates_multiple_implements' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker([
+                    'App\\Service\\MultipleImpService',
+                    'GeneratedServiceDecorator',
+                ]);
+
+                $this->runFormTest($runner, 'it_generates_multiple_implements.php');
+            }),
+        ];
+
+        yield 'it_generates_force_extends' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker([
+                    'App\\Service\\ForExtendService',
+                    'GeneratedServiceDecorator',
+                ]);
+
+                $this->runFormTest($runner, 'it_generates_force_extends.php');
+            }),
+        ];
+    }
+
+    private function runFormTest(MakerTestRunner $runner, string $filename): void
+    {
+        $runner->copy(
+            'make-decorator/tests/'.$filename,
+            'tests/GeneratedDecoratorTest.php'
+        );
+
+        $runner->runTests();
+    }
+}

--- a/tests/Util/ClassSource/ClassMethodTest.php
+++ b/tests/Util/ClassSource/ClassMethodTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Util\ClassSource;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassMethod;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\MethodArgument;
+
+class ClassMethodTest extends TestCase
+{
+    public function testGetName()
+    {
+        self::assertSame('foobar', (new ClassMethod('foobar'))->getName());
+    }
+
+    /** @dataProvider returnVoidProvider */
+    public function testReturnVoid(?string $returnType, bool $isVoid)
+    {
+        self::assertSame($isVoid, (new ClassMethod('foobar', [], $returnType))->isReturnVoid());
+    }
+
+    public function returnVoidProvider(): \Generator
+    {
+        yield ['void', true];
+        yield ['string', false];
+        yield [null, false];
+    }
+
+    public function testIsStatic()
+    {
+        self::assertTrue((new ClassMethod('foobar', [], null, true))->isStatic());
+        self::assertFalse((new ClassMethod('foobar', [], null, false))->isStatic());
+        self::assertFalse((new ClassMethod('foobar'))->isStatic());
+    }
+
+    /** @dataProvider declarationsProvider */
+    public function testGetDeclaration(array $args, ?string $returnType, bool $isStatic, string $expectedDeclaration): void
+    {
+        $classMethod = new ClassMethod('foobar', $args, $returnType, $isStatic);
+
+        self::assertSame($expectedDeclaration, $classMethod->getDeclaration());
+    }
+
+    public function declarationsProvider(): \Generator
+    {
+        yield [
+            [],
+            null,
+            false,
+            'public function foobar()',
+        ];
+
+        yield [
+            [
+                new MethodArgument('toto', 'array'),
+                new MethodArgument('titi', 'AClass'),
+                new MethodArgument('foo', 'string', '\'THE_DEFAULT_VALUE\''),
+                new MethodArgument('bar', 'int', 'self::NUM'),
+            ],
+            'void',
+            false,
+            'public function foobar(array $toto, AClass $titi, string $foo = \'THE_DEFAULT_VALUE\', int $bar = self::NUM): void',
+        ];
+
+        yield [
+            [],
+            'string',
+            true,
+            'public static function foobar(): string',
+        ];
+    }
+
+    /** @dataProvider argumentsUsesProvider */
+    public function testGetArgumentsUse(array $args, string $expectedDeclaration): void
+    {
+        $classMethod = new ClassMethod('foobar', $args);
+
+        self::assertSame($expectedDeclaration, $classMethod->getArgumentsUse());
+    }
+
+    public function argumentsUsesProvider(): \Generator
+    {
+        yield [
+            [],
+            '',
+        ];
+
+        yield [
+            [
+                new MethodArgument('toto', 'array'),
+                new MethodArgument('titi', 'AClass'),
+                new MethodArgument('foo', 'string', '\'THE_DEFAULT_VALUE\''),
+                new MethodArgument('bar', 'int', 'self::NUM'),
+            ],
+            '$toto, $titi, $foo, $bar',
+        ];
+
+        yield [
+            [
+                new MethodArgument('toto', 'array'),
+            ],
+            '$toto',
+        ];
+    }
+}

--- a/tests/Util/ClassSource/MethodArgumentTest.php
+++ b/tests/Util/ClassSource/MethodArgumentTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Util\ClassSource;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\MethodArgument;
+
+/**
+ * Class MethodArgumentTest.
+ *
+ * @author Benjamin Georgeault
+ */
+class MethodArgumentTest extends TestCase
+{
+    /** @dataProvider declarationsProvider */
+    public function testGetDeclaration(?string $type, ?string $default, string $expected)
+    {
+        $methodArgument = new MethodArgument('foo', $type, $default);
+
+        $this->assertSame($expected, $methodArgument->getDeclaration());
+    }
+
+    public function declarationsProvider(): \Generator
+    {
+        yield [
+            null,
+            null,
+            '$foo',
+        ];
+
+        yield [
+            'string',
+            '\'foobar\'',
+            'string $foo = \'foobar\'',
+        ];
+
+        yield [
+            'string',
+            null,
+            'string $foo',
+        ];
+    }
+
+    public function testGetVariable()
+    {
+        $methodArgument = new MethodArgument('foo');
+
+        $this->assertSame('$foo', $methodArgument->getVariable());
+    }
+}

--- a/tests/Util/DecoratorInfoTest.php
+++ b/tests/Util/DecoratorInfoTest.php
@@ -1,0 +1,273 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\OtherServiceInterface;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceA;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceB;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceC;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceD;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceE;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceF;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceInterface;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceZ;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\Sub\ServiceA as SubServiceA;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\Sub\ServiceB as SubServiceB;
+use Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\Sub\ServiceD as SubServiceD;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+use Symfony\Bundle\MakerBundle\Util\DecoratorInfo;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
+
+class DecoratorInfoTest extends TestCase
+{
+    public function testInvalid()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('Cannot decorate "Symfony\Bundle\MakerBundle\Tests\DependencyInjection\Fixtures\ServiceZ", its class does not have any interface, parent class and its final.');
+        new DecoratorInfo('FooBar', 'foo.bar', ServiceZ::class);
+    }
+
+    /** @dataProvider publicMethodsProvider */
+    public function testGetPublicMethods(string $decoratedClassOrInterface, array $expected)
+    {
+        $decoratorInfo = new DecoratorInfo('FooBar', 'foo.bar', $decoratedClassOrInterface);
+
+        $this->assertSame($expected, array_keys($decoratorInfo->getPublicMethods()));
+    }
+
+    public function publicMethodsProvider(): \Generator
+    {
+        yield [ServiceInterface::class, ['getName', 'getDefault']];
+        yield [ServiceA::class, ['getName', 'getDefault']];
+        yield [ServiceB::class, ['getName', 'getFoo', 'getStaticValue', 'getDefault']];
+        yield [ServiceC::class, ['getFoo']];
+        yield [ServiceD::class, ['getName', 'getDefault']];
+        yield [ServiceE::class, ['getName', 'getDefault']];
+        yield [ServiceF::class, ['getName', 'getDefault']];
+    }
+
+    /** @dataProvider classDataProvider */
+    public function testGetClassData(string $decoratedId, string $decoratedClassOrInterface, ClassData $expected)
+    {
+        $decoratorInfo = new DecoratorInfo('FooBar', $decoratedId, $decoratedClassOrInterface);
+
+        $this->assertEquals($expected, $decoratorInfo->getClassData());
+    }
+
+    public function classDataProvider(): \Generator
+    {
+        yield [
+            'foo.bar',
+            ServiceInterface::class,
+            ClassData::create(
+                class: 'FooBar',
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                ],
+                implements: [ServiceInterface::class],
+            ),
+        ];
+
+        yield [
+            'foo.bar',
+            ServiceA::class,
+            ClassData::create(
+                class: 'FooBar',
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                ],
+                implements: [ServiceInterface::class],
+            ),
+        ];
+
+        yield [
+            'foo.bar',
+            ServiceB::class,
+            ClassData::create(
+                class: 'FooBar',
+                extendsClass: ServiceB::class,
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                    ServiceB::class,
+                    ServiceInterface::class,
+                ],
+            ),
+        ];
+
+        yield [
+            'foo.bar',
+            ServiceC::class,
+            ClassData::create(
+                class: 'FooBar',
+                extendsClass: ServiceC::class,
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                ],
+            ),
+        ];
+
+        yield [
+            'foo.bar',
+            ServiceD::class,
+            ClassData::create(
+                class: 'FooBar',
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                ],
+                implements: [ServiceInterface::class],
+            ),
+        ];
+
+        yield [
+            'foo.bar',
+            ServiceE::class,
+            ClassData::create(
+                class: 'FooBar',
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                ],
+                implements: [ServiceInterface::class],
+            ),
+        ];
+
+        yield [
+            'foo.bar',
+            ServiceF::class,
+            ClassData::create(
+                class: 'FooBar',
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                ],
+                implements: [
+                    ServiceInterface::class,
+                    OtherServiceInterface::class,
+                ],
+            ),
+        ];
+
+        yield [
+            ServiceInterface::class,
+            ServiceF::class,
+            ClassData::create(
+                class: 'FooBar',
+                useStatements: [
+                    AsDecorator::class,
+                    AutowireDecorated::class,
+                ],
+                implements: [
+                    ServiceInterface::class,
+                    OtherServiceInterface::class,
+                ],
+            ),
+        ];
+    }
+
+    /** @dataProvider decoratedIdDeclarationProvider */
+    public function testGetDecoratedIdDeclaration(string $serviceId, string $decoratedClassOrInterface, string $expected, bool $idAsClassOrInterface)
+    {
+        $decoratorInfo = new DecoratorInfo('FooBar', $serviceId, $decoratedClassOrInterface);
+
+        $this->assertSame($expected, $decoratorInfo->getDecoratedIdDeclaration());
+
+        if ($idAsClassOrInterface) {
+            $this->assertTrue($decoratorInfo->getClassData()->hasUseStatement($serviceId));
+        }
+    }
+
+    public function decoratedIdDeclarationProvider(): \Generator
+    {
+        yield ['foo.bar', ServiceInterface::class, '\'foo.bar\'', false];
+        yield [ServiceInterface::class, ServiceInterface::class, 'ServiceInterface::class', true];
+    }
+
+    /** @dataProvider shortNameInnerTypeProvider */
+    public function testGetShortNameInnerType(string $decoratedClassOrInterface, string $expected, array $inUseStatements)
+    {
+        $decoratorInfo = new DecoratorInfo('FooBar', 'foo.bar', $decoratedClassOrInterface);
+
+        $this->assertSame($expected, $decoratorInfo->getShortNameInnerType());
+
+        foreach ($inUseStatements as $inUseStatement) {
+            $this->assertTrue($decoratorInfo->getClassData()->hasUseStatement($inUseStatement));
+        }
+    }
+
+    public function shortNameInnerTypeProvider(): \Generator
+    {
+        yield [ServiceInterface::class, 'ServiceInterface', [ServiceInterface::class]];
+        yield [ServiceA::class, 'ServiceInterface', [ServiceInterface::class]];
+        yield [ServiceB::class, 'ServiceB', [ServiceB::class]];
+        yield [ServiceC::class, 'ServiceC', [ServiceC::class]];
+        yield [ServiceD::class, 'ServiceInterface', [ServiceInterface::class]];
+        yield [ServiceE::class, 'ServiceInterface', [ServiceInterface::class]];
+        yield [ServiceF::class, 'ServiceInterface&OtherServiceInterface', [ServiceInterface::class, OtherServiceInterface::class]];
+    }
+
+    /** @dataProvider aliasOnClassNameProvider */
+    public function testAliasOnClassName(string $decoratorClassName, string $decoratedId, string $decoratedClassOrInterface, array $inUseStatements)
+    {
+        $decoratorInfo = new DecoratorInfo($decoratorClassName, $decoratedId, $decoratedClassOrInterface);
+
+        foreach ($inUseStatements as $class => $alias) {
+            $this->assertSame($alias, $decoratorInfo->getClassData()->getUseStatementShortName($class));
+        }
+    }
+
+    public function aliasOnClassNameProvider(): \Generator
+    {
+        yield [
+            'TheService\\ServiceA',
+            SubServiceA::class,
+            SubServiceA::class,
+            [
+                SubServiceA::class => 'ServiceServiceA',
+            ],
+        ];
+
+        yield [
+            'TheService\\ServiceB',
+            ServiceB::class,
+            ServiceB::class,
+            [
+                ServiceB::class => 'BaseServiceB',
+            ],
+        ];
+
+        yield [
+            'TheService\\ServiceB',
+            SubServiceB::class,
+            SubServiceB::class,
+            [
+                ServiceB::class => 'BaseServiceB',
+            ],
+        ];
+
+        yield [
+            'TheService\\ServiceD',
+            SubServiceD::class,
+            SubServiceD::class,
+            [
+                SubServiceD::class => 'BaseServiceD',
+            ],
+        ];
+    }
+}

--- a/tests/Util/UseStatementGeneratorTest.php
+++ b/tests/Util/UseStatementGeneratorTest.php
@@ -106,4 +106,32 @@ class UseStatementGeneratorTest extends TestCase
             EOT;
         self::assertSame($expected, (string) $unsorted);
     }
+
+    public function testUseStatementShortName()
+    {
+        $statement = new UseStatementGenerator([
+            \Symfony\UX\Turbo\Attribute\Broadcast::class,
+            \ApiPlatform\Core\Annotation\ApiResource::class,
+            [\Doctrine\ORM\Mapping::class => 'ORM'],
+        ]);
+
+        self::assertSame('Broadcast', $statement->getShortName(\Symfony\UX\Turbo\Attribute\Broadcast::class));
+        self::assertSame('ApiResource', $statement->getShortName(\ApiPlatform\Core\Annotation\ApiResource::class));
+        self::assertSame('ORM', $statement->getShortName(\Doctrine\ORM\Mapping::class));
+        self::assertSame('ORM\\Entity', $statement->getShortName(\Doctrine\ORM\Mapping\Entity::class));
+    }
+
+    public function testHasUseStatement()
+    {
+        $statement = new UseStatementGenerator([
+            \Symfony\UX\Turbo\Attribute\Broadcast::class,
+            \ApiPlatform\Core\Annotation\ApiResource::class,
+            [\Doctrine\ORM\Mapping::class => 'ORM'],
+        ]);
+
+        self::assertTrue($statement->hasUseStatement(\ApiPlatform\Core\Annotation\ApiResource::class));
+        self::assertTrue($statement->hasUseStatement(\Symfony\UX\Turbo\Attribute\Broadcast::class));
+        self::assertTrue($statement->hasUseStatement(\Doctrine\ORM\Mapping::class));
+        self::assertFalse($statement->hasUseStatement(\Doctrine\ORM\Cache::class));
+    }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -116,4 +116,53 @@ class ValidatorTest extends TestCase
         $this->expectExceptionMessage(\sprintf('Entity "%s" doesn\'t exist; please enter an existing one or create a new one.', $className));
         Validator::entityExists($className, ['Full\Entity\DummyEntity']);
     }
+
+    public function testServiceExists()
+    {
+        $id = 'my_existing.service_id';
+        $ids = ['my_existing.service_id'];
+
+        $this->assertSame($id, Validator::serviceExists($id, $ids));
+    }
+
+    public function testServiceDoesNotExists()
+    {
+        $id = 'my_non_existing.service_id';
+        $ids = ['my_existing.service_id'];
+
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('Service "my_non_existing.service_id" doesn\'t exist; please enter an existing one.');
+        Validator::serviceExists($id, $ids);
+    }
+
+    public function testEmptyAllowedInterface()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('Please give interfaces to check.');
+        Validator::allowedInterface('Throwable', []);
+    }
+
+    public function testNonExistingAllowedInterface()
+    {
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('The interface "FooBar\RandomInterface" doesn\'t exist.');
+        Validator::allowedInterface('FooBar\RandomInterface', ['Throwable']);
+    }
+
+    public function testAllowedInterface()
+    {
+        $interface = 'Throwable';
+
+        $this->assertSame($interface, Validator::allowedInterface($interface, [$interface]));
+    }
+
+    public function testNotAllowedInterface()
+    {
+        $interface = 'Throwable';
+        $interfaces = ['Iterator'];
+
+        $this->expectException(RuntimeCommandException::class);
+        $this->expectExceptionMessage('The interface "Throwable" is not allowed.');
+        $this->assertSame($interface, Validator::allowedInterface($interface, $interfaces));
+    }
 }

--- a/tests/fixtures/make-decorator/basic_setup/src/Service/BarInterface.php
+++ b/tests/fixtures/make-decorator/basic_setup/src/Service/BarInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Service;
+
+interface BarInterface
+{
+    public function doSomething(): void;
+}

--- a/tests/fixtures/make-decorator/basic_setup/src/Service/FooInterface.php
+++ b/tests/fixtures/make-decorator/basic_setup/src/Service/FooInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Service;
+
+interface FooInterface
+{
+    public function getTheValue(): string;
+}

--- a/tests/fixtures/make-decorator/basic_setup/src/Service/FooService.php
+++ b/tests/fixtures/make-decorator/basic_setup/src/Service/FooService.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Service;
+
+class FooService implements FooInterface
+{
+    public function getTheValue(): string
+    {
+        return 'THE_FOO_VALUE';
+    }
+}

--- a/tests/fixtures/make-decorator/basic_setup/src/Service/ForExtendService.php
+++ b/tests/fixtures/make-decorator/basic_setup/src/Service/ForExtendService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Service;
+
+class ForExtendService implements FooInterface, BarInterface
+{
+    public function getTheValue(): string
+    {
+        return 'THE_FOO_VALUE';
+    }
+
+    public function doSomething(): void
+    {
+    }
+
+    public function booh(): void
+    {
+    }
+}

--- a/tests/fixtures/make-decorator/basic_setup/src/Service/MultipleImpService.php
+++ b/tests/fixtures/make-decorator/basic_setup/src/Service/MultipleImpService.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Service;
+
+class MultipleImpService implements FooInterface, BarInterface
+{
+    public function getTheValue(): string
+    {
+        return 'THE_FOO_VALUE';
+    }
+
+    public function doSomething(): void
+    {
+    }
+}

--- a/tests/fixtures/make-decorator/tests/it_generates_basic_implements.php
+++ b/tests/fixtures/make-decorator/tests/it_generates_basic_implements.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests;
+
+use App\GeneratedServiceDecorator;
+use App\Service\FooInterface;
+use App\Service\FooService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GeneratedDecoratorTest extends KernelTestCase
+{
+    public function testGeneratedDecorator()
+    {
+        $container = self::getContainer();
+
+        /** @var FooService $service */
+        $service = $container->get(FooService::class);
+
+        $this->assertInstanceOf(GeneratedServiceDecorator::class, $service);
+        $this->assertInstanceOf(FooInterface::class, $service);
+        $this->assertNotInstanceOf(FooService::class, $service);
+
+        $this->assertSame('THE_FOO_VALUE', $service->getTheValue());
+    }
+}

--- a/tests/fixtures/make-decorator/tests/it_generates_force_extends.php
+++ b/tests/fixtures/make-decorator/tests/it_generates_force_extends.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Tests;
+
+use App\GeneratedServiceDecorator;
+use App\Service\ForExtendService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GeneratedDecoratorTest extends KernelTestCase
+{
+    public function testGeneratedDecorator()
+    {
+        $container = self::getContainer();
+
+        /** @var ForExtendService $service */
+        $service = $container->get(ForExtendService::class);
+
+        $this->assertInstanceOf(GeneratedServiceDecorator::class, $service);
+        $this->assertInstanceOf(ForExtendService::class, $service);
+    }
+}

--- a/tests/fixtures/make-decorator/tests/it_generates_multiple_implements.php
+++ b/tests/fixtures/make-decorator/tests/it_generates_multiple_implements.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests;
+
+use App\GeneratedServiceDecorator;
+use App\Service\BarInterface;
+use App\Service\FooInterface;
+use App\Service\MultipleImpService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GeneratedDecoratorTest extends KernelTestCase
+{
+    public function testGeneratedDecorator()
+    {
+        $container = self::getContainer();
+
+        /** @var MultipleImpService $service */
+        $service = $container->get(MultipleImpService::class);
+
+        $this->assertInstanceOf(GeneratedServiceDecorator::class, $service);
+        $this->assertInstanceOf(FooInterface::class, $service);
+        $this->assertInstanceOf(BarInterface::class, $service);
+        $this->assertNotInstanceOf(MultipleImpService::class, $service);
+
+        $this->assertSame('THE_FOO_VALUE', $service->getTheValue());
+    }
+}


### PR DESCRIPTION
Add new maker to create decorator.
https://github.com/symfony/maker-bundle/issues/1401

Allow to create new decorator for existing services.

It try first to decorate by implements:
- The service ID used is an interface => implements this interface
- The service class implements one (or more) interface(s) and it do not declare more public method => implements those interfaces

If cannot implements, it will fallback to extends:
- Simply extends the service's class
- Do not work for final class

e.g.

```shell
bin/console make:decorator Symfony\Component\Routing\Generator\UrlGeneratorInterface MyUrlGenerator
```

```php
<?php

namespace App;

use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
use Symfony\Component\Routing\RequestContext;

#[AsDecorator(UrlGeneratorInterface::class)]
final class MyUrlGenerator implements UrlGeneratorInterface
{
    public function __construct(
        #[AutowireDecorated]
        private readonly UrlGeneratorInterface $inner,
    ) {
    }

    public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
    {
        return $this->inner->generate($name, $parameters, $referenceType);
    }

    public function setContext(RequestContext $context): void
    {
        $this->inner->setContext($context);
    }

    public function getContext(): RequestContext
    {
        return $this->inner->getContext();
    }
}
```
