### PR TITLE
Update CI after release of Symfony 7.4 and 8.0

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -53,14 +53,12 @@ jobs:
                       symfony-version: '6.4.*'
                       dependency-versions: 'lowest'
 
-                    # unreleased Symfony 7.4
                     - php-version: '8.2'
-                      symfony-version: '^7.4.0-RC2'
+                      symfony-version: '^7.4.0'
                       dependency-versions: 'highest'
 
-                    # unreleased Symfony 8.0
                     - php-version: '8.4'
-                      symfony-version: '^8.0.0-RC2'
+                      symfony-version: '^8.0.0'
                       dependency-versions: 'highest'
 
         steps:

--- a/src/Security/Model/Authenticator.php
+++ b/src/Security/Model/Authenticator.php
@@ -16,7 +16,7 @@ namespace Symfony\Bundle\MakerBundle\Security\Model;
  *
  * @internal
  */
-final class Authenticator
+final class Authenticator implements \Stringable
 {
     public function __construct(
         public AuthenticatorType $type,

--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -406,13 +406,7 @@ echo json_encode($missingDependencies);
 
     public function getTargetSkeletonVersion(): ?string
     {
-        $symfonyVersion = $_SERVER['SYMFONY_VERSION'] ?? '';
-
-        return match (true) {
-            str_starts_with($symfonyVersion, '^7.4.') && str_contains($symfonyVersion, 'RC') => '7.4.x-dev',
-            str_starts_with($symfonyVersion, '^8.0.') && str_contains($symfonyVersion, 'RC') => '8.0.x-dev',
-            default => $symfonyVersion,
-        };
+        return $_SERVER['SYMFONY_VERSION'] ?? '';
     }
 
     private function composerRequireMakerBundle(string $projectDirectory): void


### PR DESCRIPTION
It's very likely that composer used the stable versions after their release but let’s clean this up for consistency.

Follow-up of:

- GH-1724