### PR TITLE
fix: `Authenticator` must implement `\Stringable`

### DIFF
--- a/src/Security/Model/Authenticator.php
+++ b/src/Security/Model/Authenticator.php
@@ -16,7 +16,7 @@ namespace Symfony\Bundle\MakerBundle\Security\Model;
  *
  * @internal
  */
-final class Authenticator
+final class Authenticator implements \Stringable
 {
     public function __construct(
         public AuthenticatorType $type,


### PR DESCRIPTION
This will fix the PHP-CS-Fixer job that is failing on main branch: https://github.com/symfony/maker-bundle/actions?query=branch%3A1.x example from scheduled job: https://github.com/symfony/maker-bundle/actions/runs/19877750206

I don’t know how to fix the PHPunit tests:

- https://github.com/symfony/maker-bundle/pull/1747#issuecomment-3608114026

So this PR is only about PHP-CS-Fixer.