### PR TITLE
Fix indentation of options_code

### DIFF
--- a/src/Doctrine/EntityDetails.php
+++ b/src/Doctrine/EntityDetails.php
@@ -77,11 +77,11 @@ final class EntityDetails
             }
             $fieldsWithTypes[$fieldName] = [
                 'type' => EntityType::class,
-                'options_code' => \sprintf('\'class\' => %s::class,', $relation['targetEntity']).\PHP_EOL.'\'choice_label\' => \'id\',',
+                'options_code' => \sprintf('\'class\' => %s::class,', $relation['targetEntity'])."\n                'choice_label' => 'id',",
                 'extra_use_classes' => [$relation['targetEntity']],
             ];
             if (\Doctrine\ORM\Mapping\ClassMetadata::MANY_TO_MANY === $relation['type']) {
-                $fieldsWithTypes[$fieldName]['options_code'] .= "\n'multiple' => true,";
+                $fieldsWithTypes[$fieldName]['options_code'] .= "\n                'multiple' => true,";
             }
         }
 


### PR DESCRIPTION
Similar to #1469 but doesn't rely on any CS fixer.

Note that using PHP_EOL was wrong: this constant is meant to be used ONLY when outputting something on a terminal. NOT when dealing with new lines in files. 