### PR TITLE
Allow creation of classes with the same name as PHP native classes

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -188,8 +188,8 @@ class Generator
             $className = Str::asClassName($name, $suffix);
 
             try {
-                Validator::classDoesNotExist($className);
                 $className = rtrim($fullNamespacePrefix, '\\').'\\'.$className;
+                Validator::classDoesNotExist($className);
             } catch (RuntimeCommandException) {
             }
         }

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -762,6 +762,19 @@ class MakeEntityTest extends MakerTestCase
             $this->runEntityTest($runner);
         }),
         ];
+
+        yield 'its_can_create_classes_with_native_class_name' => [$this->createMakeEntityTest()
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runMaker([
+                    // entity class name
+                    'Directory',
+                    // add not additional fields
+                    '',
+                ]);
+
+                $this->runEntityTest($runner);
+            }),
+        ];
     }
 
     /** @param array<string, mixed> $data */


### PR DESCRIPTION
Fix #1675 

When trying to create a class with a native PHP name (e.g., Directory), `Validator::classDoesNotExist` incorrectly throws an error stating that the class already exists. To fix this, we need to prepend the namespace before performing the check.