### PR TITLE
`[make:user]` add class name for UniqueConstraint

### DIFF
--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -162,7 +162,7 @@ final class MakeUser extends AbstractMaker
 
         $manipulator->setIo($io);
 
-        $this->userClassBuilder->addUserInterfaceImplementation($manipulator, $userClassConfiguration);
+        $this->userClassBuilder->addUserInterfaceImplementation($manipulator, $userClassConfiguration, $userClassNameDetails->getShortName());
 
         $generator->dumpFile($classPath, $manipulator->getSourceCode());
 

--- a/src/Security/UserClassBuilder.php
+++ b/src/Security/UserClassBuilder.php
@@ -26,11 +26,11 @@ use Symfony\Component\Security\Http\Attribute\IsGrantedContext;
  */
 final class UserClassBuilder
 {
-    public function addUserInterfaceImplementation(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
+    public function addUserInterfaceImplementation(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig, string $className): void
     {
         $manipulator->addInterface(UserInterface::class);
 
-        $this->addUniqueConstraint($manipulator, $userClassConfig);
+        $this->addUniqueConstraint($manipulator, $userClassConfig, $className);
 
         $this->addGetUsername($manipulator, $userClassConfig);
 
@@ -332,7 +332,7 @@ final class UserClassBuilder
         $manipulator->addMethodBuilder($builder);
     }
 
-    private function addUniqueConstraint(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig): void
+    private function addUniqueConstraint(ClassSourceManipulator $manipulator, UserClassConfiguration $userClassConfig, string $className): void
     {
         if (!$userClassConfig->isEntity()) {
             return;
@@ -341,7 +341,7 @@ final class UserClassBuilder
         $manipulator->addAttributeToClass(
             'ORM\\UniqueConstraint',
             [
-                'name' => 'UNIQ_IDENTIFIER_'.strtoupper(Str::asSnakeCase($userClassConfig->getIdentityPropertyName())),
+                'name' => strtoupper(Str::asSnakeCase($className)).'_UNIQ_IDENTIFIER_'.strtoupper(Str::asSnakeCase($userClassConfig->getIdentityPropertyName())),
                 'fields' => [$userClassConfig->getIdentityPropertyName()],
             ]
         );

--- a/tests/Security/UserClassBuilderTest.php
+++ b/tests/Security/UserClassBuilderTest.php
@@ -23,14 +23,17 @@ class UserClassBuilderTest extends TestCase
     /**
      * @dataProvider getUserInterfaceTests
      */
-    public function testAddUserInterfaceImplementation(UserClassConfiguration $userClassConfig, string $expectedFilename)
-    {
+    public function testAddUserInterfaceImplementation(
+        UserClassConfiguration $userClassConfig,
+        string $expectedFilename,
+        string $className,
+    ): void {
         $manipulator = $this->getClassSourceManipulator($userClassConfig);
 
         $classBuilder = new UserClassBuilder();
-        $classBuilder->addUserInterfaceImplementation($manipulator, $userClassConfig);
+        $classBuilder->addUserInterfaceImplementation($manipulator, $userClassConfig, $className);
 
-        $expectedPath = $this->getExpectedPath($expectedFilename, null);
+        $expectedPath = $this->getExpectedPath($expectedFilename);
         $expectedSource = file_get_contents($expectedPath);
 
         if (!class_exists(IsGrantedContext::class)) {
@@ -49,36 +52,43 @@ class UserClassBuilderTest extends TestCase
         yield 'entity_with_email_as_identifier' => [
             new UserClassConfiguration(true, 'email', true),
             'UserEntityWithEmailAsIdentifier.php',
+            'User',
         ];
 
         yield 'entity_with_password' => [
             new UserClassConfiguration(true, 'userIdentifier', true),
             'UserEntityWithPassword.php',
+            'User',
         ];
 
         yield 'entity_with_user_identifier_as_identifier' => [
             new UserClassConfiguration(true, 'user_identifier', true),
             'UserEntityWithUser_IdentifierAsIdentifier.php',
+            'User',
         ];
 
         yield 'entity_without_password' => [
             new UserClassConfiguration(true, 'userIdentifier', false),
             'UserEntityWithoutPassword.php',
+            'User',
         ];
 
         yield 'model_with_email_as_identifier' => [
             new UserClassConfiguration(false, 'email', true),
             'UserModelWithEmailAsIdentifier.php',
+            'User',
         ];
 
         yield 'model_with_password' => [
             new UserClassConfiguration(false, 'userIdentifier', true),
             'UserModelWithPassword.php',
+            'User',
         ];
 
         yield 'model_without_password' => [
             new UserClassConfiguration(false, 'userIdentifier', false),
             'UserModelWithoutPassword.php',
+            'User',
         ];
     }
 

--- a/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithEmailAsIdentifier.php
@@ -7,7 +7,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
-#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]
+#[ORM\UniqueConstraint(name: 'USER_UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]

--- a/tests/Security/fixtures/expected/UserEntityWithPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithPassword.php
@@ -7,7 +7,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
-#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['userIdentifier'])]
+#[ORM\UniqueConstraint(name: 'USER_UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['userIdentifier'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]

--- a/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
+++ b/tests/Security/fixtures/expected/UserEntityWithUser_IdentifierAsIdentifier.php
@@ -7,7 +7,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
-#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['user_identifier'])]
+#[ORM\UniqueConstraint(name: 'USER_UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['user_identifier'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     #[ORM\Id]

--- a/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
+++ b/tests/Security/fixtures/expected/UserEntityWithoutPassword.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 #[ORM\Entity]
-#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['userIdentifier'])]
+#[ORM\UniqueConstraint(name: 'USER_UNIQ_IDENTIFIER_USER_IDENTIFIER', fields: ['userIdentifier'])]
 class User implements UserInterface
 {
     #[ORM\Id]


### PR DESCRIPTION
Sometimes we can have multiple user classes and the index name is then duplicated if we don't change it manually. I added this PR to fix this by prefixing with the class name.

For instance:
I have an Admin and User entity that I generated with `make:user`. The email field is used for this index.

**Before:**
I will then have `#[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]` for User and Admin entities

**After:**
For the User entity, this will be:
`#[ORM\UniqueConstraint(name: 'USER_UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]`

For the Admin entity, this will be:
`#[ORM\UniqueConstraint(name: 'ADMIN_UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]`