### PR TITLE
[make:message] use `AsMessage` for routing if available

### DIFF
--- a/templates/message/Message.tpl.php
+++ b/templates/message/Message.tpl.php
@@ -2,6 +2,9 @@
 
 namespace <?= $namespace; ?>;
 
+<?= $use_statements; ?>
+
+<?php if ($transport): ?>#[AsMessage('<?= $transport ?>')]<?= "\n" ?><?php endif ?>
 final class <?= $class_name."\n" ?>
 {
     /*


### PR DESCRIPTION
The less files a maker touches, the better, IMO.