### PR TITLE
Fixed undefined method issue

### DIFF
--- a/_docs_build/build.php
+++ b/_docs_build/build.php
@@ -35,7 +35,7 @@ use SymfonyDocsBuilder\DocBuilder;
             ->setImagesDir(__DIR__.'/output/_images')
             ->setImagesPublicPrefix('_images')
             ->setTheme('rtd')
-            ->diableBuildCache()
+            ->disableBuildCache()
         ;
 
         $buildConfig->setExcludedPaths(['.github/', '_build/']);


### PR DESCRIPTION
This is a small fix `PHP Fatal error:  Uncaught Error: Call to undefined method SymfonyDocsBuilder\BuildConfig::diableBuildCache()` issue for `_docs_build`