### PR TITLE
[make-entity]Keep the 'is' prefixes for booleans properties setters

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -485,10 +485,6 @@ final class ClassSourceManipulator
 
     private function getSetterName(string $propertyName, $type): string
     {
-        if ('bool' === $type && 0 === strncasecmp($propertyName, 'is', 2)) {
-            return 'set'.Str::asCamelCase(substr($propertyName, 2));
-        }
-
         return 'set'.Str::asCamelCase($propertyName);
     }
 

--- a/templates/verifyEmail/EmailVerifier.tpl.php
+++ b/templates/verifyEmail/EmailVerifier.tpl.php
@@ -43,7 +43,7 @@ class <?= $class_name; ?><?= "\n" ?>
     {
         $this->verifyEmailHelper->validateEmailConfirmationFromRequest($request, (string) $user-><?= $id_getter ?>(), (string) $user-><?= $email_getter?>());
 
-        $user->setVerified(true);
+        $user->setIsVerified(true);
 
         $this->entityManager->persist($user);
         $this->entityManager->flush();

--- a/tests/Util/fixtures/add_setter/User_bool_begins_with_is.php
+++ b/tests/Util/fixtures/add_setter/User_bool_begins_with_is.php
@@ -17,7 +17,7 @@ class User
         return $this->id;
     }
 
-    public function setFooProp(bool $isFooProp): static
+    public function setIsFooProp(bool $isFooProp): static
     {
         $this->isFooProp = $isFooProp;
 


### PR DESCRIPTION
When generating a new entity, if we name a boolean property with the prefix "is", this prefix is removed to construct the setter.

example:
 ```
bool $isInternational;

public function isInternational(): ?bool
{
    return $this->isInternational;
}

public function setInternational(bool $isInternational): static
{
    $this->isInternational = $isInternational;

    return $this;
}
```
This is breaking when we want to access the property via a form :

> [NoSuchPropertyException]
> HTTP 500 Internal Server Error
> The method "isInternational" in class "App\Entity\Conference" requires 0 arguments, but should accept only 1.. Make the property public, add a setter, or set the "mapped" field option in the form type to be false.


This PR revert this change introduce in [PR 1493](https://github.com/symfony/maker-bundle/pull/1493) to keep the 'is' prefix on the setter.

example :

```
public function setIsInternational(bool $isInternational): static 
{
    $this->isInternational = $isInternational;

    return $this;
}

```