### PR TITLE
[make:stimulus-controller] Add `classes` support, generate usage code, fix doc, add tests

### DIFF
--- a/config/help/MakeStimulusController.txt
+++ b/config/help/MakeStimulusController.txt
@@ -1,5 +1,15 @@
-The <info>%command.name%</info> command generates new Stimulus Controller.
+The <info>%command.name%</info> command generates a new Stimulus controller.
 
 <info>php %command.full_name% hello</info>
 
 If the argument is missing, the command will ask for the controller name interactively.
+
+To generate a TypeScript file (instead of a JavaScript file) use the <info>--typescript</info> 
+(or <info>--ts</info>) option:
+
+<info>php %command.full_name% hello --typescript</info>
+
+It will also interactively ask for values, targets, classes to add to the Stimulus 
+controller (optional).
+
+<info>php %command.full_name%</info>

--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -293,9 +293,9 @@ final class MakeStimulusController extends AbstractMaker
     }
 
     /**
-     * @param array<int, string>                $targets
-     * @param array{name: string, type: string} $values
-     * @param array<int, string>                $classes
+     * @param array<int, string>                       $targets
+     * @param array<array{name: string, type: string}> $values
+     * @param array<int, string>                       $classes
      */
     private function generateUsageExample(string $name, array $targets, array $values, array $classes): string
     {
@@ -331,7 +331,7 @@ final class MakeStimulusController extends AbstractMaker
             $controller,
             $htmlValues ? ("\n    ".implode("\n    ", $htmlValues)) : '',
             $htmlClasses ? ("\n    ".implode("\n    ", $htmlClasses)) : '',
-            $htmlValues || $htmlClasses ? "\n" : '',
+            ($htmlValues || $htmlClasses) ? "\n" : '',
             $htmlTargets ? ("\n        ".implode("\n        ", $htmlTargets)) : '',
             "\n        <!-- ... -->\n",
         );

--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -137,7 +137,7 @@ final class MakeStimulusController extends AbstractMaker
         $io->text([
             'Next:',
             \sprintf('- Open <info>%s</info> and add the code you need', $filePath),
-            'Find the documentation at <fg=yellow>https://github.com/symfony/stimulus-bridge</>',
+            'Find the documentation at <fg=yellow>https://symfony.com/bundles/StimulusBundle</>',
         ]);
     }
 

--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -59,7 +59,8 @@ final class MakeStimulusController extends AbstractMaker
             [
                 'js' => 'JavaScript',
                 'ts' => 'TypeScript',
-            ]
+            ],
+            'js',
         );
 
         $input->setArgument('extension', $chosenExtension);

--- a/src/Maker/MakeStimulusController.php
+++ b/src/Maker/MakeStimulusController.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\Question;
 use Symfony\UX\StimulusBundle\StimulusBundle;
 use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
@@ -44,8 +45,11 @@ final class MakeStimulusController extends AbstractMaker
     {
         $command
             ->addArgument('name', InputArgument::REQUIRED, 'The name of the Stimulus controller (e.g. <fg=yellow>hello</>)')
+            ->addOption('typescript', 'ts', InputOption::VALUE_NONE, 'Create a TypeScript controller (default is JavaScript)')
             ->setHelp($this->getHelpFileContents('MakeStimulusController.txt'))
         ;
+
+        $inputConfig->setArgumentAsNonInteractive('typescript');
     }
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
@@ -54,16 +58,20 @@ final class MakeStimulusController extends AbstractMaker
         $command->addArgument('targets', InputArgument::OPTIONAL);
         $command->addArgument('values', InputArgument::OPTIONAL);
 
