### PR TITLE
[doc]remove prepended doubleslash in exceptionmessage

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -63,7 +63,7 @@ class Generator
         $targetPath = $this->fileManager->getRelativePathForFutureClass($className);
 
         if (null === $targetPath) {
-            throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "\\My\\Full\\Namespace\\%s"', $className, Str::getShortClassName($className)));
+            throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "My\\Full\\Namespace\\%s"', $className, Str::getShortClassName($className)));
         }
 
         $variables = array_merge($variables, [
@@ -97,7 +97,7 @@ class Generator
         $targetPath = $this->fileManager->getRelativePathForFutureClass($classData->getFullClassName());
 
         if (null === $targetPath) {
-            throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "\\My\\Full\\Namespace\\%s"', $classData->getFullClassName(), $classData->getClassName()));
+            throw new \LogicException(\sprintf('Could not determine where to locate the new class "%s", maybe try with a full namespace like "My\\Full\\Namespace\\%s"', $classData->getFullClassName(), $classData->getClassName()));
         }
 
         $globalTemplateVars = ['class_data' => $classData];


### PR DESCRIPTION
Removes the prepended '\\' in the Exceptionmessage when encountering an invalid FCQN 

#1615 

#SymfonyHackday
