### PR TITLE
[make:twig-component] do not throw an error if config file does not exist

### DIFF
--- a/src/Maker/MakeTwigComponent.php
+++ b/src/Maker/MakeTwigComponent.php
@@ -106,7 +106,7 @@ final class MakeTwigComponent extends AbstractMaker
         $path = 'config/packages/twig_component.yaml';
 
         if (!$this->fileManager->fileExists($path)) {
-            throw new RuntimeCommandException(message: 'Unable to find twig_component.yaml');
+            return;
         }
 
         try {


### PR DESCRIPTION
alternative of #1618

changes from https://github.com/symfony/maker-bundle/pull/1571 break if config is in php files even $namespace has a default value