### PR TITLE
In Test.ResetPasswordController.tpl.php fetch the email body directly rather than using toString #1

### DIFF
--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -367,6 +367,7 @@ class MakeResetPassword extends AbstractMaker
                 $userRepositoryDetails->getFullName(),
                 EntityManagerInterface::class,
                 KernelBrowser::class,
+                TemplatedEmail::class,
                 WebTestCase::class,
                 UserPasswordHasherInterface::class,
             ]);

--- a/templates/resetPassword/Test.ResetPasswordController.tpl.php
+++ b/templates/resetPassword/Test.ResetPasswordController.tpl.php
@@ -70,7 +70,9 @@ class ResetPasswordControllerTest extends WebTestCase
         self::assertStringContainsString('This link will expire in 1 hour', $crawler->html());
 
         // Test the link sent in the email is valid
-        $email = $messages[0]->toString();
+        /** @var array<TemplatedEmail> $messages */
+        $email = $messages[0]->getTextBody();
+        self::assertIsString($email);
         preg_match('#(/reset-password/reset/[a-zA-Z0-9]+)#', $email, $resetLink);
 
         $this->client->request('GET', $resetLink[1]);

--- a/templates/resetPassword/Test.ResetPasswordController.tpl.php
+++ b/templates/resetPassword/Test.ResetPasswordController.tpl.php
@@ -72,7 +72,7 @@ class ResetPasswordControllerTest extends WebTestCase
         // Test the link sent in the email is valid
         /** @var array<TemplatedEmail> $messages */
         $email = $messages[0]->getTextBody();
-        self::assertIsString($emailBody);
+        self::assertIsString($email);
         preg_match('#(/reset-password/reset/[a-zA-Z0-9]+)#', $email, $resetLink);
 
         $this->client->request('GET', $resetLink[1]);

--- a/templates/resetPassword/Test.ResetPasswordController.tpl.php
+++ b/templates/resetPassword/Test.ResetPasswordController.tpl.php
@@ -70,7 +70,7 @@ class ResetPasswordControllerTest extends WebTestCase
         self::assertStringContainsString('This link will expire in 1 hour', $crawler->html());
 
         // Test the link sent in the email is valid
-        $email = $messages[0]->toString();
+        $email = $messages[0]->getTextBody();
         preg_match('#(/reset-password/reset/[a-zA-Z0-9]+)#', $email, $resetLink);
 
         $this->client->request('GET', $resetLink[1]);

--- a/templates/resetPassword/Test.ResetPasswordController.tpl.php
+++ b/templates/resetPassword/Test.ResetPasswordController.tpl.php
@@ -70,7 +70,9 @@ class ResetPasswordControllerTest extends WebTestCase
         self::assertStringContainsString('This link will expire in 1 hour', $crawler->html());
 
         // Test the link sent in the email is valid
+        /** @var array<TemplatedEmail> $messages */
         $email = $messages[0]->getTextBody();
+        self::assertIsString($emailBody);
         preg_match('#(/reset-password/reset/[a-zA-Z0-9]+)#', $email, $resetLink);
 
         $this->client->request('GET', $resetLink[1]);

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -113,6 +113,18 @@ class MakeResetPasswordTest extends MakerTestCase
                     self::assertFileExists($runner->getPath($file));
                 }
 
+                /*
+                 * Move the reset link further to the right in the email body. The
+                 * quoted-printable encoder then wraps the line in the middle of the
+                 * token, which truncates the link when the raw message is read
+                 * instead of the text body.
+                 */
+                $runner->replaceInFile(
+                    'templates/reset_password/email.html.twig',
+                    '<a href=',
+                    'Reset your password: <a href='
+                );
+
                 $runner->writeFile(
                     'config/packages/mailer.yaml',
                     Yaml::dump(['framework' => [


### PR DESCRIPTION
Fixes https://github.com/SymfonyCasts/reset-password-bundle/issues/345 