### PR TITLE
Removed assertion on status code after redirect

### DIFF
--- a/templates/security/formLogin/Test.LoginController.tpl.php
+++ b/templates/security/formLogin/Test.LoginController.tpl.php
@@ -74,6 +74,5 @@ class LoginControllerTest extends WebTestCase
         $this->client->followRedirect();
 
         self::assertSelectorNotExists('.alert-danger');
-        self::assertResponseIsSuccessful();
     }
 }


### PR DESCRIPTION
The unit test for the created LoginController does an assertion on the http status code after redirecting. Since it's not required to have a root route, this assertion could fail if there is no root configured.

The functionality works as intended if the redirect works, there's no real benefit to further check the status of the page its redirected to. This functionality should be tested in the unit test of the root controller.