### PR TITLE
Fix putting the class-opening bracket on its own line

### DIFF
--- a/templates/controller/Controller.tpl.php
+++ b/templates/controller/Controller.tpl.php
@@ -5,6 +5,7 @@ namespace <?= $class_data->getNamespace(); ?>;
 <?= $class_data->getUseStatements(); ?>
 
 <?= $class_data->getClassDeclaration(); ?>
+
 {
 <?= $generator->generateRouteForControllerMethod($route_path, $route_name); ?>
     public function <?= $method_name ?>(): <?php if ($with_template) { ?>Response<?php } else { ?>JsonResponse<?php } ?>

--- a/templates/controller/test/Test.tpl.php
+++ b/templates/controller/test/Test.tpl.php
@@ -5,6 +5,7 @@ namespace <?= $class_data->getNamespace(); ?>;
 <?= $class_data->getUseStatements(); ?>
 
 <?= $class_data->getClassDeclaration(); ?>
+
 {
     public function testIndex(): void
     {

--- a/templates/crud/controller/Controller.tpl.php
+++ b/templates/crud/controller/Controller.tpl.php
@@ -6,6 +6,7 @@ namespace <?= $class_data->getNamespace() ?>;
 
 #[Route('<?= $route_path ?>')]
 <?= $class_data->getClassDeclaration() ?>
+
 {
 <?= $generator->generateRouteForControllerMethod('', sprintf('%s_index', $route_name), ['GET']) ?>
 <?php if (isset($repository_full_class_name)): ?>

--- a/templates/crud/test/Test.EntityManager.tpl.php
+++ b/templates/crud/test/Test.EntityManager.tpl.php
@@ -6,6 +6,7 @@ namespace <?= $namespace ?>;
 <?= $class_data->getUseStatements(); ?>
 
 <?= $class_data->getClassDeclaration() ?>
+
 {
     private KernelBrowser $client;
     private EntityManagerInterface $manager;

--- a/templates/security/Voter.tpl.php
+++ b/templates/security/Voter.tpl.php
@@ -5,6 +5,7 @@ namespace <?= $class_data->getNamespace(); ?>;
 <?= $class_data->getUseStatements(); ?>
 
 <?= $class_data->getClassDeclaration() ?>
+
 {
     public const EDIT = 'POST_EDIT';
     public const VIEW = 'POST_VIEW';

--- a/templates/validator/Constraint.tpl.php
+++ b/templates/validator/Constraint.tpl.php
@@ -6,6 +6,7 @@ namespace <?= $class_data->getNamespace(); ?>;
 
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 <?= $class_data->getClassDeclaration(); ?>
+
 {
     public string $message = 'The string "{{ string }}" contains an illegal character: it can only contain letters or numbers.';
 

--- a/templates/validator/Validator.tpl.php
+++ b/templates/validator/Validator.tpl.php
@@ -5,6 +5,7 @@ namespace <?= $class_data->getNamespace(); ?>;
 <?= $class_data->getUseStatements(); ?>
 
 <?= $class_data->getClassDeclaration(); ?>
+
 {
     public function validate(mixed $value, Constraint $constraint): void
     {


### PR DESCRIPTION
Without this change, eg make:controller generates the following. A PHP closing tag eats its CR in some cases.

```php
final class TotoController extends AbstractController{
```