### PR TITLE
Warn if using a maker non-interactively

### DIFF
--- a/src/Command/MakerCommand.php
+++ b/src/Command/MakerCommand.php
@@ -56,6 +56,11 @@ final class MakerCommand extends Command
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->io = new ConsoleStyle($input, $output);
+
+        if (!$input->isInteractive()) {
+            $this->io->warning(\sprintf('"%s" is not meant to be run in non-interactive mode.', $this->getName()));
+        }
+
         $this->fileManager->setIO($this->io);
 
         if ($this->checkDependencies) {


### PR DESCRIPTION
Maker's are not meant to be run non-interactively. It's possible (?) some may support this so I opted for a warning instead of an exception.

Closes #1678