### PR TITLE
[make:entity] Use stricter DateTime type instead of DateTimeInterface for mutable datetime fields

### DIFF
--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -263,7 +263,7 @@ final class DoctrineHelper
             Types::BOOLEAN => 'bool',
             Types::INTEGER, Types::SMALLINT => 'int',
             Types::FLOAT => 'float',
-            Types::DATETIME_MUTABLE, Types::DATETIMETZ_MUTABLE, Types::DATE_MUTABLE, Types::TIME_MUTABLE => '\\'.\DateTimeInterface::class,
+            Types::DATETIME_MUTABLE, Types::DATETIMETZ_MUTABLE, Types::DATE_MUTABLE, Types::TIME_MUTABLE => '\\'.\DateTime::class,
             Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE => '\\'.\DateTimeImmutable::class,
             Types::DATEINTERVAL => '\\'.\DateInterval::class,
             'object' => 'object',

--- a/tests/Util/fixtures/add_entity_field/User_simple_datetime.php
+++ b/tests/Util/fixtures/add_entity_field/User_simple_datetime.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -13,20 +12,20 @@ class User
     #[ORM\Column()]
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private ?\DateTimeInterface $createdAt = null;
+    #[ORM\Column(nullable: true)]
+    private ?\DateTime $createdAt = null;
 
     public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(?\DateTimeInterface $createdAt): static
+    public function setCreatedAt(?\DateTime $createdAt): static
     {
         $this->createdAt = $createdAt;
 


### PR DESCRIPTION
The current DateTimeInterface type hint suggest that you can put a DateTimeImmutable in a mutable datetime field, but that is no longer the case.

It results in the following error:
```
Could not convert PHP value of type DateTimeImmutable to type Doctrine\DBAL\Types\DateTimeType. 
Expected one of the following types: null, DateTime.
```

Follows:
- https://github.com/doctrine/dbal/pull/6017
- https://github.com/doctrine/dbal/pull/6161