### PR TITLE
Update Controller.tpl.php to use createView() method by default

### DIFF
--- a/templates/crud/controller/Controller.tpl.php
+++ b/templates/crud/controller/Controller.tpl.php
@@ -45,7 +45,7 @@ namespace <?= $class_data->getNamespace() ?>;
 
         return $this->render('<?= $templates_path ?>/new.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
-            'form' => $form,
+            'form' => $form->createView(),
         ]);
     }
 
@@ -71,7 +71,7 @@ namespace <?= $class_data->getNamespace() ?>;
 
         return $this->render('<?= $templates_path ?>/edit.html.twig', [
             '<?= $entity_twig_var_singular ?>' => $<?= $entity_var_singular ?>,
-            'form' => $form,
+            'form' => $form->createView(),
         ]);
     }
 

--- a/tests/fixtures/make-crud/expected/WithCustomRepository.php
+++ b/tests/fixtures/make-crud/expected/WithCustomRepository.php
@@ -38,7 +38,7 @@ final class SweetFoodController extends AbstractController
 
         return $this->render('sweet_food/new.html.twig', [
             'sweet_food' => $sweetFood,
-            'form' => $form,
+            'form' => $form->createView(),
         ]);
     }
 
@@ -64,7 +64,7 @@ final class SweetFoodController extends AbstractController
 
         return $this->render('sweet_food/edit.html.twig', [
             'sweet_food' => $sweetFood,
-            'form' => $form,
+            'form' => $form->createView(),
         ]);
     }
 


### PR DESCRIPTION
Hi, just stumble recurringly on this while using `make:crud`.

There are several ways to address that, like using render() or else, but I think the most concensual way of doing so would be to just add `createView()` to all Controller methods that pass forms to templates.

I might be wrong on that, though, but it's one of the first things I do in those files right after generating them.