### PR TITLE
Fix placeholder formatting in form class name example

### DIFF
--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -51,7 +51,7 @@ final class MakeForm extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
-            ->addArgument('name', InputArgument::OPTIONAL, \sprintf('The name of the form class (e.g. <fg=yellow>%Form</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addArgument('name', InputArgument::OPTIONAL, \sprintf('The name of the form class (e.g. <fg=yellow>%sForm</>)', Str::asClassName(Str::getRandomTerm())))
             ->addArgument('bound-class', InputArgument::OPTIONAL, 'The name of Entity or fully qualified model class name that the new form will be bound to (empty for none)')
             ->setHelp($this->getHelpFileContents('MakeForm.txt'))
         ;


### PR DESCRIPTION
Corrected a missing placeholder specifier in the example string for the form class name. This ensures the example displays correctly and aligns with expected formatting conventions.