### PR TITLE
[make:validator] Add `--target` option that allows restricting automatically where the constraint class can be used

### DIFF
--- a/config/help/MakeValidator.txt
+++ b/config/help/MakeValidator.txt
@@ -3,3 +3,11 @@ The <info>%command.name%</info> command generates a new validation constraint.
 <info>php %command.full_name% EnabledValidator</info>
 
 If the argument is missing, the command will ask for the constraint class name interactively.
+
+The <info>--target</info> option allows you to restrict where the constraint class can be used:
+
+  <info>php %command.full_name% EnabledValidator --target=class</info>
+  <info>php %command.full_name% EnabledValidator --target=method</info>
+  <info>php %command.full_name% EnabledValidator --target=property</info>
+
+If the option is invalid, the command will ask for the target type interactively.

--- a/src/Validator/TargetEnum.php
+++ b/src/Validator/TargetEnum.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Validator;
+
+enum TargetEnum: string
+{
+    case CLASS_TARGET = 'class';
+    case METHOD_TARGET = 'method';
+    case PROPERTY_TARGET = 'property';
+
+    /**
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/templates/validator/Constraint.tpl.php
+++ b/templates/validator/Constraint.tpl.php
@@ -4,7 +4,20 @@ namespace <?= $class_data->getNamespace(); ?>;
 
 <?= $class_data->getUseStatements(); ?>
 
+<?php switch ($target): ?>
+<?php case 'class': ?>
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+<?php break; ?>
+<?php case 'method': ?>
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+<?php break; ?>
+<?php case 'property': ?>
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+<?php break; ?>
+<?php default: ?>
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+<?php endswitch; ?>
+
 <?= $class_data->getClassDeclaration(); ?>
 
 {
@@ -19,4 +32,11 @@ namespace <?= $class_data->getNamespace(); ?>;
     ) {
         parent::__construct([], $groups, $payload);
     }
+
+<?php if ('class' === $target): ?>
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+<?php endif; ?>
 }

--- a/tests/Maker/MakeValidatorTest.php
+++ b/tests/Maker/MakeValidatorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 use Symfony\Bundle\MakerBundle\Maker\MakeValidator;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+use Symfony\Bundle\MakerBundle\Validator\TargetEnum;
 
 class MakeValidatorTest extends MakerTestCase
 {
@@ -45,6 +46,65 @@ class MakeValidatorTest extends MakerTestCase
 
                 self::assertSame(file_get_contents($expectedVoterPath), file_get_contents($generatedVoter));
             }),
+        ];
+
+        yield 'it_makes_validator_constraint_with_target' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $targets = $this->getTargets();
+
+                foreach ($targets as $target => $className) {
+                    $runner->runMaker(
+                        [
+                            // Validator name.
+                            $className,
+                        ],
+                        "--target=$target"
+                    );
+
+                    $expectedPath = \dirname(__DIR__)."/fixtures/make-validator/expected/$className.php";
+                    $generatedPath = $runner->getPath("src/Validator/$className.php");
+
+                    self::assertSame(file_get_contents($expectedPath), file_get_contents($generatedPath));
+                }
+            }),
+        ];
+
+        yield 'it_makes_validator_constraint_with_target_invalid' => [$this->createMakerTest()
+            ->run(function (MakerTestRunner $runner) {
+                $targets = $this->getTargets();
+                $keys = array_keys($targets);
+
+                foreach ($targets as $target => $className) {
+                    $choice = array_search($target, $keys);
+
+                    $runner->runMaker(
+                        [
+                            // Validator name.
+                            $className,
+                            // Target type.
+                            $choice,
+                        ],
+                        '--target=invalid'
+                    );
+
+                    $expectedPath = \dirname(__DIR__)."/fixtures/make-validator/expected/$className.php";
+                    $generatedPath = $runner->getPath("src/Validator/$className.php");
+
+                    self::assertSame(file_get_contents($expectedPath), file_get_contents($generatedPath));
+                }
+            }),
+        ];
+    }
+
+    /**
+     * @return array<value-of<TargetEnum>, string>
+     */
+    private function getTargets(): array
+    {
+        return [
+            'class' => 'WithTargetClass',
+            'method' => 'WithTargetMethod',
+            'property' => 'WithTargetProperty',
         ];
     }
 }

--- a/tests/fixtures/make-validator/expected/WithTargetClass.php
+++ b/tests/fixtures/make-validator/expected/WithTargetClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::IS_REPEATABLE)]
+final class WithTargetClass extends Constraint
+{
+    public string $message = 'The string "{{ value }}" contains an illegal character: it can only contain letters or numbers.';
+
+    // You can use #[HasNamedArguments] to make some constraint options required.
+    // All configurable options must be passed to the constructor.
+    public function __construct(
+        public string $mode = 'strict',
+        ?array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/tests/fixtures/make-validator/expected/WithTargetMethod.php
+++ b/tests/fixtures/make-validator/expected/WithTargetMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class WithTargetMethod extends Constraint
+{
+    public string $message = 'The string "{{ value }}" contains an illegal character: it can only contain letters or numbers.';
+
+    // You can use #[HasNamedArguments] to make some constraint options required.
+    // All configurable options must be passed to the constructor.
+    public function __construct(
+        public string $mode = 'strict',
+        ?array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+}

--- a/tests/fixtures/make-validator/expected/WithTargetProperty.php
+++ b/tests/fixtures/make-validator/expected/WithTargetProperty.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+final class WithTargetProperty extends Constraint
+{
+    public string $message = 'The string "{{ value }}" contains an illegal character: it can only contain letters or numbers.';
+
+    // You can use #[HasNamedArguments] to make some constraint options required.
+    // All configurable options must be passed to the constructor.
+    public function __construct(
+        public string $mode = 'strict',
+        ?array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

This pull request adds the `--target` option to the `make:validator` command to speed up the creation and the use of a custom validation constraint.

# Usage

```sh
php bin/console make:validator FooValidator --target=class
php bin/console make:validator FooValidator --target=method
php bin/console make:validator FooValidator --target=property
```

# Result

| Target     | Constraint class changes                                                                                               |
| ---------- | ---------------------------------------------------------------------------------------------------------------------- |
| `class`    | - Add the `#[\Attribute(\Attribute::IS_REPEATABLE)]` declaration,<br>- Add the `Constraint::getTargets` required method. |
| `method`   | - Add the `#[\Attribute(\Attribute::TARGET_METHOD \| \Attribute::IS_REPEATABLE)]` declaration.                          |
| `property` | - Add the `#[\Attribute(\Attribute::TARGET_PROPERTY \| \Attribute::IS_REPEATABLE)]` declaration.                        |