### PR TITLE
[make:controller] [make:crud] [make:registration-form] [make:reset-password] [make:security:form-login] Fix error while generating PHPUnit tests

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
@@ -148,7 +149,7 @@ final class MakeController extends AbstractMaker
                 'route_path' => Str::asRoutePath($this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
             ]);
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -16,6 +16,7 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -280,7 +281,7 @@ final class MakeCrud extends AbstractMaker
                 ]
             );
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -15,6 +15,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -437,7 +438,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 ], $userRepoVars)
             );
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PhpParser\Builder\Param;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -382,7 +383,7 @@ class MakeResetPassword extends AbstractMaker
                 ],
             );
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/Security/MakeFormLogin.php
+++ b/src/Maker/Security/MakeFormLogin.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker\Security;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -210,7 +211,7 @@ final class MakeFormLogin extends AbstractMaker
                 ],
             );
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }


### PR DESCRIPTION
Fixes: #1718 

Change 

```php
if (!class_exists(WebTestCase::class)) {
    $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
}
```

to

```php
if (!class_exists(TestCase::class)) {
    $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
}
```
- `Symfony\Bundle\FrameworkBundle\Test\WebTestCase` to `PHPUnit\Framework\TestCase`

Error is now displayed and files are created

![generate-phpunit-tests-make-controller-ok2](https://github.com/user-attachments/assets/60da9664-f6b2-45aa-a29f-49f2a0dc6631)

![generate-phpunit-tests-make-crud-ok2](https://github.com/user-attachments/assets/2c1f1431-e35a-4ef7-af59-b7a34dd5bf7e)

![generate-phpunit-tests-make-registration-form-ok1](https://github.com/user-attachments/assets/98f613af-2fc3-4dc0-81af-599d327f548e)

![generate-phpunit-tests-make-reset-password-ok2](https://github.com/user-attachments/assets/3b977e0d-cb5b-4ad7-b77d-578438b79cc6)

![generate-phpunit-tests-make-security-form-login-ok2](https://github.com/user-attachments/assets/d00bee9e-a0f6-4ed7-aa67-e3b3638fa471)



