### PR TITLE
Fix docs branch following the renaming of main to 1.x

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,6 +1,6 @@
-branches: ["main"]
+branches: ["1.x"]
 
-maintained_branches: ["main"]
+maintained_branches: ["1.x"]
 
 doc_dir: "docs"
 


### PR DESCRIPTION
So the docs on [symfony.com/bundles/SymfonyMakerBundle](https://symfony.com/bundles/SymfonyMakerBundle) are back