### PR TITLE
[Docs] Remove Symfony version in introduction

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ The Symfony MakerBundle
 
 Symfony Maker helps you create empty commands, controllers, form classes,
 tests and more so you can forget about writing boilerplate code. This bundle
-assumes you're using a standard Symfony 6.4 directory structure, but many
+assumes you're using a standard Symfony directory structure, but many
 commands can generate code into any application.
 
 Installation


### PR DESCRIPTION
At first, wanted to update the doc to write "Symfony 7 directory structure" instead of "6.4".. but i  think the best choice here (leading to the minimal amount of frustrations or doubts for the reader) would probably be to remove the version precision.

wdyt ?