### PR TITLE
Fix property doc for hashed password to allow nullable string

### DIFF
--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -201,7 +201,7 @@ final class UserClassBuilder
             return;
         }
 
-        $propertyDocs = '@var string The hashed password';
+        $propertyDocs = '@var ?string The hashed password';
         if ($userClassConfig->isEntity()) {
             // add entity property
             $manipulator->addEntityField(


### PR DESCRIPTION
Changed the PHPDoc for the hashed password property : 
`@var ?string` instead of `@var string` to handle nullable cases. This ensures better 
type safety and aligns with potential use cases.
