### PR TITLE
[minor] Fix "twig" case (-> "Twig") in make:twig-component & various places

### DIFF
--- a/config/help/MakeAuth.txt
+++ b/config/help/MakeAuth.txt
@@ -3,6 +3,6 @@ by asking questions.
 
 It can provide an empty authenticator, or a full login form authentication process.
 In both cases it also updates your <info>security.yaml</info>.
-For the login form, it also generates a controller and the twig template.
+For the login form, it also generates a controller and the Twig template.
 
 <info>php %command.full_name%</info>

--- a/config/help/MakeTwigExtension.txt
+++ b/config/help/MakeTwigExtension.txt
@@ -1,4 +1,4 @@
-The <info>%command.name%</info> command generates a new twig extension with its runtime class.
+The <info>%command.name%</info> command generates a new Twig extension with its runtime class.
 
 <info>php %command.full_name% AppExtension</info>
 

--- a/config/help/security/MakeFormLogin.txt
+++ b/config/help/security/MakeFormLogin.txt
@@ -1,4 +1,4 @@
-The <info>%command.name%</info> command generates a controller and twig template
+The <info>%command.name%</info> command generates a controller and Twig template
 to allow users to login using the form_login authenticator.
 
 The controller name, and logout ability can be customized by answering the

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -85,7 +85,7 @@ class Generator
      * @param array  $variables    Array of variables to pass to the template
      * @param bool   $isController Set to true if generating a Controller that needs
      *                             access to the TemplateComponentGenerator ("generator") in
-     *                             the twig template. e.g. to create route attributes for a route method
+     *                             the Twig template. e.g. to create route attributes for a route method
      *
      * @return string The path where the file will be created
      *

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -100,7 +100,7 @@ final class MakeController extends AbstractMaker
             ]
         );
 
-        // Again if the class name is absolute, lets not make assumptions about where the twig template
+        // Again if the class name is absolute, lets not make assumptions about where the Twig template
         // should live. E.g. templates/custom/location/for/my_controller.html.twig instead of
         // templates/my/controller.html.twig. We do however remove the root_namespace prefix in either case
         // so we don't end up with templates/app/my/controller.html.twig
@@ -109,7 +109,7 @@ final class MakeController extends AbstractMaker
             $this->controllerClassData->getClassName(relative: true, withoutSuffix: true)
         ;
 
-        // Convert the twig template name into a file path where it will be generated.
+        // Convert the Twig template name into a file path where it will be generated.
         $this->twigTemplatePath = \sprintf('%s%s', Str::asFilePath($templateName), $this->isInvokable ? '.html.twig' : '/index.html.twig');
 
         $this->interactSetGenerateTests($input, $io);

--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -43,15 +43,15 @@ final class MakeTwigComponent extends AbstractMaker
 
     public static function getCommandDescription(): string
     {
-        return 'Create a twig (or live) component';
+        return 'Create a Twig (or Live) component';
     }
 
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
             ->setDescription(self::getCommandDescription())
-            ->addArgument('name', InputArgument::OPTIONAL, 'The name of your twig component (ie <fg=yellow>Notification</>)')
-            ->addOption('live', null, InputOption::VALUE_NONE, 'Whether to create a live twig component (requires <fg=yellow>symfony/ux-live-component</>)')
+            ->addArgument('name', InputArgument::OPTIONAL, 'The name of your Twig component (ie <fg=yellow>Notification</>)')
+            ->addOption('live', null, InputOption::VALUE_NONE, 'Whether to create a Live component (requires <fg=yellow>symfony/ux-live-component</>)')
         ;
     }
 
@@ -66,7 +66,7 @@ final class MakeTwigComponent extends AbstractMaker
         $live = $input->getOption('live');
 
         if ($live && !class_exists(AsLiveComponent::class)) {
-            throw new \RuntimeException('You must install symfony/ux-live-component to create a live component (composer require symfony/ux-live-component)');
+            throw new \RuntimeException('You must install symfony/ux-live-component to create a Live component (composer require symfony/ux-live-component)');
         }
 
         $factory = $generator->createClassNameDetails(
@@ -100,7 +100,7 @@ final class MakeTwigComponent extends AbstractMaker
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
         if (!$input->getOption('live')) {
-            $input->setOption('live', $io->confirm('Make this a live component?', false));
+            $input->setOption('live', $io->confirm('Make this a Live component?', false));
         }
 
         $path = 'config/packages/twig_component.yaml';
@@ -113,7 +113,7 @@ final class MakeTwigComponent extends AbstractMaker
             $value = Yaml::parse($this->fileManager->getFileContents($path));
             $this->namespace = array_key_first($value['twig_component']['defaults']);
         } catch (\Throwable $throwable) {
-            throw new RuntimeCommandException(message: 'Unable to parse twig_component.yaml', previous: $throwable);
+            throw new RuntimeCommandException(message: 'Unable to parse config/packages/twig_component.yaml', previous: $throwable);
         }
     }
 }

--- a/templates/twig/component_template.tpl.php
+++ b/templates/twig/component_template.tpl.php
@@ -1,3 +1,3 @@
 <div{{ attributes }}>
-    <!-- component html -->
+    <!-- component HTML -->
 </div>

--- a/tests/fixtures/make-twig-component/tests/it_generates_live_component.php
+++ b/tests/fixtures/make-twig-component/tests/it_generates_live_component.php
@@ -13,6 +13,6 @@ class GeneratedTwigComponentTest extends KernelTestCase
         $this->assertStringContainsString('<div data-controller="live"', $output);
         $this->assertStringContainsString('data-live-name-value="', $output);
         $this->assertStringContainsString('data-live-url-value=', $output);
-        $this->assertStringContainsString('<!-- component html -->', $output);
+        $this->assertStringContainsString('<!-- component HTML -->', $output);
     }
 }

--- a/tests/fixtures/make-twig-component/tests/it_generates_twig_component.php
+++ b/tests/fixtures/make-twig-component/tests/it_generates_twig_component.php
@@ -10,6 +10,6 @@ class GeneratedTwigComponentTest extends KernelTestCase
     {
         $output = self::getContainer()->get('twig')->createTemplate("<twig:{name} />")->render();
 
-        $this->assertSame("<div>\n    <!-- component html -->\n</div>\n", $output);
+        $this->assertSame("<div>\n    <!-- component HTML -->\n</div>\n", $output);
     }
 }


### PR DESCRIPTION
Same thing for 
* `HTML` in component template
* `Live component` in maker help