### PR TITLE
Replace php-cs-fixer/shim with friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require": {
         "php": ">=8.1",
         "doctrine/inflector": "^2.0",
+        "friendsofphp/php-cs-fixer": "^v3.64",
         "nikic/php-parser": "^4.18|^5.0",
-        "php-cs-fixer/shim": "^v3.64",
         "symfony/config": "^6.4|^7.0",
         "symfony/console": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",


### PR DESCRIPTION
In #1575 the dependency `php-cs-fixer/shim` was added to replace a self packaged phar of php-cs-fixer.

This change causes `php-cs-fixer/shim` to be installed in all projects using `symfony/maker-bundle`, even if the non-shim package was used before. In symfony flex projects this also causes further unexpected changes since `php-cs-fixer/shim` also executes an additional recipe modifying additional files. (#1644 #1648)

I have changed the dependency to `friendsofphp/php-cs-fixer` instead, so the decision on which package to use can be made by the user instead of forcing the use of the shim package. The execution in `\Symfony\Bundle\MakerBundle\Util\TemplateLinter` remains the same for both packages.