### PR TITLE
feat: bump php-cs-fixer to 3.75

### DIFF
--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
-        "friendsofphp/php-cs-fixer": "^3.2"
+        "friendsofphp/php-cs-fixer": "^3.75"
+    },
+    "require-dev": {
+        "rector/jack": "^0.2.1"
     }
 }
+
+


### PR DESCRIPTION
Current version [3.20 ](https://packagist.org/packages/friendsofphp/php-cs-fixer#v3.20.0) is from 2023-06-27

Updating to [3.75](https://packagist.org/packages/friendsofphp/php-cs-fixer#v3.75.0) released at 2025-03-31
