### PR TITLE
Remove obsolete check for 'version' in docker compose file

### DIFF
--- a/src/Util/ComposeFileManipulator.php
+++ b/src/Util/ComposeFileManipulator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\MakerBundle\Util;
 
-use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Component\Yaml\Dumper;
 
 /**
@@ -38,8 +37,6 @@ class ComposeFileManipulator
         } else {
             $this->manipulator = new YamlSourceManipulator($contents);
         }
-
-        $this->checkComposeFileVersion();
     }
 
     public function getComposeData(): array
@@ -115,18 +112,5 @@ class ComposeFileManipulator
             'version' => $version,
             'services' => [],
         ];
-    }
-
-    private function checkComposeFileVersion(): void
-    {
-        $data = $this->manipulator->getData();
-
-        if (empty($data['version'])) {
-            throw new RuntimeCommandException('compose.yaml file version is not set.');
-        }
-
-        if (2.0 > (float) $data['version']) {
-            throw new RuntimeCommandException(\sprintf('compose.yaml version %s is not supported. Please update your compose.yaml file to the latest version.', $data['version']));
-        }
     }
 }

--- a/tests/Util/ComposeFileManipulatorTest.php
+++ b/tests/Util/ComposeFileManipulatorTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\Util\ComposeFileManipulator;
 
 /**
@@ -139,27 +138,5 @@ class ComposeFileManipulatorTest extends TestCase
         ];
 
         self::assertSame($expected, $manipulator->getComposeData());
-    }
-
-    public function testCheckComposeFileVersion(): void
-    {
-        new ComposeFileManipulator('version: \'2\'');
-
-        $this->expectException(RuntimeCommandException::class);
-        $this->expectExceptionMessage('compose.yaml version 1.9 is not supported. Please update your compose.yaml file to the latest version.');
-
-        new ComposeFileManipulator('version: \'1.9\'');
-    }
-
-    public function testCheckComposeFileVersionThrowsExceptionWithMissingVersion(): void
-    {
-        $composeFile = <<< 'EOT'
-            services:
-                []
-            EOT;
-        $this->expectException(RuntimeCommandException::class);
-        $this->expectExceptionMessage('compose.yaml file version is not set.');
-
-        new ComposeFileManipulator($composeFile);
     }
 }


### PR DESCRIPTION
Running ``symfony console make:docker:database`` fails with the error "[ERROR] compose.yaml file version is not set." if the version: field is missing.

Since Docker Compose v2, the version field is optional and considered obsolete. Users with a modern compose.yaml may see this error unnecessarily.

See: https://docs.docker.com/reference/compose-file/version-and-name/

This PR removes the version check and updates the tests accordingly.