-        $chosenExtension = $io->choice(
+        if ($input->getOption('typescript')) {
+            $input->setArgument('extension', 'ts');
+        } else {
+            $chosenExtension = $io->choice(
             'Language (<fg=yellow>JavaScript</> or <fg=yellow>TypeScript</>)',
-            [
-                'js' => 'JavaScript',
-                'ts' => 'TypeScript',
-            ],
-            'js',
-        );
+                [
+                    'js' => 'JavaScript',
+                    'ts' => 'TypeScript',
+                ],
+                'js',
+            );
 
-        $input->setArgument('extension', $chosenExtension);
+            $input->setArgument('extension', $chosenExtension);
+        }
 
         if ($io->confirm('Do you want to include targets?')) {
             $targets = [];

--- a/templates/stimulus/Controller.tpl.php
+++ b/templates/stimulus/Controller.tpl.php
@@ -4,6 +4,7 @@ import { Controller } from '@hotwired/stimulus';
 * The following line makes this controller "lazy": it won't be downloaded until needed
 * See https://symfony.com/bundles/StimulusBundle/current/index.html#lazy-stimulus-controllers
 */
+
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
 <?= $targets ? "    static targets = $targets\n" : "" ?>

--- a/templates/stimulus/Controller.tpl.php
+++ b/templates/stimulus/Controller.tpl.php
@@ -14,5 +14,32 @@ export default class extends Controller {
 <?php endforeach; ?>
     }
 <?php } ?>
-    // ...
+
+    initialize() {
+        // Called once when the controller is first instantiated (per element)
+
+        // Here you can initialize variables, create scoped callables for event
+        // listeners, instantiate external libraries, etc.
+        // this._fooBar = this.fooBar.bind(this)
+    }
+
+    connect() {
+        // Called every time the controller is connected to the DOM
+        // (on page load, when it's added to the DOM, moved in the DOM, etc.)
+
+        // Here you can add event listeners on the element or target elements,
+        // add or remove classes, attributes, dispatch custom events, etc.
+        // this.fooTarget.addEventListener('click', this._fooBar)
+    }
+
+    // Add custom controller actions here
+    // fooBar() { this.fooTarget.classList.toggle(this.bazClass) }
+
+    disconnect() {
+        // Called anytime its element is disconnected from the DOM
+        // (on page change, when it's removed from or moved in the DOM, etc.)
+
+        // Here you should remove all event listeners added in "connect()" 
+        // this.fooTarget.removeEventListener('click', this._fooBar)
+    }
 }

--- a/templates/stimulus/Controller.tpl.php
+++ b/templates/stimulus/Controller.tpl.php
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus';
 
 /*
 * The following line makes this controller "lazy": it won't be downloaded until needed
-* See https://github.com/symfony/stimulus-bridge#lazy-controllers
+* See https://symfony.com/bundles/StimulusBundle/current/index.html#lazy-stimulus-controllers
 */
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -36,7 +36,7 @@ class MakeStimulusControllerTest extends MakerTestCase
                 $this->assertFileExists($generatedFilePath);
             }),
         ];
-        
+
         yield 'it_generates_stimulus_controller_with_targets' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
@@ -87,6 +87,99 @@ class MakeStimulusControllerTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_stimulus_controller_with_values' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'with_values', // controller name
+                        'js', // controller language
+                        'no', // no targets
+                        'yes', // values
+                        'min', // first value
+                        'Number', // first value type
+                        'email', // second values
+                        'String', // second value type
+                        '', // empty input to stop adding values
+                    ]);
+
+                $generatedFilePath = $runner->getPath('assets/controllers/with_values_controller.js');
+
+                $this->assertFileExists($generatedFilePath);
+
+                $generatedFileContents = file_get_contents($generatedFilePath);
+                $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_values.js');
+
+                $this->assertSame(
+                    $expectedContents,
+                    $generatedFileContents
+                );
+            }),
+        ];
+
+        yield 'it_generates_stimulus_controller_with_classes' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'with_classes', // controller name
+                        'js', // use default extension (js)
+                        'no', // do not add targets
+                        'no', // do not add values
+                        'yes', // add classes
+                        'foo', // first class
+                        'bar', // second class
+                        '', // empty input to stop adding classes
+                    ]);
+
+                $generatedFilePath = $runner->getPath('assets/controllers/with_classes_controller.js');
+
+                $this->assertFileExists($generatedFilePath);
+
+                $generatedFileContents = file_get_contents($generatedFilePath);
+                $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_classes.js');
+
+                $this->assertSame(
+                    $expectedContents,
+                    $generatedFileContents
+                );
+            }),
+        ];
+
+        yield 'it_generates_stimulus_controller_with_targets_values_and_classes' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'with_targets_values_classes',
+                        'js',
+                        'yes', // add targets
+                        'aaa',
+                        'bbb',
+                        '',    // end
+                        'yes', // add values
+                        'ccc',
+                        'Number',
+                        'ddd',
+                        'String',
+                        '',    // end
+                        'yes', // add classes
+                        'eee',
+                        'fff',
+                        '',    // end
+                    ]);
+
+                $generatedFilePath = $runner->getPath('assets/controllers/with_targets_values_classes_controller.js');
+
+                $this->assertFileExists($generatedFilePath);
+
+                $generatedFileContents = file_get_contents($generatedFilePath);
+                $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_targets_values_classes.js');
+
+                $this->assertSame(
+                    $expectedContents,
+                    $generatedFileContents
+                );
+            }),
+        ];
+
         yield 'it_generates_typescript_stimulus_controller_interactively' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
