### PR TITLE
add customizable templates path

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -57,6 +57,7 @@
                 <argument /> <!-- root namespace -->
                 <argument>null</argument> <!-- PhpCompatUtil -->
                 <argument type="service" id="maker.template_component_generator" />
+                <argument /> <!-- templates_folders -->
             </service>
 
             <service id="maker.entity_class_generator" class="Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator">

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -33,6 +33,7 @@ class Generator
         private string $namespacePrefix,
         ?PhpCompatUtil $phpCompatUtil = null,
         private ?TemplateComponentGenerator $templateComponentGenerator = null,
+        private array $templatesFolders = [],
     ) {
         $this->twigHelper = new GeneratorTwigHelper($fileManager);
         $this->namespacePrefix = trim($namespacePrefix, '\\');
@@ -299,11 +300,7 @@ class Generator
 
         $templatePath = $templateName;
         if (!file_exists($templatePath)) {
-            $templatePath = \sprintf('%s/templates/%s', \dirname(__DIR__), $templateName);
-
-            if (!file_exists($templatePath)) {
-                $templatePath = $this->getTemplateFromLegacySkeletonPath($templateName);
-            }
+            $templatePath = $this->getTemplatePath($templatePath);
 
             if (!file_exists($templatePath)) {
                 throw new \Exception(\sprintf('Cannot find template "%s" in the templates/ dir.', $templateName));
@@ -314,6 +311,25 @@ class Generator
             'template' => $templatePath,
             'variables' => $variables,
         ];
+    }
+
+    private function getTemplatePath(string $templateName): string
+    {
+        foreach ($this->templatesFolders as $folder) {
+            $templatePath = \sprintf('%s/%s', $folder, $templateName);
+
+            if ($this->fileManager->fileExists($templatePath)) {
+                return $templatePath;
+            }
+        }
+
+        $templatePath = \sprintf('%s/templates/%s', \dirname(__DIR__), $templateName);
+
+        if (!file_exists($templatePath)) {
+            return $this->getTemplateFromLegacySkeletonPath($templateName);
+        }
+
+        return $templatePath;
     }
 
     /**

--- a/src/MakerBundle.php
+++ b/src/MakerBundle.php
@@ -35,6 +35,10 @@ class MakerBundle extends AbstractBundle
                 ->scalarNode('root_namespace')->defaultValue('App')->end()
                 ->booleanNode('generate_final_classes')->defaultTrue()->end()
                 ->booleanNode('generate_final_entities')->defaultFalse()->end()
+                ->arrayNode('templates_folders')
+                    ->defaultValue([])
+                    ->prototype('scalar')->end()
+                ->end()
             ->end()
         ;
     }
@@ -51,6 +55,7 @@ class MakerBundle extends AbstractBundle
                 ->arg(0, $rootNamespace)
             ->get('maker.generator')
                 ->arg(1, $rootNamespace)
+                ->arg(4, $config['templates_folders'])
             ->get('maker.doctrine_helper')
                 ->arg(0, \sprintf('%s\\Entity', $rootNamespace))
             ->get('maker.template_component_generator')


### PR DESCRIPTION
allow user to customize their templates by adding a config parameter to list templates folders.
generator will search in all folders listed in the configurations before to select its own template.
With that, user can modify one or more templates to get what he want without copy all maker classes :).

If no config is made => nothing move, all stay as before,
config can be set in a bundle (and the templates can be there too) to maximize reusability.

by example config can be : 
```
maker:
    templates_folders:
        - "makertemplates"
        - "vendor/eltharin/myBundle/makerTemplates
```
