### PR TITLE
Correct bug #1628 - Unable to create an `Attribute` entity

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -192,7 +192,7 @@ class Generator
                 if (!empty($namespacePrefix) && empty($suffix)) {
                     $check = \sprintf('%s\%s', $namespacePrefix, $check);
                 }
-		Validator::classDoesNotExist($check);
+                Validator::classDoesNotExist($check);
 
                 $className = rtrim($fullNamespacePrefix, '\\').'\\'.$className;
             } catch (RuntimeCommandException) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -188,7 +188,7 @@ class Generator
             $className = Str::asClassName($name, $suffix);
 
             try {
-                Validator::classDoesNotExist($className);
+                Validator::classDoesNotExist(\sprintf('%s/%s', $namespacePrefix, $className));
                 $className = rtrim($fullNamespacePrefix, '\\').'\\'.$className;
             } catch (RuntimeCommandException) {
             }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -188,7 +188,12 @@ class Generator
             $className = Str::asClassName($name, $suffix);
 
             try {
-                Validator::classDoesNotExist(\sprintf('%s/%s', $namespacePrefix, $className));
+                $check = $className;
+                if (!empty($namespacePrefix) && empty($suffix)) {
+                    $check = \sprintf('%s\%s', $namespacePrefix, $check);
+                }
+		Validator::classDoesNotExist($check);
+
                 $className = rtrim($fullNamespacePrefix, '\\').'\\'.$className;
             } catch (RuntimeCommandException) {
             }


### PR DESCRIPTION
### Description

Added namespace verification for class existence during entity creation in the maker-bundle.
Fix issue : [1628](https://github.com/symfony/maker-bundle/issues/1628)

### Changes

- Modified the file to include namespace checks when verifying class existence.