### PR TITLE
Do not call Reflection*::setAccessible()

### DIFF
--- a/src/Doctrine/DoctrineHelper.php
+++ b/src/Doctrine/DoctrineHelper.php
@@ -155,7 +155,6 @@ final class DoctrineHelper
                 if ($attributeDriver instanceof AttributeDriver) {
                     $classNames = (new \ReflectionClass(AttributeDriver::class))->getProperty('classNames');
 
-                    $classNames->setAccessible(true);
                     $classNames->setValue($attributeDriver, null);
                 }
             }


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations