### PR TITLE
Use the released versions of Symfony 7.4 and 8.0

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -53,14 +53,12 @@ jobs:
                       symfony-version: '6.4.*'
                       dependency-versions: 'lowest'
 
-                    # unreleased Symfony 7.4
                     - php-version: '8.2'
-                      symfony-version: '^7.4.0-RC2'
+                      symfony-version: '7.4.*'
                       dependency-versions: 'highest'
 
-                    # unreleased Symfony 8.0
                     - php-version: '8.4'
-                      symfony-version: '^8.0.0-RC2'
+                      symfony-version: '8.0.*'
                       dependency-versions: 'highest'
 
         steps:


### PR DESCRIPTION
Currently the CI is broken.

This one is blocked by https://github.com/symfony/panther/pull/678 ➡️ https://github.com/php-webdriver/php-webdriver/pull/1134

Or yolo-merge it? :)
