### PR TITLE
Re-enable api tests

### DIFF
--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -120,8 +120,6 @@ class MakeEntityTest extends MakerTestCase
         ];
 
         yield 'it_creates_a_new_class_and_api_resource' => [$this->createMakeEntityTest()
-            // @legacy - re-enable test when https://github.com/symfony/recipes/pull/1339 is merged
-            ->skipTest('Waiting for https://github.com/symfony/recipes/pull/1339')
             ->addExtraDependencies('api')
             ->run(function (MakerTestRunner $runner) {
                 $runner->runMaker([
@@ -661,8 +659,6 @@ class MakeEntityTest extends MakerTestCase
         ];
 
         yield 'it_makes_new_entity_no_to_all_extras' => [$this->createMakeEntityTestForMercure()
-            // @legacy - re-enable test when https://github.com/symfony/recipes/pull/1339 is merged
-            ->skipTest('Waiting for https://github.com/symfony/recipes/pull/1339')
             ->addExtraDependencies('api')
             // special setup done in createMakeEntityTestForMercure()
             ->run(function (MakerTestRunner $runner) {


### PR DESCRIPTION
Revert change from https://github.com/symfony/maker-bundle/pull/1598 as https://github.com/symfony/recipes/pull/1339 was merged.