@@ -101,7 +194,7 @@ class MakeStimulusControllerTest extends MakerTestCase
                 $this->assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
             }),
         ];
-        
+
         yield 'it_generates_typescript_stimulus_controller_when_option_is_set' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -24,6 +24,19 @@ class MakeStimulusControllerTest extends MakerTestCase
 
     public function getTestDetails(): \Generator
     {
+        yield 'it_generates_stimulus_controller' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'default', // controller name
+                    ],
+                );
+
+                $generatedFilePath = $runner->getPath('assets/controllers/default_controller.js');
+                $this->assertFileExists($generatedFilePath);
+            }),
+        ];
+        
         yield 'it_generates_stimulus_controller_with_targets' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
@@ -74,16 +87,34 @@ class MakeStimulusControllerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_typescript_stimulus_controller' => [$this->createMakerTest()
+        yield 'it_generates_typescript_stimulus_controller_interactively' => [$this->createMakerTest()
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'typescript', // controller name
                         'ts', // controller language
                         'no', // do not add targets
-                    ]);
+                    ],
+                );
 
                 $this->assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));
+                $this->assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
+            }),
+        ];
+        
+        yield 'it_generates_typescript_stimulus_controller_when_option_is_set' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [
+                        'typescript', // controller name
+                        // '', // language is not asked interactively
+                        'no', // do not add targets
+                    ],
+                    ' --typescript'
+                );
+
+                $this->assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));
+                $this->assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
             }),
         ];
     }

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -210,5 +210,70 @@ class MakeStimulusControllerTest extends MakerTestCase
                 $this->assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
             }),
         ];
+
+        yield 'it_displays_controller_basic_usage_example' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker(
+                    [
+                        'fooBar',
+                        'js',
+                    ],
+                );
+
+                $usageExample = <<<HTML
+                        <div data-controller="foo-bar">
+                            <!-- ... -->
+                        </div>
+                    HTML;
+
+                $this->assertStringContainsString('- Use the controller in your templates:', $output);
+                foreach (explode("\n", $usageExample) as $line) {
+                    $this->assertStringContainsString($line, $output);
+                }
+            }),
+        ];
+
+        yield 'it_displays_controller_complete_usage_example' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $output = $runner->runMaker(
+                    [
+                        'fooBar',
+                        'js',
+                        'yes', // add targets
+                        'firstOne',
+                        'secondOne',
+                        '',
+                        'yes', // add values
+                        'minItems',
+                        'Number',
+                        'email',
+                        'String',
+                        '',
+                        'yes', // add classes
+                        'isVisible',
+                        'hidden',
+                        '',
+                    ],
+                );
+
+                $usageExample = <<<HTML
+                        <div data-controller="foo-bar"
+                            data-foo-bar-min-items-value="123"
+                            data-foo-bar-email-value="abc"
+                            data-foo-bar-is-visible-class="isVisible"
+                            data-foo-bar-hidden-class="hidden"
+                        >
+                            <div data-foo-bar-target="firstOne"></div>
+                            <div data-foo-bar-target="secondOne"></div>
+                            <!-- ... -->
+                        </div>
+                    HTML;
+
+                $this->assertStringContainsString('- Use the controller in your templates:', $output);
+                foreach (explode("\n", $usageExample) as $line) {
+                    $this->assertStringContainsString($line, $output);
+                }
+            }),
+        ];
     }
 }

