### PR TITLE
[make:twig-component] read processed twig_component config instead of parsing the yaml file

### DIFF
--- a/config/makers.xml
+++ b/config/makers.xml
@@ -22,7 +22,6 @@
 
             <service id="maker.maker.make_twig_component" class="Symfony\Bundle\MakerBundle\Maker\MakeTwigComponent">
                 <tag name="maker.command" />
-                <argument type="service" id="maker.file_manager" />
             </service>
 
             <service id="maker.maker.make_controller" class="Symfony\Bundle\MakerBundle\Maker\MakeController">

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -11,19 +11,21 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
-use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
-use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\DependencyInjection\TwigComponentExtension;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -31,10 +33,6 @@ use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 final class MakeTwigComponent extends AbstractMaker
 {
     private string $namespace = 'Twig\\Components';
-
-    public function __construct(private FileManager $fileManager)
-    {
-    }
 
     public static function getCommandName(): string
     {
@@ -103,17 +101,63 @@ final class MakeTwigComponent extends AbstractMaker
             $input->setOption('live', $io->confirm('Make this a live component?', false));
         }
 
-        $path = 'config/packages/twig_component.yaml';
+        $application = $command->getApplication();
+        assert($application instanceof Application);
 
-        if (!$this->fileManager->fileExists($path)) {
-            throw new RuntimeCommandException(message: 'Unable to find twig_component.yaml');
+        $container = $this->compileContainer($application);
+        $config = $this->getConfig($container);
+
+        if (isset($config['defaults'])) {
+            $namespace = array_key_first($config['defaults']);
+            $this->namespace = substr($namespace, \strpos($namespace, '\\') + 1);
+        }
+    }
+
+    private function compileContainer(Application $application): ContainerBuilder
+    {
+        // logic from \Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand
+        $kernel = clone $application->getKernel();
+        $kernel->boot();
+
+        $method = new \ReflectionMethod($kernel, 'buildContainer');
+        $container = $method->invoke($kernel);
+        $container->getCompiler()->compile($container);
+
+        return $container;
+    }
+
+    private function getConfig(ContainerBuilder $container): mixed
+    {
+        return $container->resolveEnvPlaceholders(
+            $container->getParameterBag()->resolveValue(
+                $this->getConfigForExtension($container)
+            ), true
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getConfigForExtension(ContainerBuilder $container): array
+    {
+        $extensionAlias = 'twig_component';
+
+        $extensionConfig = [];
+        foreach ($container->getCompilerPassConfig()->getPasses() as $pass) {
+            if ($pass instanceof ValidateEnvPlaceholdersPass) {
+                $extensionConfig = $pass->getExtensionConfig();
+                break;
+            }
         }
 
-        try {
-            $value = Yaml::parse($this->fileManager->getFileContents($path));
-            $this->namespace = substr(array_key_first($value['twig_component']['defaults']), 4);
-        } catch (\Throwable $throwable) {
-            throw new RuntimeCommandException(message: 'Unable to parse twig_component.yaml', previous: $throwable);
+        if (isset($extensionConfig[$extensionAlias])) {
+            return $extensionConfig[$extensionAlias];
         }
+
+        // Fall back to default config if the extension has one
+        $extension = new TwigComponentExtension();
+        $configs = $container->getExtensionConfig($extensionAlias);
+
+        return (new Processor())->processConfiguration($extension, $configs);
     }
 }


### PR DESCRIPTION
changes from #1571 breaks if config is in php files even `$namespace` has a default value

this PR read the processed twig_component config no matter how the config was created