### PR TITLE
chore: split coding standards on CI, hide progress from php-cs-fixer

### DIFF
--- a/.github/workflows/ci-static-analysis.yaml
+++ b/.github/workflows/ci-static-analysis.yaml
@@ -13,8 +13,22 @@ env:
     SYMFONY_PHPUNIT_DIR: "$HOME/symfony-bridge/.phpunit"
 
 jobs:
-    coding-standards:
-        name: "Coding Standards"
+    composer-validate:
+        name: "Validate composer.json"
+
+        runs-on: ubuntu-latest
+
+        steps:
+            -
+                name: Checkout code
+                uses: "actions/checkout@v4"
+
+            -
+                name: Validate composer.json
+                run: "composer validate --strict --no-check-lock"
+
+    php-cs-fixer:
+        name: "PHP-CS-Fixer"
 
         runs-on: ubuntu-latest
 
@@ -28,10 +42,6 @@ jobs:
                 uses: "shivammathur/setup-php@v2"
                 with:
                     php-version: 8.2
-
-            -
-                name: Validate composer.json
-                run: "composer validate --strict --no-check-lock"
 
             -
                 name: Composer install

--- a/.github/workflows/ci-static-analysis.yaml
+++ b/.github/workflows/ci-static-analysis.yaml
@@ -57,7 +57,7 @@ jobs:
 
             -
                 name: Run PHP-CS-Fixer
-                run: "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff"
+                run: "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff --show-progress=none"
 
     phpstan:
         name: PHPStan


### PR DESCRIPTION
composer validation and PHP-CS-Fixer will be run separately.

Before this change, an error with `composer validate` would stop the job before running `PHP-CS-Fixer`.

And it’s not necessary to install PHP to run `composer validate`, now the whole job takes about 5 seconds.

A fix for PHP-CS-Fixer is available here:

- GH-1755

The second commit will remove this output:

```
   0/168 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
  17/168 [▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░]  10%
  34/168 [▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░]  20%
  51/168 [▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░]  30%
  68/168 [▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░]  40%
  84/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  50%
 101/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░]  60%
 112/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░]  66%
 118/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░]  70%
 133/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░]  79%
 152/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░]  90%
 159/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░]  94%
 168/168 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
```