### PR TITLE
[Make:Voter] Add Missing Vote param in `voteOnAttribute()`

### DIFF
--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -57,6 +58,7 @@ final class MakeVoter extends AbstractMaker
                 TokenInterface::class,
                 Voter::class,
                 UserInterface::class,
+                Vote::class,
             ]
         );
 

--- a/templates/security/Voter.tpl.php
+++ b/templates/security/Voter.tpl.php
@@ -18,11 +18,13 @@ namespace <?= $class_data->getNamespace(); ?>;
             && $subject instanceof \App\Entity\<?= str_replace('Voter', null, $class_data->getClassName()) ?>;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
         // if the user is anonymous, do not grant access
         if (!$user instanceof UserInterface) {
+            $vote?->addReason('The user must be logged in to access this resource.');
+
             return false;
         }
 

--- a/tests/fixtures/make-voter/expected/FooBarVoter.php
+++ b/tests/fixtures/make-voter/expected/FooBarVoter.php
@@ -3,6 +3,7 @@
 namespace App\Security\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -19,12 +20,14 @@ final class FooBarVoter extends Voter
             && $subject instanceof \App\Entity\FooBar;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
 
         // if the user is anonymous, do not grant access
         if (!$user instanceof UserInterface) {
+            $vote?->addReason('The user must be logged in to access this resource.');
+
             return false;
         }
 

--- a/tests/fixtures/make-voter/expected/not_final_FooBarVoter.php
+++ b/tests/fixtures/make-voter/expected/not_final_FooBarVoter.php
@@ -3,6 +3,7 @@
 namespace App\Security\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -19,12 +20,14 @@ class FooBarVoter extends Voter
             && $subject instanceof \App\Entity\FooBar;
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
 
         // if the user is anonymous, do not grant access
         if (!$user instanceof UserInterface) {
+            $vote?->addReason('The user must be logged in to access this resource.');
+
             return false;
         }
 


### PR DESCRIPTION
Related to [#59771](https://github.com/symfony/symfony/pull/59771) and [#61187](https://github.com/symfony/symfony/pull/61187).

Starting from Symfony 8.0, running `make:voter` generates a deprecated declaration that triggers the following error : 

<img width="1919" height="511" alt="image" src="https://github.com/user-attachments/assets/47203894-6b96-4cb0-88d9-1488828a6624" />



This PR updates the template to match the new declaration.



