### PR TITLE
Allow `ClassData` to define an implemented class

### DIFF
--- a/src/Util/ClassSource/Model/ClassData.php
+++ b/src/Util/ClassSource/Model/ClassData.php
@@ -30,13 +30,14 @@ final class ClassData
         private bool $isFinal = true,
         private string $rootNamespace = 'App',
         private ?string $classSuffix = null,
+        public readonly ?string $implements = null,
     ) {
         if (str_starts_with(haystack: $this->namespace, needle: $this->rootNamespace)) {
             $this->namespace = substr_replace(string: $this->namespace, replace: '', offset: 0, length: \strlen($this->rootNamespace) + 1);
         }
     }
 
-    public static function create(string $class, ?string $suffix = null, ?string $extendsClass = null, bool $isEntity = false, array $useStatements = []): self
+    public static function create(string $class, ?string $suffix = null, ?string $extendsClass = null, bool $isEntity = false, array $useStatements = [], ?string $implements = null): self
     {
         $className = Str::getShortClassName($class);
 
@@ -50,6 +51,10 @@ final class ClassData
             $useStatements->addUseStatement($extendsClass);
         }
 
+        if ($implements) {
+            $useStatements->addUseStatement($implements);
+        }
+
         return new self(
             className: Str::asClassName($className),
             namespace: Str::getNamespace($class),
@@ -57,6 +62,7 @@ final class ClassData
             isEntity: $isEntity,
             useStatementGenerator: $useStatements,
             classSuffix: $suffix,
+            implements: null === $implements ? null : Str::getShortClassName($implements),
         );
     }
 
@@ -130,10 +136,17 @@ final class ClassData
             $extendsDeclaration = \sprintf(' extends %s', $this->extends);
         }
 
+        $implementsDeclaration = '';
+
+        if (null !== $this->implements) {
+            $implementsDeclaration = \sprintf(' implements %s', $this->implements);
+        }
+
         return \sprintf('%sclass %s%s',
             $this->isFinal ? 'final ' : '',
             $this->className,
             $extendsDeclaration,
+            $implementsDeclaration
         );
     }
 

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -12,7 +12,11 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Util\ClassSource;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\MakerBundle\InputAwareMakerInterface;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Bundle\MakerBundle\Maker\MakeWebhook;
 use Symfony\Bundle\MakerBundle\MakerBundle;
+use Symfony\Bundle\MakerBundle\MakerInterface;
 use Symfony\Bundle\MakerBundle\Test\MakerTestKernel;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 
@@ -54,6 +58,20 @@ class ClassDataTest extends TestCase
         $meta = ClassData::create(class: MakerBundle::class, extendsClass: MakerTestKernel::class);
 
         self::assertSame('final class MakerBundle extends MakerTestKernel', $meta->getClassDeclaration());
+    }
+
+    public function testGetClassDeclarationWithImplements(): void
+    {
+        $meta = ClassData::create(class: AbstractMaker::class, implements: MakerInterface::class);
+
+        self::assertSame('final class AbstractMaker implements MakerInterface', $meta->getClassDeclaration());
+    }
+
+    public function testGetClassDeclarationWithExtendsAndImplements(): void
+    {
+        $meta = ClassData::create(class: MakeWebhook::class, extendsClass: AbstractMaker::class, implements: InputAwareMakerInterface::class);
+
+        self::assertSame('final class MakeWebhook extends AbstractMaker implements InputAwareMakerInterface', $meta->getClassDeclaration());
     }
 
     /** @dataProvider suffixDataProvider */


### PR DESCRIPTION
A new `ClassData` has been introduced in #1539 and allows to define a class to extend
While working on #1637 I also wanted to be able to choose a class to implement to generate `WebhookConsumer` class (and maybe others will use this, I didn't check)

Implementation is fully inspired from extends as both lead to a similar result