### PR TITLE
use parser v5 for consistent Emulative constructor

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -84,9 +84,6 @@ jobs:
 
             - name: Install PHPUnit
               run: |
-                if [[ ${{ matrix.dependency_versions == 'lowest' }} ]]; then
-                  echo "SYMFONY_PHPUNIT_REQUIRE=nikic/php-parser:^4.18" >> $GITHUB_ENV
-                fi
                 vendor/bin/simple-phpunit install
 
             - name: PHPUnit version

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/inflector": "^2.0",
-        "nikic/php-parser": "^4.18|^5.0",
+        "nikic/php-parser": "^5.0",
         "symfony/config": "^6.4|^7.0",
         "symfony/console": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -66,21 +66,10 @@ final class ClassSourceManipulator
         private bool $overwrite = false,
         private bool $useAttributesForDoctrineMapping = true,
     ) {
-        /* @legacy Support for nikic/php-parser v4 */
-        if (class_exists(PhpVersion::class)) {
-            $version = PhpVersion::fromString(\PHP_VERSION);
-            $this->lexer = new Lexer\Emulative($version);
-            $this->parser = new Parser\Php8($this->lexer, $version);
-        } else {
-            $this->lexer = new Lexer\Emulative([
-                'usedAttributes' => [
-                    'comments',
-                    'startLine', 'endLine',
-                    'startTokenPos', 'endTokenPos',
-                ],
-            ]);
-            $this->parser = new Parser\Php7($this->lexer);
-        }
+        $this->lexer = new Lexer\Emulative(
+            PhpVersion::fromString('8.1'),
+        );
+        $this->parser = new Parser\Php7($this->lexer);
 
         $this->printer = new PrettyPrinter();
 
@@ -963,12 +952,7 @@ final class ClassSourceManipulator
         $this->sourceCode = $sourceCode;
         $this->oldStmts = $this->parser->parse($sourceCode);
 
-        /* @legacy Support for nikic/php-parser v4 */
-        if (\is_callable([$this->parser, 'getTokens'])) {
-            $this->oldTokens = $this->parser->getTokens();
-        } elseif (\is_callable($this->lexer->getTokens(...))) {
-            $this->oldTokens = $this->lexer->getTokens();
-        }
+        $this->oldTokens = $this->parser->getTokens();
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NodeVisitor\CloningVisitor());


### PR DESCRIPTION
Fixes #1680

No good reason to keep this flexibility 