### PR TITLE
[make:entity] Allow specify the table name

### DIFF
--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -40,7 +40,7 @@ final class EntityClassGenerator
     ) {
     }
 
-    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true, bool $broadcast = false, EntityIdTypeEnum $useUuidIdentifier = EntityIdTypeEnum::INT): string
+    public function generateEntityClass(ClassNameDetails $entityClassDetails, bool $apiResource, bool $withPasswordUpgrade = false, bool $generateRepositoryClass = true, bool $broadcast = false, EntityIdTypeEnum $useUuidIdentifier = EntityIdTypeEnum::INT, array $params = []): string
     {
         $repoClassDetails = $this->generator->createClassNameDetails(
             $entityClassDetails->getRelativeName(),
@@ -48,7 +48,7 @@ final class EntityClassGenerator
             'Repository'
         );
 
-        $tableName = $this->doctrineHelper->getPotentialTableName($entityClassDetails->getFullName());
+        $potentialTableName = $this->doctrineHelper->getPotentialTableName($entityClassDetails->getFullName());
 
         $useStatements = new UseStatementGenerator([
             $repoClassDetails->getFullName(),
@@ -85,8 +85,9 @@ final class EntityClassGenerator
                 'repository_class_name' => $repoClassDetails->getShortName(),
                 'api_resource' => $apiResource,
                 'broadcast' => $broadcast,
-                'should_escape_table_name' => $this->doctrineHelper->isKeyword($tableName),
-                'table_name' => $tableName,
+                'is_keyword' => $this->doctrineHelper->isKeyword($params['tableName']),
+                'table_name' => $params['tableName'],
+                'should_render_table_annotation' => $params['tableName'] != $potentialTableName,
                 'id_type' => $useUuidIdentifier,
             ]
         );

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -208,8 +208,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
                 apiResource: $input->getOption('api-resource'),
                 broadcast: $broadcast,
                 useUuidIdentifier: $this->getIdType(),
-                params:
-                [
+                params: [
                     'tableName' => $tableName,
                 ]
             );

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -97,6 +97,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             ->addOption('broadcast', 'b', InputOption::VALUE_NONE, 'Add the ability to broadcast entity updates using Symfony UX Turbo?')
             ->addOption('regenerate', null, InputOption::VALUE_NONE, 'Instead of adding new fields, simply generate the methods (e.g. getter/setter) for existing fields')
             ->addOption('overwrite', null, InputOption::VALUE_NONE, 'Overwrite any existing getter/setter methods')
+            ->addOption('table', null, InputOption::VALUE_OPTIONAL, 'Allow specify the table name')
             ->setHelp($this->getHelpFileContents('MakeEntity.txt'))
         ;
 
@@ -186,14 +187,31 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             'Entity\\'
         );
 
+        if (!$input->getOption('table')) {
+            $potentialTableName = $this->doctrineHelper->getPotentialTableName($input->getArgument('name'));
+
+            $tableName = $io->ask(
+                sprintf('Enter the database table name (e.g. `%s`)', $potentialTableName),
+                $potentialTableName
+            );
+            $input->setOption('table', $tableName);
+        }
+
+
         $classExists = class_exists($entityClassDetails->getFullName());
         if (!$classExists) {
+            $tableName = $input->getOption('table');
+
             $broadcast = $input->getOption('broadcast');
             $entityPath = $this->entityClassGenerator->generateEntityClass(
                 entityClassDetails: $entityClassDetails,
                 apiResource: $input->getOption('api-resource'),
                 broadcast: $broadcast,
                 useUuidIdentifier: $this->getIdType(),
+                params:
+                [
+                    'tableName' => $tableName,
+                ]
             );
 
             if ($broadcast) {

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -197,7 +197,6 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             $input->setOption('table', $tableName);
         }
 
-
         $classExists = class_exists($entityClassDetails->getFullName());
         if (!$classExists) {
             $tableName = $input->getOption('table');

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -191,7 +191,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             $potentialTableName = $this->doctrineHelper->getPotentialTableName($input->getArgument('name'));
 
             $tableName = $io->ask(
-                sprintf('Enter the database table name (e.g. `%s`)', $potentialTableName),
+                \sprintf('Enter the database table name (e.g. `%s`)', $potentialTableName),
                 $potentialTableName
             );
             $input->setOption('table', $tableName);

--- a/templates/doctrine/Entity.tpl.php
+++ b/templates/doctrine/Entity.tpl.php
@@ -10,8 +10,9 @@ namespace <?= $namespace ?>;
 <?= $use_statements; ?>
 
 #[ORM\Entity(repositoryClass: <?= $repository_class_name ?>::class)]
-<?php if ($should_escape_table_name): ?>#[ORM\Table(name: '`<?= $table_name ?>`')]
-<?php endif ?>
+<?php if ($should_render_table_annotation): ?>
+#[ORM\Table(name: '<?= $is_keyword ? '`'.$table_name.'`' : $table_name ?>')]
+<?php endif; ?>
 <?php if ($api_resource): ?>
 #[ApiResource]
 <?php endif ?>


### PR DESCRIPTION
Related to #1626, here's a PR to fit that need. I've checked it's backwards compatible, so if you want to keep the current behaviour, you just have to confirm the default guessing. If you want to have a different table name from the default guessing, just enter when prompted. And I've tested that if you enter a keyword, it's properly quoted.