### PR TITLE
[make:listener] use FQCN for kernel events, fix adding unnecessary `#[AsEventListener]` arg

### DIFF
--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -153,12 +153,11 @@ final class MakeListener extends AbstractMaker
         $eventFullClassName = $this->eventRegistry->getEventClassName($event);
         $eventClassName = $eventFullClassName ? Str::getShortClassName($eventFullClassName) : null;
 
-        if (null !== ($eventConstant = $this->getEventConstant($event))) {
-            $useStatements->addUseStatement(KernelEvents::class);
-            $eventName = $eventConstant;
-        } else {
-            $eventName = class_exists($event) ? \sprintf('%s::class', $eventClassName) : \sprintf('\'%s\'', $event);
+        if ($this->getEventConstant($event)) {
+            $event = $eventFullClassName;
         }
+
+        $eventName = class_exists($event) ? \sprintf('%s::class', $eventClassName) : \sprintf('\'%s\'', $event);
 
         if (null !== $eventFullClassName) {
             $useStatements->addUseStatement($eventFullClassName);
@@ -230,6 +229,7 @@ final class MakeListener extends AbstractMaker
             [
                 'use_statements' => $useStatements,
                 'event' => $eventName,
+                'class_event' => str_ends_with($eventName, '::class'),
                 'event_arg' => $eventClassName ? \sprintf('%s $event', $eventClassName) : '$event',
                 'method_name' => class_exists($event) ? Str::asEventMethod($eventClassName) : Str::asEventMethod($event),
             ]

--- a/templates/event/Listener.tpl.php
+++ b/templates/event/Listener.tpl.php
@@ -6,7 +6,7 @@ namespace <?= $namespace; ?>;
 
 final class <?= $class_name."\n" ?>
 {
-    #[AsEventListener(event: <?= $event ?>)]
+    #[AsEventListener<?php if (!$class_event): ?>(event: <?= $event ?>)<?php endif ?>]
     public function <?= $method_name ?>(<?= $event_arg ?>): void
     {
         // ...

--- a/tests/Maker/MakeSubscriberTest.php
+++ b/tests/Maker/MakeSubscriberTest.php
@@ -39,7 +39,7 @@ class MakeSubscriberTest extends MakerTestCase
                 );
 
                 self::assertStringContainsString(
-                    'KernelEvents::REQUEST => \'onKernelRequest\'',
+                    'RequestEvent::class => \'onRequestEvent\'',
                     file_get_contents($runner->getPath('src/EventSubscriber/FooBarSubscriber.php'))
                 );
             }),

--- a/tests/fixtures/make-listener/tests/EventListener/BarListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/BarListener.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 final class BarListener
 {
-    #[AsEventListener(event: RequestEvent::class)]
+    #[AsEventListener]
     public function onRequestEvent(RequestEvent $event): void
     {
         // ...

--- a/tests/fixtures/make-listener/tests/EventListener/CustomListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/CustomListener.php
@@ -7,7 +7,7 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
 final class CustomListener
 {
-    #[AsEventListener(event: Generator::class)]
+    #[AsEventListener]
     public function onGenerator(Generator $event): void
     {
         // ...

--- a/tests/fixtures/make-listener/tests/EventListener/FooBarListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/FooBarListener.php
@@ -4,12 +4,11 @@ namespace App\EventListener;
 
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 final class FooBarListener
 {
-    #[AsEventListener(event: KernelEvents::REQUEST)]
-    public function onKernelRequest(RequestEvent $event): void
+    #[AsEventListener]
+    public function onRequestEvent(RequestEvent $event): void
     {
         // ...
     }

--- a/tests/fixtures/make-listener/tests/EventListener/FooListener.php
+++ b/tests/fixtures/make-listener/tests/EventListener/FooListener.php
@@ -4,12 +4,11 @@ namespace App\EventListener;
 
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 final class FooListener
 {
-    #[AsEventListener(event: KernelEvents::REQUEST)]
-    public function onKernelRequest(RequestEvent $event): void
+    #[AsEventListener]
+    public function onRequestEvent(RequestEvent $event): void
     {
         // ...
     }

--- a/tests/fixtures/make-listener/tests/EventSubscriber/FooBarSubscriber.php
+++ b/tests/fixtures/make-listener/tests/EventSubscriber/FooBarSubscriber.php
@@ -4,11 +4,10 @@ namespace App\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 class FooBarSubscriber implements EventSubscriberInterface
 {
-    public function onKernelRequest(RequestEvent $event): void
+    public function onRequestEvent(RequestEvent $event): void
     {
         // ...
     }
@@ -16,7 +15,7 @@ class FooBarSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => 'onKernelRequest',
+            RequestEvent::class => 'onRequestEvent',
         ];
     }
 }

--- a/tests/fixtures/make-listener/tests/EventSubscriber/FooSubscriber.php
+++ b/tests/fixtures/make-listener/tests/EventSubscriber/FooSubscriber.php
@@ -4,11 +4,10 @@ namespace App\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 class FooSubscriber implements EventSubscriberInterface
 {
-    public function onKernelRequest(RequestEvent $event): void
+    public function onRequestEvent(RequestEvent $event): void
     {
         // ...
     }
@@ -16,7 +15,7 @@ class FooSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => 'onKernelRequest',
+            RequestEvent::class => 'onRequestEvent',
         ];
     }
 }


### PR DESCRIPTION
- adding the `event` argument to `#[AsEventListener]` isn't required when it's a FQCN
- use FQCN for kernel events - I believe this is the best practice