### PR TITLE
allow Symfony 8 and doctrine-bundle:^3

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -42,7 +42,7 @@ jobs:
             fail-fast: false
             matrix:
                 php-version:
-                    - '8.3'
+                    - '8.4'
                 symfony-version:
                     - '6.4.*'
                     - '7.3.*'

--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -45,7 +45,8 @@ jobs:
                     - '8.3'
                 symfony-version:
                     - '6.4.*'
-                    - '7.2.*'
+                    - '7.3.*'
+                    - '8.0.*'
                 dependency-versions: ['highest']
                 include:
                     # testing lowest PHP+dependencies with lowest Symfony

--- a/composer.json
+++ b/composer.json
@@ -17,25 +17,25 @@
         "php": ">=8.1",
         "doctrine/inflector": "^2.0",
         "nikic/php-parser": "^5.0",
-        "symfony/config": "^6.4|^7.0",
-        "symfony/console": "^6.4|^7.0",
-        "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/config": "^6.4|^7.3|^8.0",
+        "symfony/console": "^6.4|^7.3|^8.0",
+        "symfony/dependency-injection": "^6.4|^7.3|^8.0",
         "symfony/deprecation-contracts": "^2.2|^3",
-        "symfony/filesystem": "^6.4|^7.0",
-        "symfony/finder": "^6.4|^7.0",
-        "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/http-kernel": "^6.4|^7.0",
-        "symfony/process": "^6.4|^7.0"
+        "symfony/filesystem": "^6.4|^7.3|^8.0",
+        "symfony/finder": "^6.4|^7.3|^8.0",
+        "symfony/framework-bundle": "^6.4|^7.3|^8.0",
+        "symfony/http-kernel": "^6.4|^7.3|^8.0",
+        "symfony/process": "^6.4|^7.3|^8.0"
     },
     "require-dev": {
         "composer/semver": "^3.0",
-        "doctrine/doctrine-bundle": "^2.5.0",
+        "doctrine/doctrine-bundle": "^2.5.0|^3.0",
         "doctrine/orm": "^2.15|^3",
-        "symfony/http-client": "^6.4|^7.0",
+        "symfony/http-client": "^6.4|^7.3|^8.0",
         "symfony/phpunit-bridge": "^6.4.1|^7.0",
-        "symfony/security-core": "^6.4|^7.0",
-        "symfony/security-http": "^6.4|^7.0",
-        "symfony/yaml": "^6.4|^7.0",
+        "symfony/security-core": "^6.4|^7.3|^8.0",
+        "symfony/security-http": "^6.4|^7.3|^8.0",
+        "symfony/yaml": "^6.4|^7.3|^8.0",
         "twig/twig": "^3.0|^4.x-dev"
     },
     "config": {
@@ -53,6 +53,9 @@
         "psr-4": { "Symfony\\Bundle\\MakerBundle\\Tests\\": "tests/" }
     },
     "extra": {
+        "symfony": {
+            "require": "8.0-dev"
+        },
         "branch-alias": {
             "dev-main": "1.x-dev"
         }


### PR DESCRIPTION
This is a minimal patch that should at least allow webapp to install in Symfony 8.