--- a/tests/fixtures/make-stimulus-controller/with_classes.js
+++ b/tests/fixtures/make-stimulus-controller/with_classes.js
@@ -7,15 +7,7 @@ import { Controller } from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
-<?= $targets ? "    static targets = $targets\n" : "" ?>
-<?php if ($values) { ?>
-    static values = {
-<?php foreach ($values as $value): ?>
-        <?= $value['name'] ?>: <?= $value['type'] ?>,
-<?php endforeach; ?>
-    }
-<?php } ?>
-<?= $classes ? "    static classes = $classes\n" : '' ?>
+    static classes = ['foo', 'bar']
 
     initialize() {
         // Called once when the controller is first instantiated (per element)

--- a/tests/fixtures/make-stimulus-controller/with_targets.js
+++ b/tests/fixtures/make-stimulus-controller/with_targets.js
@@ -4,6 +4,7 @@ import { Controller } from '@hotwired/stimulus';
 * The following line makes this controller "lazy": it won't be downloaded until needed
 * See https://symfony.com/bundles/StimulusBundle/current/index.html#lazy-stimulus-controllers
 */
+
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
     static targets = ['results', 'messages', 'errors']

--- a/tests/fixtures/make-stimulus-controller/with_targets.js
+++ b/tests/fixtures/make-stimulus-controller/with_targets.js
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus';
 
 /*
 * The following line makes this controller "lazy": it won't be downloaded until needed
-* See https://github.com/symfony/stimulus-bridge#lazy-controllers
+* See https://symfony.com/bundles/StimulusBundle/current/index.html#lazy-stimulus-controllers
 */
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {

--- a/tests/fixtures/make-stimulus-controller/with_targets.js
+++ b/tests/fixtures/make-stimulus-controller/with_targets.js
@@ -8,5 +8,32 @@ import { Controller } from '@hotwired/stimulus';
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
     static targets = ['results', 'messages', 'errors']
-    // ...
+
+    initialize() {
+        // Called once when the controller is first instantiated (per element)
+
+        // Here you can initialize variables, create scoped callables for event
+        // listeners, instantiate external libraries, etc.
+        // this._fooBar = this.fooBar.bind(this)
+    }
+
+    connect() {
+        // Called every time the controller is connected to the DOM
+        // (on page load, when it's added to the DOM, moved in the DOM, etc.)
+
+        // Here you can add event listeners on the element or target elements,
+        // add or remove classes, attributes, dispatch custom events, etc.
+        // this.fooTarget.addEventListener('click', this._fooBar)
+    }
+
+    // Add custom controller actions here
+    // fooBar() { this.fooTarget.classList.toggle(this.bazClass) }
+
+    disconnect() {
+        // Called anytime its element is disconnected from the DOM
+        // (on page change, when it's removed from or moved in the DOM, etc.)
+
+        // Here you should remove all event listeners added in "connect()" 
+        // this.fooTarget.removeEventListener('click', this._fooBar)
+    }
 }

--- a/tests/fixtures/make-stimulus-controller/with_targets_values_classes.js
+++ b/tests/fixtures/make-stimulus-controller/with_targets_values_classes.js
@@ -7,15 +7,12 @@ import { Controller } from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
-<?= $targets ? "    static targets = $targets\n" : "" ?>
-<?php if ($values) { ?>
+    static targets = ['aaa', 'bbb']
     static values = {
-<?php foreach ($values as $value): ?>
-        <?= $value['name'] ?>: <?= $value['type'] ?>,
-<?php endforeach; ?>
+        ccc: Number,
+        ddd: String,
     }
-<?php } ?>
-<?= $classes ? "    static classes = $classes\n" : '' ?>
+    static classes = ['eee', 'fff']
 
     initialize() {
         // Called once when the controller is first instantiated (per element)

--- a/tests/fixtures/make-stimulus-controller/with_values.js
+++ b/tests/fixtures/make-stimulus-controller/with_values.js
@@ -7,15 +7,10 @@ import { Controller } from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
-<?= $targets ? "    static targets = $targets\n" : "" ?>
-<?php if ($values) { ?>
     static values = {
-<?php foreach ($values as $value): ?>
-        <?= $value['name'] ?>: <?= $value['type'] ?>,
-<?php endforeach; ?>
+        min: Number,
+        email: String,
     }
-<?php } ?>
-<?= $classes ? "    static classes = $classes\n" : '' ?>
 
     initialize() {
         // Called once when the controller is first instantiated (per element)

--- a/tests/fixtures/make-stimulus-controller/without_targets.js
+++ b/tests/fixtures/make-stimulus-controller/without_targets.js
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus';
 
 /*
 * The following line makes this controller "lazy": it won't be downloaded until needed
-* See https://github.com/symfony/stimulus-bridge#lazy-controllers
+* See https://symfony.com/bundles/StimulusBundle/current/index.html#lazy-stimulus-controllers
 */
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {

--- a/tests/fixtures/make-stimulus-controller/without_targets.js
+++ b/tests/fixtures/make-stimulus-controller/without_targets.js
@@ -4,6 +4,7 @@ import { Controller } from '@hotwired/stimulus';
 * The following line makes this controller "lazy": it won't be downloaded until needed
 * See https://symfony.com/bundles/StimulusBundle/current/index.html#lazy-stimulus-controllers
 */
+
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
     // ...

--- a/tests/fixtures/make-stimulus-controller/without_targets.js
+++ b/tests/fixtures/make-stimulus-controller/without_targets.js
@@ -7,5 +7,32 @@ import { Controller } from '@hotwired/stimulus';
 
 /* stimulusFetch: 'lazy' */
 export default class extends Controller {
-    // ...
+
+    initialize() {
+        // Called once when the controller is first instantiated (per element)
+
+        // Here you can initialize variables, create scoped callables for event
+        // listeners, instantiate external libraries, etc.
+        // this._fooBar = this.fooBar.bind(this)
+    }
+
+    connect() {
+        // Called every time the controller is connected to the DOM
+        // (on page load, when it's added to the DOM, moved in the DOM, etc.)
+
+        // Here you can add event listeners on the element or target elements,
+        // add or remove classes, attributes, dispatch custom events, etc.
+        // this.fooTarget.addEventListener('click', this._fooBar)
+    }
+
+    // Add custom controller actions here
+    // fooBar() { this.fooTarget.classList.toggle(this.bazClass) }
+
+    disconnect() {
+        // Called anytime its element is disconnected from the DOM
+        // (on page change, when it's removed from or moved in the DOM, etc.)
+
+        // Here you should remove all event listeners added in "connect()" 
+        // this.fooTarget.removeEventListener('click', this._fooBar)
+    }
 }


### PR DESCRIPTION
Hello,

this PR adds new features to the Stimulus controller maker (and updates minor things)

- [x] Add "default" methods (initialize, connect, disconnect) in generated  code, with explanation of what they do and example of usage, to encourage good practices for event listeners
- [x] Add cli option `--typescript` (shorcut: `-ts`) to choose extension from command line
- [x] Add feature to generate `classes` attributes interactively
- [x] Add code usage example at the end, to avoid (frequent) mistakes with data attribute placement or markup 
- [x] Cover new features with tests

Also
- [x] Fix documentation links (StimulusBridge -> StimulusBundle)
- [x] Set Javascript as default extension in interactive step
- [x] Add missing tests for values

Most of things here are based on feedback received or mistakes seen frequently... but everything is _of course_ very open to debate and suggestions 🤗 

I tried to make a clean commit history to ease review, but if you do want, i can split this PR.

PS: I intentionally did _not_ add outlets to this maker. They are a very advanced feature that can often lead to debatable choices in terms of component architecture, isolation, and more.