### PR TITLE
[make:entity] Issue with detected mixed type set to be nullable

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -143,7 +143,7 @@ final class ClassSourceManipulator
         }
 
         $propertyType = $typeHint;
-        if ($propertyType && !$defaultValue) {
+        if ($propertyType && !$defaultValue && $propertyType !== 'mixed') {
             // all property types
             $propertyType = '?'.$propertyType;
         }
@@ -162,13 +162,13 @@ final class ClassSourceManipulator
             // getter methods always have nullable return values
             // because even though these are required in the db, they may not be set yet
             // unless there is a default value
-            null === $defaultValue,
+            null === $defaultValue && $propertyType !== 'mixed',
             $commentLines
         );
 
         // don't generate setters for id fields
         if (!($mapping->id ?? false)) {
-            $this->addSetter($mapping->propertyName, $typeHint, $nullable);
+            $this->addSetter($mapping->propertyName, $typeHint, $nullable && $propertyType !== 'mixed');
         }
     }
 


### PR DESCRIPTION
Hi there, pretty strange edge case found in #1612 when `mixed` type is detected from a custom doctrine type and was set to be nullable. Maker tried to set is as `?mixed` which is not allowed.

That should fix this behavior.

closes #1612 