### PR TITLE
[MakeForm.php] Fix wrong sprintf placeholder in argument description

### DIFF
--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -51,7 +51,7 @@ final class MakeForm extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
-            ->addArgument('name', InputArgument::OPTIONAL, \sprintf('The name of the form class (e.g. <fg=yellow>%Form</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addArgument('name', InputArgument::OPTIONAL, \sprintf('The name of the form class (e.g. <fg=yellow>%sForm</>)', Str::asClassName(Str::getRandomTerm())))
             ->addArgument('bound-class', InputArgument::OPTIONAL, 'The name of Entity or fully qualified model class name that the new form will be bound to (empty for none)')
             ->setHelp($this->getHelpFileContents('MakeForm.txt'))
         ;


### PR DESCRIPTION
This merge request fixes a formatting issue in the help text of the make:form command by correcting the sprintf placeholder.

It displays as (%F):
<img width="417" alt="Screenshot 2025-05-11 at 18 39 18" src="https://github.com/user-attachments/assets/54cd57da-3664-4d0e-a154-e46ffb8dccbc" />

Instead of (%s)
<img width="418" alt="Screenshot 2025-05-11 at 18 39 36" src="https://github.com/user-attachments/assets/33e6c5e2-bca0-4439-a22e-a08026af6a61" />
