### PR TITLE
ci: add testruns for PHP 8.4 and symfony 7.2

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -40,10 +40,12 @@ jobs:
             matrix:
                 php-version:
                     - '8.3'
+                    - '8.4'
                 symfony-version:
                     - '6.4.x-dev'
                     - '7.0.x-dev'
                     - '7.1.x-dev'
+                    - '7.2.x-dev'
                 dependency-versions: ['highest']
                 allow-dev-deps-in-apps: ['0']
                 include:


### PR DESCRIPTION
There are multiple options to add testruns for PHP 8.4 and Symfony 7.2.

Please adjust to your needs.