### PR TITLE
[maker:controller] Fix invokable `-i` conflict with APP_ID  `-i`

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -69,7 +69,7 @@ final class MakeController extends AbstractMaker
         $command
             ->addArgument('controller-class', InputArgument::OPTIONAL, \sprintf('Choose a name for your controller class (e.g. <fg=yellow>%sController</>)', Str::asClassName(Str::getRandomTerm())))
             ->addOption('no-template', null, InputOption::VALUE_NONE, 'Use this option to disable template generation')
-            ->addOption('invokable', 'i', InputOption::VALUE_NONE, 'Use this option to create an invokable controller')
+            ->addOption('invokable', null, InputOption::VALUE_NONE, 'Use this option to create an invokable controller')
             ->setHelp($this->getHelpFileContents('MakeController.txt'))
         ;
 


### PR DESCRIPTION
Fixs #1738

Unability to generate an app-specific controller

`php bin/console make:controller test -iapi`

> [critical] Error thrown while running command "make:controller test -iapi". Message: "The "-a" option does not exist."

` php bin/console make:controller test -i -iapi`

> [critical] Error thrown while running command "make:controller test -i -iapi". Message: "The "-a" option does not exist."

I think we are better off without this short param