### PR TITLE
Fix flex `SYMFONY_REQUIRE` configuration in CI

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -35,17 +35,15 @@ jobs:
                 ports:
                     - 1337:1337
 
-        env:
-            SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
         strategy:
             fail-fast: false
             matrix:
                 php-version:
-                    - '8.3'
+                    - '8.4'
                 symfony-version:
                     - '6.4.*'
-                    - '7.2.*'
+                    - '7.3.*'
                 dependency-versions: ['highest']
                 include:
                     # testing lowest PHP+dependencies with lowest Symfony
@@ -69,6 +67,8 @@ jobs:
 
             - name: Composer install
               uses: "ramsey/composer-install@v3"
+              env:
+                  SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
               with:
                   dependency-versions: "${{ matrix.dependency-versions }}"
 

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -36,7 +36,7 @@ jobs:
                     - 1337:1337
 
         env:
-            SYMFONY_VERSION: ${{ matrix.symfony-version }}
+            SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
Flex uses the `SYMFONY_REQUIRE` variable for version constraint https://github.com/symfony/flex/blob/f356aa35f3cf3d2f46c31d344c1098eb2d260426/src/Flex.php#L129