### PR TITLE
[make:migration] Add `--nowdoc` option

### DIFF
--- a/src/Maker/MakeMigration.php
+++ b/src/Maker/MakeMigration.php
@@ -74,6 +74,7 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
 
         $command
             ->addOption('formatted', null, InputOption::VALUE_NONE, 'Format the generated SQL')
+            ->addOption('nowdoc', null, InputOption::VALUE_NONE, 'Use nowdoc format for generated SQL')
             ->addOption('configuration', null, InputOption::VALUE_OPTIONAL, 'The path of doctrine configuration file')
         ;
     }
@@ -97,6 +98,10 @@ final class MakeMigration extends AbstractMaker implements ApplicationAwareMaker
 
         if ($input->getOption('formatted')) {
             $options[] = '--formatted';
+        }
+
+        if ($input->getOption('nowdoc')) {
+            $options[] = '--nowdoc';
         }
 
         if (null !== $configuration = $input->getOption('configuration')) {

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -142,5 +142,16 @@ class MakeMigrationTest extends MakerTestCase
                 $this->assertStringContainsString('Success', $output);
             }),
         ];
+
+        yield 'it_generates_a_nowdoc_migration' => [$this->createMakeMigrationTest()
+            ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
+            ->run(function (MakerTestRunner $runner) {
+                $runner->runConsole('make:migration', [], '--nowdoc');
+
+                $output = $runner->runMaker([/* no input */]);
+
+                $this->assertStringContainsString('Success', $output);
+            }),
+        ];
     }
 }


### PR DESCRIPTION
As doctrine migration has the new option "nowdoc"
https://github.com/doctrine/migrations/pull/1504
added the parameter for make:migration command to pass that option for generating