### PR TITLE
Updated MigrationDiffFilteredOutput to implement all methods from OutputInterface

### DIFF
--- a/src/Console/MigrationDiffFilteredOutput.php
+++ b/src/Console/MigrationDiffFilteredOutput.php
@@ -53,6 +53,11 @@ class MigrationDiffFilteredOutput implements OutputInterface
         return $this->output->getVerbosity();
     }
 
+    public function isSilent(): bool
+    {
+        return $this->output->isSilent();
+    }
+
     public function isQuiet(): bool
     {
         return $this->output->isQuiet();


### PR DESCRIPTION
This PR adds an implementation for `OutputInterface::isSilent()` which is currently missing from the `MigrationDiffFilteredOutput` class.

Currently, the `./bin/console make:migration` command is failing when the latest version of `symfony/console` is installed because the class is incomplete.