### PR TITLE
PHPUnit 11 compatibility

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -42,10 +42,11 @@ jobs:
             fail-fast: false
             matrix:
                 php-version:
-                    - '8.3'
+                    - '8.4'
                 symfony-version:
                     - '6.4.*'
-                    - '7.3.*'
+                    - '7.4.*'
+                    - '^8'
                 dependency-versions: ['highest']
                 include:
                     # testing lowest PHP+dependencies with lowest Symfony
@@ -53,13 +54,11 @@ jobs:
                       symfony-version: '6.4.*'
                       dependency-versions: 'lowest'
 
-                    - php-version: '8.2'
-                      symfony-version: '^7.4.0'
+                    # testing newest PHPUnit
+                    - php-version: '8.5'
+                      symfony-version: '8.*'
                       dependency-versions: 'highest'
-
-                    - php-version: '8.4'
-                      symfony-version: '^8.0.0'
-                      dependency-versions: 'highest'
+                      phpunit-version: '11.5'
 
         steps:
             - name: Checkout code
@@ -93,6 +92,8 @@ jobs:
             - name: Install PHPUnit
               run: |
                 vendor/bin/simple-phpunit install
+              env:
+                PHPUNIT_VERSION: ${{ matrix.phpunit-version || '9.6' }}
 
             - name: PHPUnit version
               run: vendor/bin/simple-phpunit --version

--- a/src/Test/MakerTestDetails.php
+++ b/src/Test/MakerTestDetails.php
@@ -37,8 +37,11 @@ final class MakerTestDetails
     private string $skipTestMessage = '';
 
     public function __construct(
-        private MakerInterface $maker,
+        private ?MakerInterface $maker = null,
     ) {
+        if (null !== $this->maker) {
+            trigger_deprecation('symfony/maker-bundle', 'v1.66.0', 'Passing a MakerInterface to the %s constructor is deprecated.', __CLASS__);
+        }
     }
 
     public function run(\Closure $callback): self
@@ -79,7 +82,7 @@ final class MakerTestDetails
 
     public function setRequiredPhpVersion(int $version): self
     {
-        @trigger_deprecation('symfony/maker-bundle', 'v1.44.0', 'setRequiredPhpVersion() is no longer used and will be removed in a future version.');
+        trigger_deprecation('symfony/maker-bundle', 'v1.44.0', 'setRequiredPhpVersion() is no longer used and will be removed in a future version.');
 
         $this->requiredPhpVersion = $version;
 
@@ -116,8 +119,20 @@ final class MakerTestDetails
         return 'maker_'.strtolower($this->getRootNamespace()).'_'.md5(serialize($this->getDependencies()));
     }
 
+    /**
+     * @internal
+     */
+    public function setMaker(MakerInterface $maker): void
+    {
+        $this->maker = $maker;
+    }
+
     public function getMaker(): MakerInterface
     {
+        if (!$this->maker) {
+            throw new \LogicException('The maker has not been set.');
+        }
+
         return $this->maker;
     }
 
@@ -140,7 +155,7 @@ final class MakerTestDetails
     public function getDependencyBuilder(): DependencyBuilder
     {
         $depBuilder = new DependencyBuilder();
-        $this->maker->configureDependencies($depBuilder);
+        $this->getMaker()->configureDependencies($depBuilder);
 
         return $depBuilder;
     }
@@ -173,7 +188,7 @@ final class MakerTestDetails
     public function getRunCallback(): \Closure
     {
         if (!$this->runCallback) {
-            throw new \Exception('Don\'t forget to call ->run()');
+            throw new \Exception('Don\'t forget to call ->run().');
         }
 
         return $this->runCallback;

--- a/tests/DependencyBuilderTest.php
+++ b/tests/DependencyBuilderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 
@@ -70,6 +71,7 @@ class DependencyBuilderTest extends TestCase
     /**
      * @dataProvider getMissingPackagesMessageTests
      */
+    #[DataProvider('getMissingPackagesMessageTests')]
     public function testGetMissingPackagesMessage(array $missingPackages, array $missingDevPackages, string $expectedMessage)
     {
         $depBuilder = new DependencyBuilder();
@@ -86,7 +88,7 @@ class DependencyBuilderTest extends TestCase
         $this->assertSame($expectedMessage, $depBuilder->getMissingPackagesMessage('make:something'));
     }
 
-    public function getMissingPackagesMessageTests()
+    public static function getMissingPackagesMessageTests()
     {
         yield 'nothing_missing' => [
             [],

--- a/tests/Docker/DatabaseServicesTest.php
+++ b/tests/Docker/DatabaseServicesTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Docker;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Docker\DockerDatabaseServices;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
@@ -28,7 +29,7 @@ final class DatabaseServicesTest extends TestCase
         DockerDatabaseServices::getDatabaseSkeleton('foo', 'latest');
     }
 
-    public function mixedNameDataProvider(): \Generator
+    public static function mixedNameDataProvider(): \Generator
     {
         yield ['mariadb'];
         yield ['mysql'];
@@ -38,6 +39,7 @@ final class DatabaseServicesTest extends TestCase
     /**
      * @dataProvider mixedNameDataProvider
      */
+    #[DataProvider('mixedNameDataProvider')]
     public function testSkeletonReturnArrayForDesiredDatabase(string $databaseName)
     {
         $result = DockerDatabaseServices::getDatabaseSkeleton($databaseName, 'latest');
@@ -49,6 +51,7 @@ final class DatabaseServicesTest extends TestCase
     /**
      * @dataProvider mixedNameDataProvider
      */
+    #[DataProvider('mixedNameDataProvider')]
     public function testGetDefaultPorts(string $databaseName)
     {
         $result = DockerDatabaseServices::getDefaultPorts($databaseName);
@@ -59,6 +62,7 @@ final class DatabaseServicesTest extends TestCase
     /**
      * @dataProvider mixedNameDataProvider
      */
+    #[DataProvider('mixedNameDataProvider')]
     public function testSuggestedVersion(string $databaseName)
     {
         $result = DockerDatabaseServices::getSuggestedServiceVersion($databaseName);

--- a/tests/Doctrine/DoctrineHelperTest.php
+++ b/tests/Doctrine/DoctrineHelperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Doctrine;
 
 use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 
@@ -20,12 +21,13 @@ class DoctrineHelperTest extends TestCase
     /**
      * @dataProvider getTypeConstantTests
      */
+    #[DataProvider('getTypeConstantTests')]
     public function testGetTypeConstant(string $columnType, ?string $expectedConstant)
     {
         $this->assertSame($expectedConstant, DoctrineHelper::getTypeConstant($columnType));
     }
 
-    public function getTypeConstantTests(): \Generator
+    public static function getTypeConstantTests(): \Generator
     {
         yield 'unknown_type' => ['foo', null];
         yield 'string' => ['string', 'Types::STRING'];
@@ -35,12 +37,13 @@ class DoctrineHelperTest extends TestCase
     /**
      * @dataProvider getCanColumnTypeBeInferredTests
      */
+    #[DataProvider('getCanColumnTypeBeInferredTests')]
     public function testCanColumnTypeBeInferredByPropertyType(string $columnType, string $propertyType, bool $expected)
     {
         $this->assertSame($expected, DoctrineHelper::canColumnTypeBeInferredByPropertyType($columnType, $propertyType));
     }
 
-    public function getCanColumnTypeBeInferredTests(): \Generator
+    public static function getCanColumnTypeBeInferredTests(): \Generator
     {
         yield 'non_matching' => [Types::TEXT, 'string', false];
         yield 'yes_matching' => [Types::STRING, 'string', true];

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Tests\Doctrine;
 use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -38,6 +39,7 @@ class EntityRegeneratorTest extends TestCase
     /**
      * @dataProvider getRegenerateEntitiesTests
      */
+    #[DataProvider('getRegenerateEntitiesTests')]
     public function testRegenerateEntities(string $expectedDirName, bool $overwrite)
     {
         $kernel = new TestEntityRegeneratorKernel('dev', true);
@@ -51,7 +53,7 @@ class EntityRegeneratorTest extends TestCase
         );
     }
 
-    public function getRegenerateEntitiesTests(): \Generator
+    public static function getRegenerateEntitiesTests(): \Generator
     {
         yield 'regenerate_no_overwrite' => [
             'expected_no_overwrite',

--- a/tests/FileManagerTest.php
+++ b/tests/FileManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
@@ -25,6 +26,7 @@ class FileManagerTest extends TestCase
     /**
      * @dataProvider getRelativizePathTests
      */
+    #[DataProvider('getRelativizePathTests')]
     public function testRelativizePath(string $rootDir, string $absolutePath, string $expectedPath)
     {
         $fileManager = new FileManager(
@@ -37,7 +39,7 @@ class FileManagerTest extends TestCase
         $this->assertSame($expectedPath, $fileManager->relativizePath($absolutePath));
     }
 
-    public function getRelativizePathTests()
+    public static function getRelativizePathTests()
     {
         yield [
             '/home/project',
@@ -79,6 +81,7 @@ class FileManagerTest extends TestCase
     /**
      * @dataProvider getAbsolutePathTests
      */
+    #[DataProvider('getAbsolutePathTests')]
     public function testAbsolutizePath(string $rootDir, string $path, string $expectedPath)
     {
         $fileManager = new FileManager(
@@ -90,7 +93,7 @@ class FileManagerTest extends TestCase
         $this->assertSame($expectedPath, $fileManager->absolutizePath($path));
     }
 
-    public function getAbsolutePathTests()
+    public static function getAbsolutePathTests()
     {
         yield 'normal_path_change' => [
             '/home/project/',
@@ -120,6 +123,7 @@ class FileManagerTest extends TestCase
     /**
      * @dataProvider getIsPathInVendorTests
      */
+    #[DataProvider('getIsPathInVendorTests')]
     public function testIsPathInVendor(string $rootDir, string $path, bool $expectedIsInVendor)
     {
         $fileManager = new FileManager(
@@ -131,7 +135,7 @@ class FileManagerTest extends TestCase
         $this->assertSame($expectedIsInVendor, $fileManager->isPathInVendor($path));
     }
 
-    public function getIsPathInVendorTests()
+    public static function getIsPathInVendorTests()
     {
         yield 'not_in_vendor' => [
             '/home/project/',
@@ -167,6 +171,7 @@ class FileManagerTest extends TestCase
     /**
      * @dataProvider getPathForTemplateTests
      */
+    #[DataProvider('getPathForTemplateTests')]
     public function testPathForTemplate(string $rootDir, string $twigDefaultPath, string $expectedTemplatesFolder)
     {
         $fileManager = new FileManager(
@@ -179,7 +184,7 @@ class FileManagerTest extends TestCase
         $this->assertSame($expectedTemplatesFolder, $fileManager->getPathForTemplate('template.html.twig'));
     }
 
-    public function getPathForTemplateTests()
+    public static function getPathForTemplateTests()
     {
         yield 'its_a_folder' => [
             '/home/project/',

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -20,6 +21,7 @@ class GeneratorTest extends TestCase
     /**
      * @dataProvider getClassNameDetailsTests
      */
+    #[DataProvider('getClassNameDetailsTests')]
     public function testCreateClassNameDetails(string $name, string $prefix, string $suffix, string $expectedFullClassName, string $expectedRelativeClassName)
     {
         $fileManager = $this->createMock(FileManager::class);
@@ -35,7 +37,7 @@ class GeneratorTest extends TestCase
         $this->assertSame($expectedRelativeClassName, $classNameDetails->getRelativeName());
     }
 
-    public function getClassNameDetailsTests(): \Generator
+    public static function getClassNameDetailsTests(): \Generator
     {
         yield 'simple_class' => [
             'foo',

--- a/tests/GeneratorTwigHelperTest.php
+++ b/tests/GeneratorTwigHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\GeneratorTwigHelper;
@@ -20,6 +21,7 @@ class GeneratorTwigHelperTest extends TestCase
     /**
      * @dataProvider getEntityFieldPrintCodeTests
      */
+    #[DataProvider('getEntityFieldPrintCodeTests')]
     public function testGetEntityFieldPrintCode(string $entity, string $fieldName, string $fieldType, string $expect)
     {
         $generator = new GeneratorTwigHelper($this->createMock(FileManager::class));
@@ -32,7 +34,7 @@ class GeneratorTwigHelperTest extends TestCase
         $this->assertSame($expect, $result);
     }
 
-    public function getEntityFieldPrintCodeTests()
+    public static function getEntityFieldPrintCodeTests()
     {
         yield 'normal' => [
             'entity',

--- a/tests/Maker/MakeAuthenticatorTest.php
+++ b/tests/Maker/MakeAuthenticatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\MakerBundle\Maker\MakeAuthenticator;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
@@ -19,6 +20,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 /**
  * @group legacy
  */
+#[Group('legacy')]
 class MakeAuthenticatorTest extends MakerTestCase
 {
     protected function getMakerClass(): string
@@ -26,10 +28,10 @@ class MakeAuthenticatorTest extends MakerTestCase
         return MakeAuthenticator::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'auth_empty_one_firewall' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'auth_empty_one_firewall' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     // authenticator type => empty-auth
                     0,
@@ -37,18 +39,18 @@ class MakeAuthenticatorTest extends MakerTestCase
                     'AppCustomAuthenticator',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
-                $this->assertFileExists($runner->getPath('src/Security/AppCustomAuthenticator.php'));
+                self::assertStringContainsString('Success', $output);
+                self::assertFileExists($runner->getPath('src/Security/AppCustomAuthenticator.php'));
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
-                $this->assertEquals(
+                self::assertEquals(
                     'App\\Security\\AppCustomAuthenticator',
                     $securityConfig['security']['firewalls']['main']['custom_authenticator']
                 );
             }),
         ];
 
-        yield 'auth_empty_multiple_firewalls' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'auth_empty_multiple_firewalls' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->modifyYamlFile('config/packages/security.yaml', static function (array $config) {
                     $config['security']['firewalls']['second']['lazy'] = true;
 
@@ -64,17 +66,17 @@ class MakeAuthenticatorTest extends MakerTestCase
                     1,
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
-                $this->assertEquals(
+                self::assertEquals(
                     'App\\Security\\AppCustomAuthenticator',
                     $securityConfig['security']['firewalls']['second']['custom_authenticator']
                 );
             }),
         ];
 
-        yield 'auth_empty_existing_authenticator' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'auth_empty_existing_authenticator' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-auth/BlankAuthenticator.php',
                     'src/Security/BlankAuthenticator.php'
@@ -95,18 +97,18 @@ class MakeAuthenticatorTest extends MakerTestCase
                     1,
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
-                $this->assertEquals(
+                self::assertEquals(
                     'App\\Security\\AppCustomAuthenticator',
                     $securityConfig['security']['firewalls']['main']['custom_authenticator'][1]
                 );
             }),
         ];
 
-        yield 'auth_empty_multiple_firewalls_existing_authenticator' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'auth_empty_multiple_firewalls_existing_authenticator' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-auth/BlankAuthenticator.php',
                     'src/Security/BlankAuthenticator.php'
@@ -129,20 +131,20 @@ class MakeAuthenticatorTest extends MakerTestCase
                     1,
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
-                $this->assertEquals(
+                self::assertEquals(
                     'App\\Security\\AppCustomAuthenticator',
                     $securityConfig['security']['firewalls']['second']['custom_authenticator'][1]
                 );
             }),
         ];
 
-        yield 'auth_login_form_user_entity_with_hasher' => [$this->createMakerTest()
+        yield 'auth_login_form_user_entity_with_hasher' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine', 'twig', 'symfony/form')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'userEmail');
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'userEmail');
 
                 $output = $runner->runMaker([
                     // authenticator type => login-form
@@ -158,20 +160,20 @@ class MakeAuthenticatorTest extends MakerTestCase
                     'no',
                 ]);
 
-                $this->runLoginTest($runner, 'userEmail');
+                self::runLoginTest($runner, 'userEmail');
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $this->assertFileExists($runner->getPath('src/Controller/SecurityController.php'));
-                $this->assertFileExists($runner->getPath('templates/security/login.html.twig'));
-                $this->assertFileExists($runner->getPath('src/Security/AppCustomAuthenticator.php'));
+                self::assertFileExists($runner->getPath('src/Controller/SecurityController.php'));
+                self::assertFileExists($runner->getPath('templates/security/login.html.twig'));
+                self::assertFileExists($runner->getPath('src/Security/AppCustomAuthenticator.php'));
             }),
         ];
 
-        yield 'auth_login_form_no_entity_custom_username_field' => [$this->createMakerTest()
+        yield 'auth_login_form_no_entity_custom_username_field' => [self::buildMakerTest()
             ->addExtraDependencies('twig', 'symfony/form')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'userEmail', false);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'userEmail', false);
 
                 $runner->runMaker([
                     // authenticator type => login-form
@@ -190,7 +192,7 @@ class MakeAuthenticatorTest extends MakerTestCase
                 ]);
 
                 $runner->runTests();
-                $this->runLoginTest(
+                self::runLoginTest(
                     $runner,
                     'userEmail',
                     false,
@@ -199,10 +201,10 @@ class MakeAuthenticatorTest extends MakerTestCase
             }),
         ];
 
-        yield 'auth_login_form_user_not_entity_with_hasher' => [$this->createMakerTest()
+        yield 'auth_login_form_user_not_entity_with_hasher' => [self::buildMakerTest()
             ->addExtraDependencies('twig', 'symfony/form')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'email', false);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'email', false);
 
                 $runner->runMaker([
                     // authenticator type => login-form
@@ -220,10 +222,10 @@ class MakeAuthenticatorTest extends MakerTestCase
             }),
         ];
 
-        yield 'auth_login_form_existing_controller' => [$this->createMakerTest()
+        yield 'auth_login_form_existing_controller' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine', 'twig', 'symfony/form')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'email');
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'email');
 
                 $runner->copy(
                     'make-auth/SecurityController-empty.php',
@@ -242,14 +244,14 @@ class MakeAuthenticatorTest extends MakerTestCase
                     'no',
                 ]);
 
-                $this->runLoginTest($runner, 'email');
+                self::runLoginTest($runner, 'email');
             }),
         ];
 
-        yield 'auth_login_form_user_entity_with_logout' => [$this->createMakerTest()
+        yield 'auth_login_form_user_entity_with_logout' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine', 'twig', 'symfony/form')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'userEmail');
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'userEmail');
 
                 $output = $runner->runMaker([
                     // authenticator type => login-form
@@ -264,26 +266,26 @@ class MakeAuthenticatorTest extends MakerTestCase
                     'no',
                 ]);
 
-                $this->runLoginTest($runner, 'userEmail', true, 'App\\Entity\\User', true);
+                self::runLoginTest($runner, 'userEmail', true, 'App\\Entity\\User', true);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $this->assertFileExists($runner->getPath('src/Controller/SecurityController.php'));
-                $this->assertFileExists($runner->getPath('templates/security/login.html.twig'));
-                $this->assertFileExists($runner->getPath('src/Security/AppCustomAuthenticator.php'));
+                self::assertFileExists($runner->getPath('src/Controller/SecurityController.php'));
+                self::assertFileExists($runner->getPath('templates/security/login.html.twig'));
+                self::assertFileExists($runner->getPath('src/Security/AppCustomAuthenticator.php'));
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
-                $this->assertEquals(
+                self::assertEquals(
                     'app_logout',
                     $securityConfig['security']['firewalls']['main']['logout']['path']
                 );
             }),
         ];
 
-        yield 'auth_login_form_remember_me_via_checkbox' => [$this->createMakerTest()
+        yield 'auth_login_form_remember_me_via_checkbox' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine', 'twig', 'symfony/form')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'userEmail');
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'userEmail');
 
                 $output = $runner->runMaker([
                     // authenticator type => login-form
@@ -300,22 +302,22 @@ class MakeAuthenticatorTest extends MakerTestCase
                     0,
                 ]);
 
-                $this->runLoginTest($runner, 'userEmail');
+                self::runLoginTest($runner, 'userEmail');
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $seucrityConfig = $runner->readYaml('config/packages/security.yaml');
                 $firewallMain = $seucrityConfig['security']['firewalls']['main'];
 
-                $this->assertEquals('%kernel.secret%', $firewallMain['remember_me']['secret']);
-                $this->assertEquals('604800', $firewallMain['remember_me']['lifetime']);
-                $this->assertArrayNotHasKey('always_remember_me', $firewallMain['remember_me']);
+                self::assertEquals('%kernel.secret%', $firewallMain['remember_me']['secret']);
+                self::assertEquals('604800', $firewallMain['remember_me']['lifetime']);
+                self::assertArrayNotHasKey('always_remember_me', $firewallMain['remember_me']);
             }),
         ];
 
-        yield 'auth_login_form_always_remember_me' => [$this->createMakerTest()
+        yield 'auth_login_form_always_remember_me' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine', 'twig', 'symfony/form')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'userEmail');
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'userEmail');
 
                 $output = $runner->runMaker([
                     // authenticator type => login-form
@@ -332,19 +334,19 @@ class MakeAuthenticatorTest extends MakerTestCase
                     1,
                 ]);
 
-                $this->runLoginTest($runner, 'userEmail');
+                self::runLoginTest($runner, 'userEmail');
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $seucrityConfig = $runner->readYaml('config/packages/security.yaml');
                 $firewallMain = $seucrityConfig['security']['firewalls']['main'];
 
-                $this->assertEquals('%kernel.secret%', $firewallMain['remember_me']['secret']);
-                $this->assertTrue($firewallMain['remember_me']['always_remember_me']);
+                self::assertEquals('%kernel.secret%', $firewallMain['remember_me']['secret']);
+                self::assertTrue($firewallMain['remember_me']['always_remember_me']);
             }),
         ];
     }
 
-    private function runLoginTest(MakerTestRunner $runner, string $userIdentifier, bool $isEntity = true, string $userClass = 'App\\Entity\\User', bool $testLogin = false): void
+    private static function runLoginTest(MakerTestRunner $runner, string $userIdentifier, bool $isEntity = true, string $userClass = 'App\\Entity\\User', bool $testLogin = false): void
     {
         $runner->renderTemplateFile(
             'make-auth/LoginFlowTest.php.twig',
@@ -374,7 +376,7 @@ class MakeAuthenticatorTest extends MakerTestCase
         $runner->runTests();
     }
 
-    private function makeUser(MakerTestRunner $runner, string $userIdentifier, bool $isEntity = true): void
+    private static function makeUser(MakerTestRunner $runner, string $userIdentifier, bool $isEntity = true): void
     {
         $runner->runConsole('make:user', [
             'User', // class name

--- a/tests/Maker/MakeCommandTest.php
+++ b/tests/Maker/MakeCommandTest.php
@@ -23,27 +23,27 @@ class MakeCommandTest extends MakerTestCase
         return MakeCommand::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_a_command_no_attributes' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_a_command_no_attributes' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // command name
                     'app:foo',
                 ]);
 
-                $this->runCommandTest($runner, 'it_makes_a_command.php');
+                self::runCommandTest($runner, 'it_makes_a_command.php');
             }),
         ];
 
-        yield 'it_makes_a_command_with_attributes' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_a_command_with_attributes' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // command name
                     'app:foo',
                 ]);
 
-                $this->runCommandTest($runner, 'it_makes_a_command.php');
+                self::runCommandTest($runner, 'it_makes_a_command.php');
 
                 $commandFileContents = file_get_contents($runner->getPath('src/Command/FooCommand.php'));
 
@@ -52,9 +52,9 @@ class MakeCommandTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_a_command_in_custom_namespace' => [$this->createMakerTest()
+        yield 'it_makes_a_command_in_custom_namespace' => [self::buildMakerTest()
             ->changeRootNamespace('Custom')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->writeFile(
                     'config/packages/dev/maker.yaml',
                     Yaml::dump(['maker' => ['root_namespace' => 'Custom']])
@@ -65,12 +65,12 @@ class MakeCommandTest extends MakerTestCase
                     'app:foo',
                 ]);
 
-                $this->runCommandTest($runner, 'it_makes_a_command_in_custom_namespace.php');
+                self::runCommandTest($runner, 'it_makes_a_command_in_custom_namespace.php');
             }),
         ];
     }
 
-    private function runCommandTest(MakerTestRunner $runner, string $filename): void
+    private static function runCommandTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-command/tests/'.$filename,

--- a/tests/Maker/MakeControllerTest.php
+++ b/tests/Maker/MakeControllerTest.php
@@ -27,17 +27,17 @@ class MakeControllerTest extends MakerTestCase
         return MakeController::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_a_controller' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_a_controller' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     // controller class name
                     'FooBar',
                 ]);
 
-                $this->assertContainsCount('created: ', $output, 1);
-                $this->runControllerTest($runner, 'it_generates_a_controller.php');
+                self::assertSubstrCount('created: ', $output, 1);
+                self::runControllerTest($runner, 'it_generates_a_controller.php');
 
                 // Ensure the generated controller matches what we expect
                 self::assertSame(
@@ -47,39 +47,39 @@ class MakeControllerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_a_controller-with-tests' => [$this->createMakerTest()
+        yield 'it_generates_a_controller-with-tests' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/test-pack')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'FooBar', // controller class name
                     'y', // create tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/FooBarController.php', $output);
-                $this->assertStringContainsString('tests/Controller/FooBarControllerTest.php', $output);
+                self::assertStringContainsString('src/Controller/FooBarController.php', $output);
+                self::assertStringContainsString('tests/Controller/FooBarControllerTest.php', $output);
 
-                $this->assertFileExists($runner->getPath('src/Controller/FooBarController.php'));
-                $this->assertFileExists($runner->getPath('tests/Controller/FooBarControllerTest.php'));
+                self::assertFileExists($runner->getPath('src/Controller/FooBarController.php'));
+                self::assertFileExists($runner->getPath('tests/Controller/FooBarControllerTest.php'));
 
-                $this->runControllerTest($runner, 'it_generates_a_controller.php');
+                self::runControllerTest($runner, 'it_generates_a_controller.php');
             }),
         ];
 
-        yield 'it_generates_a_controller__no_input' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_a_controller__no_input' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([], 'FooBar');
 
-                $this->assertContainsCount('created: ', $output, 1);
+                self::assertSubstrCount('created: ', $output, 1);
 
-                $this->assertFileExists($runner->getPath('src/Controller/FooBarController.php'));
+                self::assertFileExists($runner->getPath('src/Controller/FooBarController.php'));
 
-                $this->runControllerTest($runner, 'it_generates_a_controller.php');
+                self::runControllerTest($runner, 'it_generates_a_controller.php');
             }),
         ];
 
-        yield 'it_generates_a_controller_with_twig' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_twig' => [self::buildMakerTest()
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     // controller class name
                     'FooTwig',
@@ -88,7 +88,7 @@ class MakeControllerTest extends MakerTestCase
                 $controllerPath = $runner->getPath('templates/foo_twig/index.html.twig');
                 self::assertFileExists($controllerPath);
 
-                $this->runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
+                self::runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
 
                 // Ensure the generated controller matches what we expect
                 self::assertSame(
@@ -98,21 +98,21 @@ class MakeControllerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_a_controller_with_twig__no_input' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_twig__no_input' => [self::buildMakerTest()
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([], 'FooTwig');
 
-                $this->assertFileExists($runner->getPath('src/Controller/FooTwigController.php'));
-                $this->assertFileExists($runner->getPath('templates/foo_twig/index.html.twig'));
+                self::assertFileExists($runner->getPath('src/Controller/FooTwigController.php'));
+                self::assertFileExists($runner->getPath('templates/foo_twig/index.html.twig'));
 
-                $this->runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
+                self::runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
             }),
         ];
 
-        yield 'it_generates_a_controller_with_twig_no_base_template' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_twig_no_base_template' => [self::buildMakerTest()
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->deleteFile('templates/base.html.twig');
 
                 $runner->runMaker([
@@ -123,13 +123,13 @@ class MakeControllerTest extends MakerTestCase
                 $controllerPath = $runner->getPath('templates/foo_twig/index.html.twig');
                 self::assertFileExists($controllerPath);
 
-                $this->runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
+                self::runControllerTest($runner, 'it_generates_a_controller_with_twig.php');
             }),
         ];
 
-        yield 'it_generates_a_controller_with_without_template' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_without_template' => [self::buildMakerTest()
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->deleteFile('templates/base.html.twig');
 
                 $output = $runner->runMaker([
@@ -138,40 +138,40 @@ class MakeControllerTest extends MakerTestCase
                 ], '--no-template');
 
                 // make sure the template was not configured
-                $this->assertContainsCount('created: ', $output, 1);
-                $this->assertStringContainsString('src/Controller/FooNoTemplateController.php', $output);
-                $this->assertStringNotContainsString('templates/foo_no_template/index.html.twig', $output);
+                self::assertSubstrCount('created: ', $output, 1);
+                self::assertStringContainsString('src/Controller/FooNoTemplateController.php', $output);
+                self::assertStringNotContainsString('templates/foo_no_template/index.html.twig', $output);
             }),
         ];
 
-        yield 'it_generates_a_controller_in_sub_namespace' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_a_controller_in_sub_namespace' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     // controller class name
                     'Admin\\FooBar',
                 ]);
 
-                $this->assertFileExists($runner->getPath('src/Controller/Admin/FooBarController.php'));
-                $this->assertStringContainsString('src/Controller/Admin/FooBarController.php', $output);
+                self::assertFileExists($runner->getPath('src/Controller/Admin/FooBarController.php'));
+                self::assertStringContainsString('src/Controller/Admin/FooBarController.php', $output);
             }),
         ];
 
-        yield 'it_generates_a_controller_in_sub_namespace__no_input' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_in_sub_namespace__no_input' => [self::buildMakerTest()
             ->skipTest(
                 message: 'Test Skipped - MAKER_TEST_WINDOWS is true.',
                 skipped: getenv('MAKER_TEST_WINDOWS')
             )
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([], 'Admin\\\\FooBar');
 
-                $this->assertFileExists($runner->getPath('src/Controller/Admin/FooBarController.php'));
-                $this->assertStringContainsString('src/Controller/Admin/FooBarController.php', $output);
+                self::assertFileExists($runner->getPath('src/Controller/Admin/FooBarController.php'));
+                self::assertStringContainsString('src/Controller/Admin/FooBarController.php', $output);
             }),
         ];
 
-        yield 'it_generates_a_controller_in_sub_namespace_with_template' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_in_sub_namespace_with_template' => [self::buildMakerTest()
             ->addExtraDependencies('twig')
-           ->run(function (MakerTestRunner $runner) {
+           ->run(static function (MakerTestRunner $runner) {
                $output = $runner->runMaker([
                    // controller class name
                    'Admin\\FooBar',
@@ -180,13 +180,13 @@ class MakeControllerTest extends MakerTestCase
                $controllerPath = $runner->getPath('templates/admin/foo_bar/index.html.twig');
                self::assertFileExists($controllerPath);
 
-               $this->assertFileExists($runner->getPath('templates/admin/foo_bar/index.html.twig'));
+               self::assertFileExists($runner->getPath('templates/admin/foo_bar/index.html.twig'));
            }),
         ];
 
-        yield 'it_generates_a_controller_with_full_custom_namespace' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_full_custom_namespace' => [self::buildMakerTest()
              ->addExtraDependencies('twig')
-             ->run(function (MakerTestRunner $runner) {
+             ->run(static function (MakerTestRunner $runner) {
                  $output = $runner->runMaker([
                      // controller class name
                      '\App\Foo\Bar\CoolController',
@@ -195,30 +195,30 @@ class MakeControllerTest extends MakerTestCase
                  $controllerPath = $runner->getPath('templates/foo/bar/cool/index.html.twig');
                  self::assertFileExists($controllerPath);
 
-                 $this->assertStringContainsString('src/Foo/Bar/CoolController.php', $output);
-                 $this->assertStringContainsString('templates/foo/bar/cool/index.html.twig', $output);
+                 self::assertStringContainsString('src/Foo/Bar/CoolController.php', $output);
+                 self::assertStringContainsString('templates/foo/bar/cool/index.html.twig', $output);
              }),
         ];
 
-        yield 'it_generates_a_controller_with_full_custom_namespace__no_input' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_full_custom_namespace__no_input' => [self::buildMakerTest()
             ->skipTest(
                 message: 'Test Skipped - MAKER_TEST_WINDOWS is true.',
                 skipped: getenv('MAKER_TEST_WINDOWS')
             )
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([], '\\\\App\\\\Foo\\\\Bar\\\\CoolController');
 
                 self::assertFileExists($runner->getPath('templates/foo/bar/cool/index.html.twig'));
 
-                $this->assertStringContainsString('src/Foo/Bar/CoolController.php', $output);
-                $this->assertStringContainsString('templates/foo/bar/cool/index.html.twig', $output);
+                self::assertStringContainsString('src/Foo/Bar/CoolController.php', $output);
+                self::assertStringContainsString('templates/foo/bar/cool/index.html.twig', $output);
             }),
         ];
 
-        yield 'it_generates_a_controller_with_invoke' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_invoke' => [self::buildMakerTest()
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     // controller class name
                     'FooInvokable',
@@ -227,15 +227,15 @@ class MakeControllerTest extends MakerTestCase
                 $controllerPath = $runner->getPath('templates/foo_invokable.html.twig');
                 self::assertFileExists($controllerPath);
 
-                $this->assertStringContainsString('src/Controller/FooInvokableController.php', $output);
-                $this->assertStringContainsString('templates/foo_invokable.html.twig', $output);
-                $this->runControllerTest($runner, 'it_generates_an_invokable_controller.php');
+                self::assertStringContainsString('src/Controller/FooInvokableController.php', $output);
+                self::assertStringContainsString('templates/foo_invokable.html.twig', $output);
+                self::runControllerTest($runner, 'it_generates_an_invokable_controller.php');
             }),
         ];
 
-        yield 'it_generates_a_controller_with_invoke_in_sub_namespace' => [$this->createMakerTest()
+        yield 'it_generates_a_controller_with_invoke_in_sub_namespace' => [self::buildMakerTest()
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     // controller class name
                     'Admin\\FooInvokable',
@@ -244,13 +244,18 @@ class MakeControllerTest extends MakerTestCase
                 $controllerPath = $runner->getPath('templates/admin/foo_invokable.html.twig');
                 self::assertFileExists($controllerPath);
 
-                $this->assertStringContainsString('src/Controller/Admin/FooInvokableController.php', $output);
-                $this->assertStringContainsString('templates/admin/foo_invokable.html.twig', $output);
+                self::assertStringContainsString('src/Controller/Admin/FooInvokableController.php', $output);
+                self::assertStringContainsString('templates/admin/foo_invokable.html.twig', $output);
             }),
         ];
     }
 
-    private function runControllerTest(MakerTestRunner $runner, string $filename): void
+    private static function assertSubstrCount(string $needle, string $haystack, int $count): void
+    {
+        self::assertEquals(1, substr_count($haystack, $needle), \sprintf('Found more than %d occurrences of "%s" in "%s"', $count, $needle, $haystack));
+    }
+
+    private static function runControllerTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-controller/tests/'.$filename,

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -23,10 +23,10 @@ class MakeCrudTest extends MakerTestCase
         return MakeCrud::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_basic_crud' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_basic_crud' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-crud/SweetFood.php',
                     'src/Entity/SweetFood.php'
@@ -38,15 +38,15 @@ class MakeCrudTest extends MakerTestCase
                     'n',         // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/SweetFoodController.php', $output);
-                $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_basic_crud.php');
+                self::runCrudTest($runner, 'it_generates_basic_crud.php');
             }),
         ];
 
-        yield 'it_generates_crud_with_custom_controller' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_crud_with_custom_controller' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-crud/SweetFood.php',
                     'src/Entity/SweetFood.php'
@@ -58,16 +58,16 @@ class MakeCrudTest extends MakerTestCase
                     'y',                        // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/SweetFoodAdminController.php', $output);
-                $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('src/Controller/SweetFoodAdminController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_crud_with_custom_controller.php');
+                self::runCrudTest($runner, 'it_generates_crud_with_custom_controller.php');
             }),
         ];
 
-        yield 'it_generates_crud_with_tests' => [$this->createMakerTest()
+        yield 'it_generates_crud_with_tests' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/test-pack')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-crud/SweetFood.php',
                     'src/Entity/SweetFood.php'
@@ -79,17 +79,17 @@ class MakeCrudTest extends MakerTestCase
                     'y',         // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/SweetFoodController.php', $output);
-                $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
-                $this->assertStringContainsString('tests/Controller/SweetFoodControllerTest.php', $output);
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('tests/Controller/SweetFoodControllerTest.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_basic_crud.php');
+                self::runCrudTest($runner, 'it_generates_basic_crud.php');
             }),
         ];
 
-        yield 'it_generates_correct_class_methods' => [$this->createMakerTest()
+        yield 'it_generates_correct_class_methods' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/test-pack')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-crud/Foo.php',
                     'src/Entity/Foo.php'
@@ -101,17 +101,17 @@ class MakeCrudTest extends MakerTestCase
                     'y',   // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/FooController.php', $output);
-                $this->assertStringContainsString('src/Form/FooType.php', $output);
-                $this->assertStringContainsString('tests/Controller/FooControllerTest.php', $output);
+                self::assertStringContainsString('src/Controller/FooController.php', $output);
+                self::assertStringContainsString('src/Form/FooType.php', $output);
+                self::assertStringContainsString('tests/Controller/FooControllerTest.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_correct_class_methods.php');
+                self::runCrudTest($runner, 'it_generates_correct_class_methods.php');
             }),
         ];
 
-        yield 'it_generates_crud_custom_repository_with_test' => [$this->createMakerTest()
+        yield 'it_generates_crud_custom_repository_with_test' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/test-pack')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-crud/SweetFoodCustomRepository.php',
                     'src/Entity/SweetFood.php'
@@ -128,17 +128,17 @@ class MakeCrudTest extends MakerTestCase
                     'y',         // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/SweetFoodController.php', $output);
-                $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
-                $this->assertStringContainsString('tests/Controller/SweetFoodControllerTest.php', $output);
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('tests/Controller/SweetFoodControllerTest.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_basic_crud.php');
+                self::runCrudTest($runner, 'it_generates_basic_crud.php');
             }),
         ];
 
-        yield 'it_generates_crud_with_custom_root_namespace' => [$this->createMakerTest()
+        yield 'it_generates_crud_with_custom_root_namespace' => [self::buildMakerTest()
             ->changeRootNamespace('Custom')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->writeFile(
                     'config/packages/dev/maker.yaml',
                     Yaml::dump(['maker' => ['root_namespace' => 'Custom']])
@@ -166,15 +166,15 @@ class MakeCrudTest extends MakerTestCase
                     'n',         // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/SweetFoodController.php', $output);
-                $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_crud_with_custom_root_namespace.php');
+                self::runCrudTest($runner, 'it_generates_crud_with_custom_root_namespace.php');
             }),
         ];
 
-        yield 'it_generates_crud_using_custom_repository' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_crud_using_custom_repository' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-crud/SweetFoodCustomRepository.php',
                     'src/Entity/SweetFood.php'
@@ -190,10 +190,10 @@ class MakeCrudTest extends MakerTestCase
                     'n',         // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/SweetFoodController.php', $output);
-                $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_basic_crud.php');
+                self::runCrudTest($runner, 'it_generates_basic_crud.php');
                 self::assertFileEquals(
                     \sprintf('%s/fixtures/make-crud/expected/WithCustomRepository.php', \dirname(__DIR__)),
                     $runner->getPath('src/Controller/SweetFoodController.php')
@@ -201,8 +201,8 @@ class MakeCrudTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_crud_with_no_base_template' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_crud_with_no_base_template' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-crud/SweetFood.php',
                     'src/Entity/SweetFood.php'
@@ -216,15 +216,15 @@ class MakeCrudTest extends MakerTestCase
                     'n',         // Generate Tests
                 ]);
 
-                $this->assertStringContainsString('src/Controller/SweetFoodController.php', $output);
-                $this->assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
 
-                $this->runCrudTest($runner, 'it_generates_basic_crud.php');
+                self::runCrudTest($runner, 'it_generates_basic_crud.php');
             }),
         ];
     }
 
-    private function runCrudTest(MakerTestRunner $runner, string $filename): void
+    private static function runCrudTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-crud/tests/'.$filename,

--- a/tests/Maker/MakeDockerDatabaseTest.php
+++ b/tests/Maker/MakeDockerDatabaseTest.php
@@ -26,18 +26,18 @@ final class MakeDockerDatabaseTest extends MakerTestCase
         return MakeDockerDatabase::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_uses_3_7_compose_file_version_generates_mysql_database' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_uses_3_7_compose_file_version_generates_mysql_database' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     '0', // Select MySQL as the database
                     '', // use the default "latest" service version
                 ]);
 
-                $this->assertFileExists($runner->getPath('compose.yaml'));
+                self::assertFileExists($runner->getPath('compose.yaml'));
 
-                $manipulator = $this->getComposeManipulator($runner);
+                $manipulator = self::getComposeManipulator($runner);
                 $data = $manipulator->getComposeData();
 
                 self::assertSame('3.7', $data['version']);
@@ -53,16 +53,16 @@ final class MakeDockerDatabaseTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_creates_mariadb' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_creates_mariadb' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     '1', // Select MariaDB as the database
                     '', // use the default "latest" service version
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $manipulator = $this->getComposeManipulator($runner);
+                $manipulator = self::getComposeManipulator($runner);
 
                 self::assertTrue($manipulator->serviceExists('database'));
 
@@ -76,16 +76,16 @@ final class MakeDockerDatabaseTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_creates_postgresql' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_creates_postgresql' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     '2', // Select Postgres as the database
                     '', // use the default "alpine" service version
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $manipulator = $this->getComposeManipulator($runner);
+                $manipulator = self::getComposeManipulator($runner);
 
                 self::assertTrue($manipulator->serviceExists('database'));
 
@@ -101,7 +101,7 @@ final class MakeDockerDatabaseTest extends MakerTestCase
         ];
     }
 
-    private function getComposeManipulator(MakerTestRunner $runner): ComposeFileManipulator
+    private static function getComposeManipulator(MakerTestRunner $runner): ComposeFileManipulator
     {
         $composeFile = $runner->getPath('compose.yaml');
 

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -25,9 +25,9 @@ class MakeEntityTest extends MakerTestCase
         return MakeEntity::class;
     }
 
-    private function createMakeEntityTest(bool $withDatabase = true): MakerTestDetails
+    private static function createMakeEntityTest(bool $withDatabase = true): MakerTestDetails
     {
-        return $this->createMakerTest()
+        return self::buildMakerTest()
             ->preRun(static function (MakerTestRunner $runner) use ($withDatabase) {
                 if ($withDatabase) {
                     $runner->configureDatabase();
@@ -35,16 +35,16 @@ class MakeEntityTest extends MakerTestCase
             });
     }
 
-    private function createMakeEntityTestForMercure(): MakerTestDetails
+    private static function createMakeEntityTestForMercure(): MakerTestDetails
     {
         if (getenv('MAKER_SKIP_MERCURE_TEST')) {
             // This test is skipped, don't worry about persistence
-            return $this->createMakerTest()
+            return self::buildMakerTest()
                 ->skipTest('MAKER_SKIP_MERCURE_TEST set to true')
             ;
         }
 
-        return $this->createMakeEntityTest()
+        return self::createMakeEntityTest()
             ->preRun(static function (MakerTestRunner $runner) {
                 // installed manually later so that the compatibility check can run first
                 $runner->runProcess('composer require symfony/ux-turbo');
@@ -53,10 +53,10 @@ class MakeEntityTest extends MakerTestCase
         ;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_creates_a_new_class_basic' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_creates_a_new_class_basic' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // entity class name
                     'User',
@@ -64,11 +64,11 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_only_shows_supported_types' => [$this->createMakeEntityTest()
+        yield 'it_only_shows_supported_types' => [self::createMakeEntityTest()
             ->run(function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     // entity class name
@@ -102,8 +102,8 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_does_not_validate_entity_name_with_accent' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_does_not_validate_entity_name_with_accent' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // entity class with accent
                     'Usé',
@@ -115,13 +115,13 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_creates_a_new_class_and_api_resource' => [$this->createMakeEntityTest()
+        yield 'it_creates_a_new_class_and_api_resource' => [self::createMakeEntityTest()
             ->addExtraDependencies('api')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // entity class name
                     'User',
@@ -131,19 +131,19 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->assertFileExists($runner->getPath('src/Entity/User.php'));
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
 
                 $content = file_get_contents($runner->getPath('src/Entity/User.php'));
-                $this->assertStringContainsString('use ApiPlatform\Metadata\ApiResource;', $content);
-                $this->assertStringContainsString('#[ApiResource]', $content);
+                self::assertStringContainsString('use ApiPlatform\Metadata\ApiResource;', $content);
+                self::assertStringContainsString('#[ApiResource]', $content);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_creates_a_new_class_with_uuid' => [$this->createMakeEntityTest()
+        yield 'it_creates_a_new_class_with_uuid' => [self::createMakeEntityTest()
             ->addExtraDependencies('symfony/uid')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // entity class name
                     'User',
@@ -151,19 +151,19 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ], '--with-uuid');
 
-                $this->assertFileExists($runner->getPath('src/Entity/User.php'));
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
 
                 $content = file_get_contents($runner->getPath('src/Entity/User.php'));
-                $this->assertStringContainsString('use Symfony\Component\Uid\Uuid;', $content);
-                $this->assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.uuid_generator\')]', $content);
+                self::assertStringContainsString('use Symfony\Component\Uid\Uuid;', $content);
+                self::assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.uuid_generator\')]', $content);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_creates_a_new_class_with_ulid' => [$this->createMakeEntityTest()
+        yield 'it_creates_a_new_class_with_ulid' => [self::createMakeEntityTest()
             ->addExtraDependencies('symfony/uid')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // entity class name
                     'User',
@@ -171,18 +171,18 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ], '--with-ulid');
 
-                $this->assertFileExists($runner->getPath('src/Entity/User.php'));
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
 
                 $content = file_get_contents($runner->getPath('src/Entity/User.php'));
-                $this->assertStringContainsString('use Symfony\Component\Uid\Ulid;', $content);
-                $this->assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.ulid_generator\')]', $content);
+                self::assertStringContainsString('use Symfony\Component\Uid\Ulid;', $content);
+                self::assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.ulid_generator\')]', $content);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_creates_a_new_class_with_fields' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_creates_a_new_class_with_fields' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // entity class name
                     'User',
@@ -201,13 +201,13 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_updates_existing_entity' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
+        yield 'it_updates_existing_entity' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -222,7 +222,7 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runEntityTest($runner, [
+                self::runEntityTest($runner, [
                     // existing field
                     'firstName' => 'Mr. Chocolate',
                     // new field
@@ -231,9 +231,9 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_updates_entity_many_to_one_no_inverse' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
+        yield 'it_updates_entity_many_to_one_no_inverse' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -254,13 +254,13 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runCustomTest($runner, 'it_updates_entity_many_to_one_no_inverse.php');
+                self::runCustomTest($runner, 'it_updates_entity_many_to_one_no_inverse.php');
             }),
         ];
 
-        yield 'it_adds_many_to_one_self_referencing' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
+        yield 'it_adds_many_to_one_self_referencing' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -285,13 +285,13 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runCustomTest($runner, 'it_adds_many_to_one_self_referencing.php');
+                self::runCustomTest($runner, 'it_adds_many_to_one_self_referencing.php');
             }),
         ];
 
-        yield 'it_adds_one_to_many_simple' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'UserAvatarPhoto-basic.php');
+        yield 'it_adds_one_to_many_simple' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'UserAvatarPhoto-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -314,13 +314,13 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runCustomTest($runner, 'it_adds_one_to_many_simple.php');
+                self::runCustomTest($runner, 'it_adds_one_to_many_simple.php');
             }),
         ];
 
-        yield 'it_adds_many_to_many_simple' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
+        yield 'it_adds_many_to_many_simple' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -341,14 +341,14 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runCustomTest($runner, 'it_adds_many_to_many_simple.php');
+                self::runCustomTest($runner, 'it_adds_many_to_many_simple.php');
             }),
         ];
 
-        yield 'it_adds_many_to_many_with_custom_root_namespace' => [$this->createMakeEntityTest()
+        yield 'it_adds_many_to_many_with_custom_root_namespace' => [self::createMakeEntityTest()
             ->changeRootNamespace('Custom')
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-custom-namespace.php');
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-custom-namespace.php');
 
                 $runner->writeFile(
                     'config/packages/dev/maker.yaml',
@@ -374,14 +374,14 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runCustomTest($runner, 'it_adds_many_to_many_with_custom_root_namespace.php');
+                self::runCustomTest($runner, 'it_adds_many_to_many_with_custom_root_namespace.php');
             }),
         ];
 
-        yield 'it_adds_many_to_many_between_same_entity_name_different_namespace' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
-                $this->copyEntity($runner, 'Friend/User-sub-namespace.php');
+        yield 'it_adds_many_to_many_between_same_entity_name_different_namespace' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+                self::copyEntity($runner, 'Friend/User-sub-namespace.php');
 
                 $output = $runner->runMaker([
                     // entity class name
@@ -402,24 +402,24 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->assertStringContainsString('src/Entity/User.php', $output);
-                $this->assertStringContainsString('src/Entity/Friend/User.php', $output);
-                $this->assertStringContainsString('ManyToOne    Each User relates to (has) one Friend\User.', $output);
-                $this->assertStringContainsString('Each Friend\User can relate to (can have) many User objects.', $output);
-                $this->assertStringContainsString('OneToMany    Each User can relate to (can have) many Friend\User objects.', $output);
-                $this->assertStringContainsString('Each Friend\User relates to (has) one User.', $output);
-                $this->assertStringContainsString('ManyToMany   Each User can relate to (can have) many Friend\User objects.', $output);
-                $this->assertStringContainsString('Each Friend\User can also relate to (can also have) many User objects.', $output);
-                $this->assertStringContainsString('OneToOne     Each User relates to (has) exactly one Friend\User.', $output);
-                $this->assertStringContainsString('Each Friend\User also relates to (has) exactly one User.', $output);
+                self::assertStringContainsString('src/Entity/User.php', $output);
+                self::assertStringContainsString('src/Entity/Friend/User.php', $output);
+                self::assertStringContainsString('ManyToOne    Each User relates to (has) one Friend\User.', $output);
+                self::assertStringContainsString('Each Friend\User can relate to (can have) many User objects.', $output);
+                self::assertStringContainsString('OneToMany    Each User can relate to (can have) many Friend\User objects.', $output);
+                self::assertStringContainsString('Each Friend\User relates to (has) one User.', $output);
+                self::assertStringContainsString('ManyToMany   Each User can relate to (can have) many Friend\User objects.', $output);
+                self::assertStringContainsString('Each Friend\User can also relate to (can also have) many User objects.', $output);
+                self::assertStringContainsString('OneToOne     Each User relates to (has) exactly one Friend\User.', $output);
+                self::assertStringContainsString('Each Friend\User also relates to (has) exactly one User.', $output);
 
-                // $this->runCustomTest($runner, 'it_adds_many_to_many_between_same_entity_name_different_namespace.php');
+                // self::runCustomTest($runner, 'it_adds_many_to_many_between_same_entity_name_different_namespace.php');
             }),
         ];
 
-        yield 'it_adds_one_to_one_simple' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
+        yield 'it_adds_one_to_one_simple' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -442,14 +442,14 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runCustomTest($runner, 'it_adds_one_to_one_simple.php');
+                self::runCustomTest($runner, 'it_adds_one_to_one_simple.php');
             }),
         ];
 
-        yield 'it_adds_many_to_one_to_vendor_target' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
-                $this->setupGroupEntityInVendor($runner);
+        yield 'it_adds_many_to_one_to_vendor_target' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+                self::setupGroupEntityInVendor($runner);
 
                 $output = $runner->runMaker([
                     // entity class name
@@ -470,22 +470,22 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->assertStringContainsString('src/Entity/User.php', $output);
-                $this->assertStringNotContainsString('updated: vendor/', $output);
+                self::assertStringContainsString('src/Entity/User.php', $output);
+                self::assertStringNotContainsString('updated: vendor/', $output);
 
                 // sanity checks on the generated code
                 $finder = new Finder();
                 $finder->in($runner->getPath('src/Entity'))->files()->name('*.php');
-                $this->assertCount(1, $finder);
+                self::assertCount(1, $finder);
 
-                $this->assertStringNotContainsString('inversedBy', file_get_contents($runner->getPath('src/Entity/User.php')));
+                self::assertStringNotContainsString('inversedBy', file_get_contents($runner->getPath('src/Entity/User.php')));
             }),
         ];
 
-        yield 'it_adds_many_to_many_to_vendor_target' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
-                $this->setupGroupEntityInVendor($runner);
+        yield 'it_adds_many_to_many_to_vendor_target' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+                self::setupGroupEntityInVendor($runner);
 
                 $output = $runner->runMaker([
                     // entity class name
@@ -504,16 +504,16 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->assertStringNotContainsString('updated: vendor/', $output);
+                self::assertStringNotContainsString('updated: vendor/', $output);
 
-                $this->assertStringNotContainsString('inversedBy', file_get_contents($runner->getPath('src/Entity/User.php')));
+                self::assertStringNotContainsString('inversedBy', file_get_contents($runner->getPath('src/Entity/User.php')));
             }),
         ];
 
-        yield 'it_adds_one_to_one_to_vendor_target' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
-                $this->setupGroupEntityInVendor($runner);
+        yield 'it_adds_one_to_one_to_vendor_target' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+                self::setupGroupEntityInVendor($runner);
 
                 $output = $runner->runMaker([
                     // entity class name
@@ -534,67 +534,67 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->assertStringNotContainsString('updated: vendor/', $output);
+                self::assertStringNotContainsString('updated: vendor/', $output);
 
-                $this->assertStringNotContainsString('inversedBy', file_get_contents($runner->getPath('src/Entity/User.php')));
+                self::assertStringNotContainsString('inversedBy', file_get_contents($runner->getPath('src/Entity/User.php')));
             }),
         ];
 
-        yield 'it_regenerates_entities' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntityDirectory($runner, 'regenerate');
+        yield 'it_regenerates_entities' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntityDirectory($runner, 'regenerate');
 
                 $runner->runMaker([
                     // namespace: use default App\Entity
                     '',
                 ], '--regenerate');
 
-                $this->runCustomTest($runner, 'it_regenerates_entities.php');
+                self::runCustomTest($runner, 'it_regenerates_entities.php');
             }),
         ];
 
-        yield 'it_regenerates_embedded_entities' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntityDirectory($runner, 'regenerate-embedded');
+        yield 'it_regenerates_embedded_entities' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntityDirectory($runner, 'regenerate-embedded');
 
                 $runner->runMaker([
                     // namespace: use default App\Entity
                     '',
                 ], '--regenerate');
 
-                $this->runCustomTest($runner, 'it_regenerates_embedded_entities.php');
+                self::runCustomTest($runner, 'it_regenerates_embedded_entities.php');
             }),
         ];
 
-        yield 'it_regenerates_embeddable_entity' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntityDirectory($runner, 'regenerate-embeddable');
+        yield 'it_regenerates_embeddable_entity' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntityDirectory($runner, 'regenerate-embeddable');
 
                 $runner->runMaker([
                     // namespace: use default App\Entity
                     '',
                 ], '--regenerate');
 
-                $this->runCustomTest($runner, 'it_regenerates_embeddable_entity.php');
+                self::runCustomTest($runner, 'it_regenerates_embeddable_entity.php');
             }),
         ];
 
-        yield 'it_regenerates_with_overwrite' => [$this->createMakeEntityTest(false)
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-invalid-method.php');
+        yield 'it_regenerates_with_overwrite' => [self::createMakeEntityTest(false)
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-invalid-method.php');
 
                 $runner->runMaker([
                     // namespace: use default App\Entity
                     '',
                 ], '--regenerate --overwrite');
 
-                $this->runCustomTest($runner, 'it_regenerates_with_overwrite.php', false);
+                self::runCustomTest($runner, 'it_regenerates_with_overwrite.php', false);
             }),
         ];
 
-        yield 'it_can_overwrite_while_adding_fields' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-invalid-method-no-property.php');
+        yield 'it_can_overwrite_while_adding_fields' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-invalid-method-no-property.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -610,14 +610,14 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ], '--overwrite');
 
-                $this->runCustomTest($runner, 'it_regenerates_with_overwrite.php');
+                self::runCustomTest($runner, 'it_regenerates_with_overwrite.php');
             }),
         ];
 
         // see #192
-        yield 'it_creates_class_that_matches_existing_namespace' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'User-basic.php');
+        yield 'it_creates_class_that_matches_existing_namespace' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -626,13 +626,13 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runCustomTest($runner, 'it_creates_class_that_matches_existing_namespace.php');
+                self::runCustomTest($runner, 'it_creates_class_that_matches_existing_namespace.php');
             }),
         ];
 
-        yield 'it_makes_new_entity_with_mercure_broadcast' => [$this->createMakeEntityTestForMercure()
+        yield 'it_makes_new_entity_with_mercure_broadcast' => [self::createMakeEntityTestForMercure()
             // special setup done in createMakeEntityTestForMercure()
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->replaceInFile(
                     '.env',
                     'https://example.com/.well-known/mercure',
@@ -648,20 +648,20 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->assertFileExists($runner->getPath('src/Entity/User.php'));
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
 
                 $content = file_get_contents($runner->getPath('src/Entity/User.php'));
-                $this->assertStringContainsString('use Symfony\UX\Turbo\Attribute\Broadcast;', $content);
-                $this->assertStringContainsString('#[Broadcast]', $content);
+                self::assertStringContainsString('use Symfony\UX\Turbo\Attribute\Broadcast;', $content);
+                self::assertStringContainsString('#[Broadcast]', $content);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_makes_new_entity_no_to_all_extras' => [$this->createMakeEntityTestForMercure()
+        yield 'it_makes_new_entity_no_to_all_extras' => [self::createMakeEntityTestForMercure()
             ->addExtraDependencies('api')
             // special setup done in createMakeEntityTestForMercure()
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // entity class name
                     'User',
@@ -673,30 +673,30 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->assertFileExists($runner->getPath('src/Entity/User.php'));
-                $this->runEntityTest($runner);
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_generates_entity_with_turbo_without_mercure' => [$this->createMakeEntityTest()
+        yield 'it_generates_entity_with_turbo_without_mercure' => [self::createMakeEntityTest()
             ->preRun(static function (MakerTestRunner $runner) {
                 $runner->runProcess('composer require symfony/ux-turbo');
             })
             ->addExtraDependencies('twig')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     'User', // entity class
                     'n', // no broadcast
                     '',
                 ]);
 
-                $this->assertFileExists($runner->getPath('src/Entity/User.php'));
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
             }),
         ];
 
-        yield 'it_creates_a_new_class_with_enum_field' => [$this->createMakeEntityTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->copyEntity($runner, 'Enum/Role-basic.php');
+        yield 'it_creates_a_new_class_with_enum_field' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'Enum/Role-basic.php');
 
                 $runner->runMaker([
                     // entity class name
@@ -712,13 +712,13 @@ class MakeEntityTest extends MakerTestCase
                     '',
                 ]);
 
-                $this->runEntityTest($runner);
+                self::runEntityTest($runner);
             }),
         ];
 
-        yield 'it_creates_a_new_class_with_enum_field_multiple_and_nullable' => [$this->createMakeEntityTest()
-        ->run(function (MakerTestRunner $runner) {
-            $this->copyEntity($runner, 'Enum/Role-basic.php');
+        yield 'it_creates_a_new_class_with_enum_field_multiple_and_nullable' => [self::createMakeEntityTest()
+        ->run(static function (MakerTestRunner $runner) {
+            self::copyEntity($runner, 'Enum/Role-basic.php');
 
             $runner->runMaker([
                 // entity class name
@@ -735,13 +735,13 @@ class MakeEntityTest extends MakerTestCase
                 '',
             ]);
 
-            $this->runEntityTest($runner);
+            self::runEntityTest($runner);
         }),
         ];
     }
 
     /** @param array<string, mixed> $data */
-    private function runEntityTest(MakerTestRunner $runner, array $data = []): void
+    private static function runEntityTest(MakerTestRunner $runner, array $data = []): void
     {
         $runner->renderTemplateFile(
             'make-entity/GeneratedEntityTest.php.twig',
@@ -755,7 +755,7 @@ class MakeEntityTest extends MakerTestCase
         $runner->runTests();
     }
 
-    private function runCustomTest(MakerTestRunner $runner, string $filename, bool $withDatabase = true): void
+    private static function runCustomTest(MakerTestRunner $runner, string $filename, bool $withDatabase = true): void
     {
         $runner->copy(
             'make-entity/tests/'.$filename,
@@ -768,7 +768,7 @@ class MakeEntityTest extends MakerTestCase
         $runner->runTests();
     }
 
-    private function setupGroupEntityInVendor(MakerTestRunner $runner): void
+    private static function setupGroupEntityInVendor(MakerTestRunner $runner): void
     {
         $runner->copy(
             'make-entity/Group-vendor.php',
@@ -781,7 +781,7 @@ class MakeEntityTest extends MakerTestCase
         );
     }
 
-    private function copyEntity(MakerTestRunner $runner, string $filename): void
+    private static function copyEntity(MakerTestRunner $runner, string $filename): void
     {
         $entityClassName = substr(
             $filename,
@@ -795,7 +795,7 @@ class MakeEntityTest extends MakerTestCase
         );
     }
 
-    private function copyEntityDirectory(MakerTestRunner $runner, string $directory): void
+    private static function copyEntityDirectory(MakerTestRunner $runner, string $directory): void
     {
         $runner->copy(
             \sprintf('make-entity/%s/attributes', $directory),

--- a/tests/Maker/MakeFixturesTest.php
+++ b/tests/Maker/MakeFixturesTest.php
@@ -22,15 +22,15 @@ class MakeFixturesTest extends MakerTestCase
         return MakeFixtures::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_fixtures' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_fixtures' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'FooFixtures',
                 ]);
 
-                $this->assertStringContainsString('src/DataFixtures/FooFixtures.php', $output);
+                self::assertStringContainsString('src/DataFixtures/FooFixtures.php', $output);
             }),
         ];
     }

--- a/tests/Maker/MakeFormTest.php
+++ b/tests/Maker/MakeFormTest.php
@@ -22,23 +22,23 @@ class MakeFormTest extends MakerTestCase
         return MakeForm::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_basic_form' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_basic_form' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     // form name
                     'FooBar',
                     '',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_basic_form.php');
+                self::runFormTest($runner, 'it_generates_basic_form.php');
             }),
         ];
 
-        yield 'it_generates_form_with_entity' => [$this->createMakerTest()
+        yield 'it_generates_form_with_entity' => [self::buildMakerTest()
             ->addExtraDependencies('orm')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/Property.php',
                     'src/Entity/Property.php'
@@ -54,12 +54,12 @@ class MakeFormTest extends MakerTestCase
                     'SourFood',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_entity.php');
+                self::runFormTest($runner, 'it_generates_form_with_entity.php');
             }),
         ];
 
-        yield 'it_generates_form_with_non_entity_dto' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_form_with_non_entity_dto' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/TaskData.php',
                     'src/Form/Data/TaskData.php'
@@ -71,13 +71,13 @@ class MakeFormTest extends MakerTestCase
                     '\\App\\Form\\Data\\TaskData',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_non_entity_dto.php');
+                self::runFormTest($runner, 'it_generates_form_with_non_entity_dto.php');
             }),
         ];
 
-        yield 'it_generates_form_with_single_table_inheritance_entity' => [$this->createMakerTest()
+        yield 'it_generates_form_with_single_table_inheritance_entity' => [self::buildMakerTest()
             ->addExtraDependencies('orm')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/inheritance/Food.php',
                     'src/Entity/Food.php'
@@ -93,13 +93,13 @@ class MakeFormTest extends MakerTestCase
                     'SourFood',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_single_table_inheritance_entity.php');
+                self::runFormTest($runner, 'it_generates_form_with_single_table_inheritance_entity.php');
             }),
         ];
 
-        yield 'it_generates_form_with_many_to_one_relation' => [$this->createMakerTest()
+        yield 'it_generates_form_with_many_to_one_relation' => [self::buildMakerTest()
             ->addExtraDependencies('orm')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/relation_one_to_many/Book.php',
                     'src/Entity/Book.php'
@@ -115,12 +115,12 @@ class MakeFormTest extends MakerTestCase
                     'Book',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_many_to_one_relation.php');
+                self::runFormTest($runner, 'it_generates_form_with_many_to_one_relation.php');
             }),
         ];
-        yield 'it_generates_form_with_one_to_many_relation' => [$this->createMakerTest()
+        yield 'it_generates_form_with_one_to_many_relation' => [self::buildMakerTest()
             ->addExtraDependencies('orm')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/relation_one_to_many/Book.php',
                     'src/Entity/Book.php'
@@ -136,12 +136,12 @@ class MakeFormTest extends MakerTestCase
                     'Author',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_one_to_many_relation.php');
+                self::runFormTest($runner, 'it_generates_form_with_one_to_many_relation.php');
             }),
         ];
-        yield 'it_generates_form_with_many_to_many_relation' => [$this->createMakerTest()
+        yield 'it_generates_form_with_many_to_many_relation' => [self::buildMakerTest()
             ->addExtraDependencies('orm')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/relation_many_to_many/Book.php',
                     'src/Entity/Book.php'
@@ -157,12 +157,12 @@ class MakeFormTest extends MakerTestCase
                     'Book',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_many_to_many_relation.php');
+                self::runFormTest($runner, 'it_generates_form_with_many_to_many_relation.php');
             }),
         ];
-        yield 'it_generates_form_with_one_to_one_relation' => [$this->createMakerTest()
+        yield 'it_generates_form_with_one_to_one_relation' => [self::buildMakerTest()
             ->addExtraDependencies('orm')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/relation_one_to_one/Librarian.php',
                     'src/Entity/Librarian.php'
@@ -178,12 +178,12 @@ class MakeFormTest extends MakerTestCase
                     'Library',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_one_to_one_relation.php');
+                self::runFormTest($runner, 'it_generates_form_with_one_to_one_relation.php');
             }),
         ];
-        yield 'it_generates_form_with_embeddable_entity' => [$this->createMakerTest()
+        yield 'it_generates_form_with_embeddable_entity' => [self::buildMakerTest()
             ->addExtraDependencies('orm')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-form/embeddable/Food.php',
                     'src/Entity/Food.php'
@@ -199,12 +199,12 @@ class MakeFormTest extends MakerTestCase
                     'Food',
                 ]);
 
-                $this->runFormTest($runner, 'it_generates_form_with_embeddable_entity.php');
+                self::runFormTest($runner, 'it_generates_form_with_embeddable_entity.php');
             }),
         ];
     }
 
-    private function runFormTest(MakerTestRunner $runner, string $filename): void
+    private static function runFormTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-form/tests/'.$filename,

--- a/tests/Maker/MakeFunctionalTestTest.php
+++ b/tests/Maker/MakeFunctionalTestTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\MakerBundle\Maker\MakeFunctionalTest;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestDetails;
@@ -19,6 +20,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 /**
  * @group legacy
  */
+#[Group('legacy')]
 class MakeFunctionalTestTest extends MakerTestCase
 {
     protected function getMakerClass(): string
@@ -26,9 +28,9 @@ class MakeFunctionalTestTest extends MakerTestCase
         return MakeFunctionalTest::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_test_with_panther' => [$this->getPantherTest()
+        yield 'it_generates_test_with_panther' => [self::getPantherTest()
             ->addExtraDependencies('panther')
             ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
@@ -50,9 +52,9 @@ class MakeFunctionalTestTest extends MakerTestCase
         ];
     }
 
-    protected function getPantherTest(): MakerTestDetails
+    protected static function getPantherTest(): MakerTestDetails
     {
-        return $this->createMakerTest()
+        return self::buildMakerTest()
             ->skipTest(
                 message: 'Panther test skipped - MAKER_SKIP_PANTHER_TEST set to TRUE.',
                 skipped: getenv('MAKER_SKIP_PANTHER_TEST')

--- a/tests/Maker/MakeListenerTest.php
+++ b/tests/Maker/MakeListenerTest.php
@@ -20,9 +20,9 @@ class MakeListenerTest extends MakerTestCase
     private const EXPECTED_SUBSCRIBER_PATH = __DIR__.'/../../tests/fixtures/make-listener/tests/EventSubscriber/';
     private const EXPECTED_LISTENER_PATH = __DIR__.'/../../tests/fixtures/make-listener/tests/EventListener/';
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_make_subscriber_without_conventional_name' => [$this->createMakerTest()
+        yield 'it_make_subscriber_without_conventional_name' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -41,7 +41,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_make_listener_without_conventional_name' => [$this->createMakerTest()
+        yield 'it_make_listener_without_conventional_name' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -60,7 +60,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_subscriber_for_known_event' => [$this->createMakerTest()
+        yield 'it_makes_subscriber_for_known_event' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -78,7 +78,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_subscriber_for_custom_event_class' => [$this->createMakerTest()
+        yield 'it_makes_subscriber_for_custom_event_class' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -96,7 +96,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_subscriber_for_unknown_event_class' => [$this->createMakerTest()
+        yield 'it_makes_subscriber_for_unknown_event_class' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -114,7 +114,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_listener_for_known_event' => [$this->createMakerTest()
+        yield 'it_makes_listener_for_known_event' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -132,7 +132,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_listener_for_custom_event_class' => [$this->createMakerTest()
+        yield 'it_makes_listener_for_custom_event_class' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -150,7 +150,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_listener_for_unknown_event_class' => [$this->createMakerTest()
+        yield 'it_makes_listener_for_unknown_event_class' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -168,7 +168,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_listener_for_known_event_by_id' => [$this->createMakerTest()
+        yield 'it_makes_listener_for_known_event_by_id' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -187,7 +187,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_listener_for_known_event_by_short_class_name' => [$this->createMakerTest()
+        yield 'it_makes_listener_for_known_event_by_short_class_name' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -206,7 +206,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_listener_for_known_event_by_id_with_2_letters_typo' => [$this->createMakerTest()
+        yield 'it_makes_listener_for_known_event_by_id_with_2_letters_typo' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -225,7 +225,7 @@ class MakeListenerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_listener_for_known_event_by_short_class_name_with_2_letters_typo' => [$this->createMakerTest()
+        yield 'it_makes_listener_for_known_event_by_short_class_name_with_2_letters_typo' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeMessageTest.php
+++ b/tests/Maker/MakeMessageTest.php
@@ -25,9 +25,9 @@ class MakeMessageTest extends MakerTestCase
         return MakeMessage::class;
     }
 
-    private function createMakeMessageTest(): MakerTestDetails
+    private static function createMakeMessageTest(): MakerTestDetails
     {
-        return $this->createMakerTest()
+        return self::buildMakerTest()
             ->preRun(static function (MakerTestRunner $runner) {
                 $runner->writeFile(
                     'config/services_test.yaml',
@@ -41,39 +41,39 @@ class MakeMessageTest extends MakerTestCase
             });
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_basic_message' => [$this->createMakeMessageTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_basic_message' => [self::createMakeMessageTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([
                     'SendWelcomeEmail',
                 ]);
 
-                $this->runMessageTest($runner, 'it_generates_basic_message.php');
+                self::runMessageTest($runner, 'it_generates_basic_message.php');
             }),
         ];
 
-        yield 'it_generates_message_with_transport' => [$this->createMakeMessageTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->configureTransports($runner);
+        yield 'it_generates_message_with_transport' => [self::createMakeMessageTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::configureTransports($runner);
 
                 $output = $runner->runMaker([
                     'SendWelcomeEmail',
                     1,
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $this->runMessageTest($runner, 'it_generates_message_with_transport.php');
+                self::runMessageTest($runner, 'it_generates_message_with_transport.php');
 
                 $messageContents = file_get_contents($runner->getPath('src/Message/SendWelcomeEmail.php'));
 
                 if (!str_contains($messageContents, AsMessage::class)) {
                     /* @legacy remove when AsMessage is always available */
                     $messengerConfig = $runner->readYaml('config/packages/messenger.yaml');
-                    $this->assertArrayHasKey('routing', $messengerConfig['framework']['messenger']);
-                    $this->assertArrayHasKey('App\Message\SendWelcomeEmail', $messengerConfig['framework']['messenger']['routing']);
-                    $this->assertSame(
+                    self::assertArrayHasKey('routing', $messengerConfig['framework']['messenger']);
+                    self::assertArrayHasKey('App\Message\SendWelcomeEmail', $messengerConfig['framework']['messenger']['routing']);
+                    self::assertSame(
                         'async',
                         $messengerConfig['framework']['messenger']['routing']['App\Message\SendWelcomeEmail']
                     );
@@ -81,34 +81,34 @@ class MakeMessageTest extends MakerTestCase
                     return;
                 }
 
-                $this->assertStringContainsString(AsMessage::class, $messageContents);
-                $this->assertStringContainsString("#[AsMessage('async')]", $messageContents);
+                self::assertStringContainsString(AsMessage::class, $messageContents);
+                self::assertStringContainsString("#[AsMessage('async')]", $messageContents);
             }),
         ];
 
-        yield 'it_generates_message_with_no_transport' => [$this->createMakeMessageTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->configureTransports($runner);
+        yield 'it_generates_message_with_no_transport' => [self::createMakeMessageTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::configureTransports($runner);
 
                 $output = $runner->runMaker([
                     'SendWelcomeEmail',
                     0,
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $this->runMessageTest($runner, 'it_generates_message_with_transport.php');
+                self::runMessageTest($runner, 'it_generates_message_with_transport.php');
 
                 $messengerConfig = $runner->readYaml('config/packages/messenger.yaml');
-                $this->assertArrayNotHasKey('routing', $messengerConfig['framework']['messenger']);
+                self::assertArrayNotHasKey('routing', $messengerConfig['framework']['messenger']);
 
                 $messageContents = file_get_contents($runner->getPath('src/Message/SendWelcomeEmail.php'));
-                $this->assertStringNotContainsString(AsMessage::class, $messageContents);
+                self::assertStringNotContainsString(AsMessage::class, $messageContents);
             }),
         ];
     }
 
-    private function runMessageTest(MakerTestRunner $runner, string $filename): void
+    private static function runMessageTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-message/tests/'.$filename,
@@ -118,7 +118,7 @@ class MakeMessageTest extends MakerTestCase
         $runner->runTests();
     }
 
-    private function configureTransports(MakerTestRunner $runner): void
+    private static function configureTransports(MakerTestRunner $runner): void
     {
         $runner->writeFile(
             'config/packages/messenger.yaml',

--- a/tests/Maker/MakeMessengerMiddlewareTest.php
+++ b/tests/Maker/MakeMessengerMiddlewareTest.php
@@ -22,17 +22,17 @@ class MakeMessengerMiddlewareTest extends MakerTestCase
         return MakeMessengerMiddleware::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_messenger_middleware' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_messenger_middleware' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         // middleware name
                         'CustomMiddleware',
                     ]);
 
-                $this->assertFileExists($runner->getPath('src/Middleware/CustomMiddleware.php'));
+                self::assertFileExists($runner->getPath('src/Middleware/CustomMiddleware.php'));
             }),
         ];
     }

--- a/tests/Maker/MakeMigrationTest.php
+++ b/tests/Maker/MakeMigrationTest.php
@@ -25,9 +25,9 @@ class MakeMigrationTest extends MakerTestCase
         return MakeMigration::class;
     }
 
-    private function createMakeMigrationTest(): MakerTestDetails
+    private static function createMakeMigrationTest(): MakerTestDetails
     {
-        return $this->createMakerTest()
+        return self::buildMakerTest()
             // doctrine-migrations-bundle only requires doctrine-bundle, which
             // only requires doctrine/dbal. But we're testing with the ORM,
             // so let's install it
@@ -43,13 +43,13 @@ class MakeMigrationTest extends MakerTestCase
         ;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_migration_with_changes' => [$this->createMakeMigrationTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_migration_with_changes' => [self::createMakeMigrationTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([/* no input */]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 // support for Migrations 3 (/migrations) and earlier
                 $migrationsDirectoryPath = file_exists($runner->getPath('/migrations')) ? 'migrations' : 'src/Migrations';
@@ -57,52 +57,52 @@ class MakeMigrationTest extends MakerTestCase
                 $finder = new Finder();
                 $finder->in($runner->getPath($migrationsDirectoryPath))
                     ->name('*.php');
-                $this->assertCount(1, $finder);
+                self::assertCount(1, $finder);
 
                 // see that the exact filename is in the output
                 $iterator = $finder->getIterator();
                 $iterator->rewind();
-                $this->assertStringContainsString(\sprintf('%s/%s', $migrationsDirectoryPath, $iterator->current()->getFilename()), $output);
+                self::assertStringContainsString(\sprintf('%s/%s', $migrationsDirectoryPath, $iterator->current()->getFilename()), $output);
             }),
         ];
 
-        yield 'it_detects_symfony_cli_usage' => [$this->createMakeMigrationTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_detects_symfony_cli_usage' => [self::createMakeMigrationTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(
                     inputs: [],
                     envVars: [CliOutputHelper::ENV_VERSION => '0.0.0', CliOutputHelper::ENV_BIN_NAME => 'symfony']
                 );
 
-                $this->assertStringContainsString('symfony console doctrine:migrations:migrate', $output);
+                self::assertStringContainsString('symfony console doctrine:migrations:migrate', $output);
             }),
         ];
 
-        yield 'it_detects_symfony_cli_is_not_used' => [$this->createMakeMigrationTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_detects_symfony_cli_is_not_used' => [self::createMakeMigrationTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(
                     inputs: [],
                     envVars: []
                 );
 
-                $this->assertStringContainsString('php bin/console doctrine:migrations:migrate', $output);
+                self::assertStringContainsString('php bin/console doctrine:migrations:migrate', $output);
             }),
         ];
 
-        yield 'it_generates_migration_with_no_changes' => [$this->createMakeMigrationTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_migration_with_no_changes' => [self::createMakeMigrationTest()
+            ->run(static function (MakerTestRunner $runner) {
                 // sync so there are no changes
                 $runner->updateSchema();
                 $output = $runner->runMaker([/* no input */]);
 
-                $this->assertStringNotContainsString('Success', $output);
+                self::assertStringNotContainsString('Success', $output);
 
-                $this->assertStringContainsString('No database changes were detected', $output);
+                self::assertStringContainsString('No database changes were detected', $output);
             }),
         ];
 
-        yield 'it_asks_previous_migration_question' => [$this->createMakeMigrationTest()
+        yield 'it_asks_previous_migration_question' => [self::createMakeMigrationTest()
             ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 // generate a migration first
                 $runner->runConsole('make:migration', []);
 
@@ -111,15 +111,15 @@ class MakeMigrationTest extends MakerTestCase
                     'y',
                 ]);
 
-                $this->assertStringContainsString('[WARNING] You have 1 available migrations to execute', $output);
-                $this->assertStringContainsString('Are you sure you wish to continue?', $output);
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('[WARNING] You have 1 available migrations to execute', $output);
+                self::assertStringContainsString('Are you sure you wish to continue?', $output);
+                self::assertStringContainsString('Success', $output);
             }),
         ];
 
-        yield 'it_asks_previous_migration_question_and_decline' => [$this->createMakeMigrationTest()
+        yield 'it_asks_previous_migration_question_and_decline' => [self::createMakeMigrationTest()
             ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 // generate a migration first
                 $runner->runConsole('make:migration', []);
 
@@ -128,29 +128,29 @@ class MakeMigrationTest extends MakerTestCase
                     'n',
                 ]);
 
-                $this->assertStringNotContainsString('Success', $output);
+                self::assertStringNotContainsString('Success', $output);
             }),
         ];
 
-        yield 'it_generates_a_formatted_migration' => [$this->createMakeMigrationTest()
+        yield 'it_generates_a_formatted_migration' => [self::createMakeMigrationTest()
             ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runConsole('make:migration', [], '--formatted');
 
                 $output = $runner->runMaker([/* no input */]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
             }),
         ];
 
-        yield 'it_generates_a_nowdoc_migration' => [$this->createMakeMigrationTest()
+        yield 'it_generates_a_nowdoc_migration' => [self::createMakeMigrationTest()
             ->addRequiredPackageVersion('doctrine/doctrine-migrations-bundle', '>=3')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runConsole('make:migration', [], '--nowdoc');
 
                 $output = $runner->runMaker([/* no input */]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
             }),
         ];
     }

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -24,9 +24,9 @@ class MakeRegistrationFormTest extends MakerTestCase
         return MakeRegistrationForm::class;
     }
 
-    private function createRegistrationFormTest(): MakerTestDetails
+    private static function createRegistrationFormTest(): MakerTestDetails
     {
-        return $this->createMakerTest()
+        return self::buildMakerTest()
             ->preRun(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-registration-form/standard_setup',
@@ -36,11 +36,11 @@ class MakeRegistrationFormTest extends MakerTestCase
         ;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_registration_with_entity_and_form_login_with_no_login' => [$this->createRegistrationFormTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'it_generates_registration_with_entity_and_form_login_with_no_login' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $runner->runMaker([
                     // user class guessed,
@@ -55,19 +55,19 @@ class MakeRegistrationFormTest extends MakerTestCase
 
                 $fixturePath = \dirname(__DIR__, 1).'/fixtures/make-registration-form/expected';
 
-                $this->assertFileEquals($fixturePath.'/RegistrationControllerNoLogin.php', $runner->getPath('src/Controller/RegistrationController.php'));
+                self::assertFileEquals($fixturePath.'/RegistrationControllerNoLogin.php', $runner->getPath('src/Controller/RegistrationController.php'));
 
-                $this->runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
+                self::runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
             }),
         ];
 
-        yield 'it_generates_registration_with_entity_and_form_login_with_security_bundle_login' => [$this->createRegistrationFormTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_registration_with_entity_and_form_login_with_security_bundle_login' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
                 if (60200 > $runner->getSymfonyVersion()) {
-                    $this->markTestSkipped('Requires Symfony 6.2+');
+                    self::markTestSkipped('Requires Symfony 6.2+');
                 }
 
-                $this->makeUser($runner);
+                self::makeUser($runner);
 
                 $runner->modifyYamlFile('config/packages/security.yaml', static function (array $data) {
                     $data['security']['firewalls']['main']['form_login']['login_path'] = 'app_login';
@@ -89,15 +89,15 @@ class MakeRegistrationFormTest extends MakerTestCase
 
                 $fixturePath = \dirname(__DIR__, 1).'/fixtures/make-registration-form/expected';
 
-                $this->assertFileEquals($fixturePath.'/RegistrationControllerFormLogin.php', $runner->getPath('src/Controller/RegistrationController.php'));
+                self::assertFileEquals($fixturePath.'/RegistrationControllerFormLogin.php', $runner->getPath('src/Controller/RegistrationController.php'));
 
-                $this->runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
+                self::runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
             }),
         ];
 
-        yield 'it_generates_registration_with_entity_and_custom_authenticator' => [$this->createRegistrationFormTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'it_generates_registration_with_entity_and_custom_authenticator' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $runner->modifyYamlFile('config/packages/security.yaml', static function (array $data) {
                     $data['security']['firewalls']['main']['custom_authenticator'] = 'App\\Security\\StubAuthenticator';
@@ -118,15 +118,15 @@ class MakeRegistrationFormTest extends MakerTestCase
 
                 $fixturePath = \dirname(__DIR__, 1).'/fixtures/make-registration-form/expected';
 
-                $this->assertFileEquals($fixturePath.'/RegistrationControllerCustomAuthenticator.php', $runner->getPath('src/Controller/RegistrationController.php'));
+                self::assertFileEquals($fixturePath.'/RegistrationControllerCustomAuthenticator.php', $runner->getPath('src/Controller/RegistrationController.php'));
 
-                $this->runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
+                self::runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
             }),
         ];
 
-        yield 'it_generates_registration_form_with_no_guessing' => [$this->createRegistrationFormTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'emailAlt');
+        yield 'it_generates_registration_form_with_no_guessing' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'emailAlt');
 
                 $runner->runMaker([
                     'App\\Entity\\User',
@@ -141,9 +141,9 @@ class MakeRegistrationFormTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_registration_form_with_entity_no_login' => [$this->createRegistrationFormTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'it_generates_registration_form_with_entity_no_login' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $runner->runMaker([
                     // all basic data guessed
@@ -153,15 +153,15 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'app_anonymous', // route name to redirect to
                 ]);
 
-                $this->runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
+                self::runRegistrationTest($runner, 'it_generates_registration_with_entity_and_authenticator.php');
             }),
         ];
 
-        yield 'it_generates_registration_form_with_verification' => [$this->createRegistrationFormTest()
+        yield 'it_generates_registration_form_with_verification' => [self::createRegistrationFormTest()
             ->addExtraDependencies('symfonycasts/verify-email-bundle')
             // needed for internal functional test
             ->addExtraDependencies('symfony/web-profiler-bundle', 'mailer')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->writeFile(
                     'config/packages/mailer.yaml',
                     Yaml::dump(['framework' => [
@@ -169,7 +169,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                     ]])
                 );
 
-                $this->makeUser($runner);
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'n', // add UniqueEntity
@@ -181,7 +181,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'app_anonymous', // route number to redirect to
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $generatedFiles = [
                     'src/Security/EmailVerifier.php',
@@ -189,22 +189,22 @@ class MakeRegistrationFormTest extends MakerTestCase
                 ];
 
                 foreach ($generatedFiles as $file) {
-                    $this->assertFileExists($runner->getPath($file));
+                    self::assertFileExists($runner->getPath($file));
                 }
 
                 $userContents = file_get_contents($runner->getPath('src/Entity/User.php'));
 
-                $this->assertStringContainsString('private bool $isVerified = false', $userContents);
+                self::assertStringContainsString('private bool $isVerified = false', $userContents);
 
-                $this->runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
+                self::runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
             }),
         ];
 
-        yield 'it_generates_registration_form_with_verification_and_translator' => [$this->createRegistrationFormTest()
+        yield 'it_generates_registration_form_with_verification_and_translator' => [self::createRegistrationFormTest()
             ->addExtraDependencies('symfonycasts/verify-email-bundle')
             // needed for internal functional test
             ->addExtraDependencies('symfony/web-profiler-bundle', 'mailer', 'symfony/translation')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->writeFile(
                     'config/packages/mailer.yaml',
                     Yaml::dump(['framework' => [
@@ -212,7 +212,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                     ]])
                 );
 
-                $this->makeUser($runner);
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'n', // add UniqueEntity
@@ -224,15 +224,15 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'app_anonymous', // route number to redirect to
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $this->runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
+                self::runRegistrationTest($runner, 'it_generates_registration_form_with_verification.php');
             }),
         ];
 
-        yield 'it_generates_registration_form_with_tests' => [$this->createRegistrationFormTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'it_generates_registration_form_with_tests' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'n', // add UniqueEntity
@@ -242,17 +242,17 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'y', // Generate tests
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
-                $this->assertFileExists($runner->getPath('tests/RegistrationControllerTest.php'));
+                self::assertStringContainsString('Success', $output);
+                self::assertFileExists($runner->getPath('tests/RegistrationControllerTest.php'));
 
                 $runner->configureDatabase();
                 $runner->runTests();
             }),
         ];
 
-        yield 'it_generates_registration_form_with_tests_using_flag' => [$this->createRegistrationFormTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'it_generates_registration_form_with_tests_using_flag' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'n', // add UniqueEntity
@@ -261,19 +261,19 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'app_anonymous', // route number to redirect to
                 ], '--with-tests');
 
-                $this->assertStringContainsString('Success', $output);
-                $this->assertFileExists($runner->getPath('tests/RegistrationControllerTest.php'));
+                self::assertStringContainsString('Success', $output);
+                self::assertFileExists($runner->getPath('tests/RegistrationControllerTest.php'));
 
                 $runner->configureDatabase();
                 $runner->runTests();
             }),
         ];
 
-        yield 'it_generates_registration_form_with_verification_and_with_tests' => [$this->createRegistrationFormTest()
+        yield 'it_generates_registration_form_with_verification_and_with_tests' => [self::createRegistrationFormTest()
             ->addExtraDependencies('symfonycasts/verify-email-bundle')
             // needed for internal functional test
             ->addExtraDependencies('symfony/web-profiler-bundle', 'mailer')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->writeFile(
                     'config/packages/mailer.yaml',
                     Yaml::dump(['framework' => [
@@ -281,7 +281,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                     ]])
                 );
 
-                $this->makeUser($runner);
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'n', // add UniqueEntity
@@ -294,7 +294,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                     'y', // Generate tests
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $generatedFiles = [
                     'src/Security/EmailVerifier.php',
@@ -303,7 +303,7 @@ class MakeRegistrationFormTest extends MakerTestCase
                 ];
 
                 foreach ($generatedFiles as $file) {
-                    $this->assertFileExists($runner->getPath($file));
+                    self::assertFileExists($runner->getPath($file));
                 }
 
                 $runner->runConsole('cache:clear', [], '--env=test');
@@ -314,7 +314,7 @@ class MakeRegistrationFormTest extends MakerTestCase
         ];
     }
 
-    private function makeUser(MakerTestRunner $runner, string $identifier = 'email'): void
+    private static function makeUser(MakerTestRunner $runner, string $identifier = 'email'): void
     {
         $runner->runConsole('make:user', [
             'User', // class name
@@ -324,7 +324,7 @@ class MakeRegistrationFormTest extends MakerTestCase
         ]);
     }
 
-    private function runRegistrationTest(MakerTestRunner $runner, string $filename): void
+    private static function runRegistrationTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-registration-form/tests/'.$filename,

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -24,13 +24,13 @@ class MakeResetPasswordTest extends MakerTestCase
         return MakeResetPassword::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_with_normal_setup' => [$this->createMakerTest()
+        yield 'it_generates_with_normal_setup' => [self::buildMakerTest()
             // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
             ->setSkippedPhpVersions(80100, 80109)
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'App\Entity\User',
@@ -39,7 +39,7 @@ class MakeResetPasswordTest extends MakerTestCase
                     'SymfonyCasts',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $generatedFiles = [
                     'src/Controller/ResetPasswordController.php',
@@ -54,17 +54,17 @@ class MakeResetPasswordTest extends MakerTestCase
                 ];
 
                 foreach ($generatedFiles as $file) {
-                    $this->assertFileExists($runner->getPath($file));
+                    self::assertFileExists($runner->getPath($file));
                 }
 
                 $configFileContents = file_get_contents($runner->getPath('config/packages/reset_password.yaml'));
 
                 // Flex recipe adds comments in reset_password.yaml, check file was replaced by maker
-                $this->assertStringNotContainsString('#', $configFileContents);
+                self::assertStringNotContainsString('#', $configFileContents);
 
                 $resetPasswordConfig = $runner->readYaml('config/packages/reset_password.yaml');
 
-                $this->assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
+                self::assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
 
                 $runner->writeFile(
                     'config/packages/mailer.yaml',
@@ -82,7 +82,7 @@ class MakeResetPasswordTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_tests' => [$this->createMakerTest()
+        yield 'it_generates_tests' => [self::buildMakerTest()
             // Needed to assertEmails && NotCompromisedPassword
             ->addExtraDependencies('symfony/mailer', 'symfony/http-client')
             // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
@@ -93,8 +93,8 @@ class MakeResetPasswordTest extends MakerTestCase
                     'src/Controller/FixtureController.php'
                 );
             })
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'app_home',
@@ -103,14 +103,14 @@ class MakeResetPasswordTest extends MakerTestCase
                     'y',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $generatedFiles = [
                     'tests/ResetPasswordControllerTest.php',
                 ];
 
                 foreach ($generatedFiles as $file) {
-                    $this->assertFileExists($runner->getPath($file));
+                    self::assertFileExists($runner->getPath($file));
                 }
 
                 $runner->writeFile(
@@ -130,11 +130,11 @@ class MakeResetPasswordTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_with_uuid' => [$this->createMakerTest()
+        yield 'it_generates_with_uuid' => [self::buildMakerTest()
             ->setSkippedPhpVersions(80100, 80109)
             ->addExtraDependencies('symfony/uid')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'App\Entity\User',
@@ -143,7 +143,7 @@ class MakeResetPasswordTest extends MakerTestCase
                     'SymfonyCasts',
                 ], '--with-uuid');
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $generatedFiles = [
                     'src/Controller/ResetPasswordController.php',
@@ -158,21 +158,21 @@ class MakeResetPasswordTest extends MakerTestCase
                 ];
 
                 foreach ($generatedFiles as $file) {
-                    $this->assertFileExists($runner->getPath($file));
+                    self::assertFileExists($runner->getPath($file));
                 }
 
                 $resetPasswordRequestEntityContents = file_get_contents($runner->getPath('src/Entity/ResetPasswordRequest.php'));
-                $this->assertStringContainsString('use Symfony\Component\Uid\Uuid;', $resetPasswordRequestEntityContents);
-                $this->assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.uuid_generator\')]', $resetPasswordRequestEntityContents);
+                self::assertStringContainsString('use Symfony\Component\Uid\Uuid;', $resetPasswordRequestEntityContents);
+                self::assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.uuid_generator\')]', $resetPasswordRequestEntityContents);
 
                 $configFileContents = file_get_contents($runner->getPath('config/packages/reset_password.yaml'));
 
                 // Flex recipe adds comments in reset_password.yaml, check file was replaced by maker
-                $this->assertStringNotContainsString('#', $configFileContents);
+                self::assertStringNotContainsString('#', $configFileContents);
 
                 $resetPasswordConfig = $runner->readYaml('config/packages/reset_password.yaml');
 
-                $this->assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
+                self::assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
 
                 $runner->writeFile(
                     'config/packages/mailer.yaml',
@@ -190,11 +190,11 @@ class MakeResetPasswordTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_with_ulid' => [$this->createMakerTest()
+        yield 'it_generates_with_ulid' => [self::buildMakerTest()
             ->setSkippedPhpVersions(80100, 80109)
             ->addExtraDependencies('symfony/uid')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'App\Entity\User',
@@ -203,7 +203,7 @@ class MakeResetPasswordTest extends MakerTestCase
                     'SymfonyCasts',
                 ], '--with-ulid');
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $generatedFiles = [
                     'src/Controller/ResetPasswordController.php',
@@ -218,21 +218,21 @@ class MakeResetPasswordTest extends MakerTestCase
                 ];
 
                 foreach ($generatedFiles as $file) {
-                    $this->assertFileExists($runner->getPath($file));
+                    self::assertFileExists($runner->getPath($file));
                 }
 
                 $resetPasswordRequestEntityContents = file_get_contents($runner->getPath('src/Entity/ResetPasswordRequest.php'));
-                $this->assertStringContainsString('use Symfony\Component\Uid\Ulid;', $resetPasswordRequestEntityContents);
-                $this->assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.ulid_generator\')]', $resetPasswordRequestEntityContents);
+                self::assertStringContainsString('use Symfony\Component\Uid\Ulid;', $resetPasswordRequestEntityContents);
+                self::assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.ulid_generator\')]', $resetPasswordRequestEntityContents);
 
                 $configFileContents = file_get_contents($runner->getPath('config/packages/reset_password.yaml'));
 
                 // Flex recipe adds comments in reset_password.yaml, check file was replaced by maker
-                $this->assertStringNotContainsString('#', $configFileContents);
+                self::assertStringNotContainsString('#', $configFileContents);
 
                 $resetPasswordConfig = $runner->readYaml('config/packages/reset_password.yaml');
 
-                $this->assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
+                self::assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
 
                 $runner->writeFile(
                     'config/packages/mailer.yaml',
@@ -250,12 +250,12 @@ class MakeResetPasswordTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_with_translator_installed' => [$this->createMakerTest()
+        yield 'it_generates_with_translator_installed' => [self::buildMakerTest()
             // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
             ->setSkippedPhpVersions(80100, 80109)
             ->addExtraDependencies('symfony/translation')
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'App\Entity\User',
@@ -264,14 +264,14 @@ class MakeResetPasswordTest extends MakerTestCase
                     'SymfonyCasts',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
             }),
         ];
 
-        yield 'it_generates_with_custom_config' => [$this->createMakerTest()
+        yield 'it_generates_with_custom_config' => [self::buildMakerTest()
             // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
             ->setSkippedPhpVersions(80100, 80109)
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->deleteFile('config/packages/reset_password.yaml');
                 $runner->writeFile(
                     'config/packages/custom_reset_password.yaml',
@@ -280,7 +280,7 @@ class MakeResetPasswordTest extends MakerTestCase
                     ]])
                 );
 
-                $this->makeUser($runner);
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'App\Entity\User',
@@ -289,27 +289,27 @@ class MakeResetPasswordTest extends MakerTestCase
                     'SymfonyCasts',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
-                $this->assertFileDoesNotExist($runner->getPath('config/packages/reset_password.yaml'));
-                $this->assertStringContainsString(
+                self::assertFileDoesNotExist($runner->getPath('config/packages/reset_password.yaml'));
+                self::assertStringContainsString(
                     'Just remember to set the request_password_repository in your configuration.',
                     $output
                 );
             }),
         ];
 
-        yield 'it_amends_configuration' => [$this->createMakerTest()
+        yield 'it_amends_configuration' => [self::buildMakerTest()
             // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
             ->setSkippedPhpVersions(80100, 80109)
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->modifyYamlFile('config/packages/reset_password.yaml', static function (array $config) {
                     $config['symfonycasts_reset_password']['lifetime'] = 9999;
 
                     return $config;
                 });
 
-                $this->makeUser($runner);
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'App\Entity\User',
@@ -318,20 +318,20 @@ class MakeResetPasswordTest extends MakerTestCase
                     'SymfonyCasts',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $resetPasswordConfig = $runner->readYaml('config/packages/reset_password.yaml');
 
-                $this->assertStringContainsString('9999', $resetPasswordConfig['symfonycasts_reset_password']['lifetime']);
-                $this->assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
+                self::assertStringContainsString('9999', $resetPasswordConfig['symfonycasts_reset_password']['lifetime']);
+                self::assertSame('App\Repository\ResetPasswordRequestRepository', $resetPasswordConfig['symfonycasts_reset_password']['request_password_repository']);
             }),
         ];
 
-        yield 'it_generates_with_custom_user' => [$this->createMakerTest()
+        yield 'it_generates_with_custom_user' => [self::buildMakerTest()
             // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
             ->setSkippedPhpVersions(80100, 80109)
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner, 'emailAddress', 'UserCustom', false);
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner, 'emailAddress', 'UserCustom', false);
 
                 $runner->manipulateClass('src/Entity/UserCustom.php', static function (ClassSourceManipulator $manipulator) {
                     $manipulator->addSetter('myPassword', 'string', true);
@@ -346,31 +346,31 @@ class MakeResetPasswordTest extends MakerTestCase
                     'SymfonyCasts',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 // check ResetPasswordController
                 $contentResetPasswordController = file_get_contents($runner->getPath('src/Controller/ResetPasswordController.php'));
-                $this->assertStringContainsString('$form->get(\'emailAddress\')->getData()', $contentResetPasswordController);
-                $this->assertStringContainsString('\'emailAddress\' => $emailFormData,', $contentResetPasswordController);
-                $this->assertStringContainsString('$user->setMyPassword($passwordHasher->hashPassword($user, $plainPassword));', $contentResetPasswordController);
-                $this->assertStringContainsString('->to((string) $user->getEmailAddress())', $contentResetPasswordController);
+                self::assertStringContainsString('$form->get(\'emailAddress\')->getData()', $contentResetPasswordController);
+                self::assertStringContainsString('\'emailAddress\' => $emailFormData,', $contentResetPasswordController);
+                self::assertStringContainsString('$user->setMyPassword($passwordHasher->hashPassword($user, $plainPassword));', $contentResetPasswordController);
+                self::assertStringContainsString('->to((string) $user->getEmailAddress())', $contentResetPasswordController);
 
                 // check ResetPasswordRequest
                 $contentResetPasswordRequest = file_get_contents($runner->getPath('src/Entity/ResetPasswordRequest.php'));
 
-                $this->assertStringContainsString('ORM\ManyToOne', $contentResetPasswordRequest);
+                self::assertStringContainsString('ORM\ManyToOne', $contentResetPasswordRequest);
 
                 // check ResetPasswordRequestFormType
                 $contentResetPasswordRequestFormType = file_get_contents($runner->getPath('/src/Form/ResetPasswordRequestFormType.php'));
-                $this->assertStringContainsString('->add(\'emailAddress\', EmailType::class, [', $contentResetPasswordRequestFormType);
+                self::assertStringContainsString('->add(\'emailAddress\', EmailType::class, [', $contentResetPasswordRequestFormType);
                 // check request.html.twig
                 $contentRequestHtml = file_get_contents($runner->getPath('templates/reset_password/request.html.twig'));
-                $this->assertStringContainsString('{{ form_row(requestForm.emailAddress) }}', $contentRequestHtml);
+                self::assertStringContainsString('{{ form_row(requestForm.emailAddress) }}', $contentRequestHtml);
             }),
         ];
     }
 
-    private function makeUser(MakerTestRunner $runner, string $identifier = 'email', string $userClass = 'User', bool $checkPassword = true): void
+    private static function makeUser(MakerTestRunner $runner, string $identifier = 'email', string $userClass = 'User', bool $checkPassword = true): void
     {
         $runner->runConsole('make:user', [
             $userClass, // class name

--- a/tests/Maker/MakeScheduleTest.php
+++ b/tests/Maker/MakeScheduleTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\MakerBundle\Maker\MakeSchedule;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
@@ -18,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 /**
  * @group legacy
  */
+#[Group('legacy')]
 class MakeScheduleTest extends MakerTestCase
 {
     protected function getMakerClass(): string
@@ -25,16 +27,16 @@ class MakeScheduleTest extends MakerTestCase
         return MakeSchedule::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_a_schedule_with_transport_name' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_a_schedule_with_transport_name' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'dummy', // use transport name "dummy"
                     '', // use default schedule name "MainSchedule"
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 self::assertFileEquals(
                     \dirname(__DIR__).'/fixtures/make-schedule/expected/DefaultScheduleWithTransportName.php',
@@ -43,14 +45,14 @@ class MakeScheduleTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_a_schedule' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_a_schedule' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     '', // use default transport name
                     '', // use default schedule name "MainSchedule"
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 self::assertFileEquals(
                     \dirname(__DIR__).'/fixtures/make-schedule/expected/DefaultScheduleEmpty.php',
@@ -59,21 +61,21 @@ class MakeScheduleTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_a_schedule_select_empty' => [$this->createMakerTest()
+        yield 'it_generates_a_schedule_select_empty' => [self::buildMakerTest()
             ->preRun(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-schedule/standard_setup',
                     ''
                 );
             })
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     '', // Use the default transport name
                     0,  // Select "Empty Schedule"
                     'MySchedule', // Go with the default name "MainSchedule"
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 self::assertFileEquals(
                     \dirname(__DIR__).'/fixtures/make-schedule/expected/MyScheduleEmpty.php',
@@ -82,21 +84,21 @@ class MakeScheduleTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_a_schedule_select_existing_message' => [$this->createMakerTest()
+        yield 'it_generates_a_schedule_select_existing_message' => [self::buildMakerTest()
             ->preRun(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-schedule/standard_setup',
                     ''
                 );
             })
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     '', // Use the default transport name
                     1,  // Select "MyMessage" from choice
                     '', // Go with the default name "MessageFixtureSchedule"
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 self::assertFileEquals(
                     \dirname(__DIR__).'/fixtures/make-schedule/expected/MyScheduleWithMessage.php',

--- a/tests/Maker/MakeSerializerEncoderTest.php
+++ b/tests/Maker/MakeSerializerEncoderTest.php
@@ -22,12 +22,12 @@ class MakeSerializerEncoderTest extends MakerTestCase
         return MakeSerializerEncoder::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_serializer_encoder' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_serializer_encoder' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 if (70000 >= $runner->getSymfonyVersion()) {
-                    $this->markTestSkipped('Legacy Symfony 6.4 Test');
+                    self::markTestSkipped('Legacy Symfony 6.4 Test');
                 }
                 $runner->runMaker(
                     [
@@ -46,10 +46,10 @@ class MakeSerializerEncoderTest extends MakerTestCase
         ];
 
         /* @legacy - Remove when MakerBundle no longer supports Symfony 6.4 */
-        yield 'it_makes_serializer_encoder_legacy' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_serializer_encoder_legacy' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 if (70000 < $runner->getSymfonyVersion()) {
-                    $this->markTestSkipped('Legacy Symfony 6.4 Test');
+                    self::markTestSkipped('Legacy Symfony 6.4 Test');
                 }
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeSerializerNormalizerTest.php
+++ b/tests/Maker/MakeSerializerNormalizerTest.php
@@ -22,15 +22,15 @@ class MakeSerializerNormalizerTest extends MakerTestCase
         return MakeSerializerNormalizer::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_serializer_normalizer' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_serializer_normalizer' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(
                     ['FooBarNormalizer']
                 );
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 self::assertFileEquals(
                     \dirname(__DIR__).'/fixtures/make-serializer-normalizer/FooBarNormalizer.php',
@@ -39,15 +39,15 @@ class MakeSerializerNormalizerTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_serializer_normalizer_with_existing_entity' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_serializer_normalizer_with_existing_entity' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy('make-serializer-normalizer/EntityFixture.php', 'src/Entity/EntityFixture.php');
 
                 $output = $runner->runMaker(
                     ['EntityFixture']
                 );
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 self::assertFileEquals(
                     \dirname(__DIR__).'/fixtures/make-serializer-normalizer/EntityFixtureNormalizer.php',

--- a/tests/Maker/MakeStimulusControllerTest.php
+++ b/tests/Maker/MakeStimulusControllerTest.php
@@ -22,10 +22,10 @@ class MakeStimulusControllerTest extends MakerTestCase
         return MakeStimulusController::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_stimulus_controller' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_stimulus_controller' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'default', // controller name
@@ -33,12 +33,12 @@ class MakeStimulusControllerTest extends MakerTestCase
                 );
 
                 $generatedFilePath = $runner->getPath('assets/controllers/default_controller.js');
-                $this->assertFileExists($generatedFilePath);
+                self::assertFileExists($generatedFilePath);
             }),
         ];
 
-        yield 'it_generates_stimulus_controller_with_targets' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_stimulus_controller_with_targets' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'with_targets', // controller name
@@ -52,20 +52,20 @@ class MakeStimulusControllerTest extends MakerTestCase
 
                 $generatedFilePath = $runner->getPath('assets/controllers/with_targets_controller.js');
 
-                $this->assertFileExists($generatedFilePath);
+                self::assertFileExists($generatedFilePath);
 
                 $generatedFileContents = file_get_contents($generatedFilePath);
                 $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_targets.js');
 
-                $this->assertSame(
+                self::assertSame(
                     $expectedContents,
                     $generatedFileContents
                 );
             }),
         ];
 
-        yield 'it_generates_stimulus_controller_without_targets' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_stimulus_controller_without_targets' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'without_targets', // controller name
@@ -75,20 +75,20 @@ class MakeStimulusControllerTest extends MakerTestCase
 
                 $generatedFilePath = $runner->getPath('assets/controllers/without_targets_controller.js');
 
-                $this->assertFileExists($generatedFilePath);
+                self::assertFileExists($generatedFilePath);
 
                 $generatedFileContents = file_get_contents($generatedFilePath);
                 $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/without_targets.js');
 
-                $this->assertSame(
+                self::assertSame(
                     $expectedContents,
                     $generatedFileContents
                 );
             }),
         ];
 
-        yield 'it_generates_stimulus_controller_with_values' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_stimulus_controller_with_values' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'with_values', // controller name
@@ -104,20 +104,20 @@ class MakeStimulusControllerTest extends MakerTestCase
 
                 $generatedFilePath = $runner->getPath('assets/controllers/with_values_controller.js');
 
-                $this->assertFileExists($generatedFilePath);
+                self::assertFileExists($generatedFilePath);
 
                 $generatedFileContents = file_get_contents($generatedFilePath);
                 $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_values.js');
 
-                $this->assertSame(
+                self::assertSame(
                     $expectedContents,
                     $generatedFileContents
                 );
             }),
         ];
 
-        yield 'it_generates_stimulus_controller_with_classes' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_stimulus_controller_with_classes' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'with_classes', // controller name
@@ -132,20 +132,20 @@ class MakeStimulusControllerTest extends MakerTestCase
 
                 $generatedFilePath = $runner->getPath('assets/controllers/with_classes_controller.js');
 
-                $this->assertFileExists($generatedFilePath);
+                self::assertFileExists($generatedFilePath);
 
                 $generatedFileContents = file_get_contents($generatedFilePath);
                 $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_classes.js');
 
-                $this->assertSame(
+                self::assertSame(
                     $expectedContents,
                     $generatedFileContents
                 );
             }),
         ];
 
-        yield 'it_generates_stimulus_controller_with_targets_values_and_classes' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_stimulus_controller_with_targets_values_and_classes' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'with_targets_values_classes',
@@ -168,20 +168,20 @@ class MakeStimulusControllerTest extends MakerTestCase
 
                 $generatedFilePath = $runner->getPath('assets/controllers/with_targets_values_classes_controller.js');
 
-                $this->assertFileExists($generatedFilePath);
+                self::assertFileExists($generatedFilePath);
 
                 $generatedFileContents = file_get_contents($generatedFilePath);
                 $expectedContents = file_get_contents(__DIR__.'/../fixtures/make-stimulus-controller/with_targets_values_classes.js');
 
-                $this->assertSame(
+                self::assertSame(
                     $expectedContents,
                     $generatedFileContents
                 );
             }),
         ];
 
-        yield 'it_generates_typescript_stimulus_controller_interactively' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_typescript_stimulus_controller_interactively' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'typescript', // controller name
@@ -190,13 +190,13 @@ class MakeStimulusControllerTest extends MakerTestCase
                     ],
                 );
 
-                $this->assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));
-                $this->assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
+                self::assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));
+                self::assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
             }),
         ];
 
-        yield 'it_generates_typescript_stimulus_controller_when_option_is_set' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_generates_typescript_stimulus_controller_when_option_is_set' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
                         'typescript', // controller name
@@ -206,13 +206,13 @@ class MakeStimulusControllerTest extends MakerTestCase
                     ' --typescript'
                 );
 
-                $this->assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));
-                $this->assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
+                self::assertFileExists($runner->getPath('assets/controllers/typescript_controller.ts'));
+                self::assertFileDoesNotExist($runner->getPath('assets/controllers/typescript_controller.js'));
             }),
         ];
 
-        yield 'it_displays_controller_basic_usage_example' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_displays_controller_basic_usage_example' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(
                     [
                         'fooBar',
@@ -226,15 +226,15 @@ class MakeStimulusControllerTest extends MakerTestCase
                         </div>
                     HTML;
 
-                $this->assertStringContainsString('- Use the controller in your templates:', $output);
+                self::assertStringContainsString('- Use the controller in your templates:', $output);
                 foreach (explode("\n", $usageExample) as $line) {
-                    $this->assertStringContainsString($line, $output);
+                    self::assertStringContainsString($line, $output);
                 }
             }),
         ];
 
-        yield 'it_displays_controller_complete_usage_example' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_displays_controller_complete_usage_example' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(
                     [
                         'fooBar',
@@ -269,9 +269,9 @@ class MakeStimulusControllerTest extends MakerTestCase
                         </div>
                     HTML;
 
-                $this->assertStringContainsString('- Use the controller in your templates:', $output);
+                self::assertStringContainsString('- Use the controller in your templates:', $output);
                 foreach (explode("\n", $usageExample) as $line) {
-                    $this->assertStringContainsString($line, $output);
+                    self::assertStringContainsString($line, $output);
                 }
             }),
         ];

--- a/tests/Maker/MakeSubscriberTest.php
+++ b/tests/Maker/MakeSubscriberTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\MakerBundle\Maker\MakeSubscriber;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
@@ -18,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 /**
  * @group legacy
  */
+#[Group('legacy')]
 class MakeSubscriberTest extends MakerTestCase
 {
     protected function getMakerClass(): string
@@ -25,9 +27,9 @@ class MakeSubscriberTest extends MakerTestCase
         return MakeSubscriber::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_subscriber_for_known_event' => [$this->createMakerTest()
+        yield 'it_makes_subscriber_for_known_event' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -45,7 +47,7 @@ class MakeSubscriberTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_subscriber_for_custom_event_class' => [$this->createMakerTest()
+        yield 'it_makes_subscriber_for_custom_event_class' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -63,7 +65,7 @@ class MakeSubscriberTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_subscriber_for_unknown_event_class' => [$this->createMakerTest()
+        yield 'it_makes_subscriber_for_unknown_event_class' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeTestTest.php
+++ b/tests/Maker/MakeTestTest.php
@@ -23,9 +23,9 @@ class MakeTestTest extends MakerTestCase
         return MakeTest::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_TestCase_type' => [$this->createMakerTest()
+        yield 'it_makes_TestCase_type' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -40,7 +40,7 @@ class MakeTestTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_KernelTestCase_type' => [$this->createMakerTest()
+        yield 'it_makes_KernelTestCase_type' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-test/basic_setup',
@@ -60,7 +60,7 @@ class MakeTestTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_WebTestCase_type' => [$this->createMakerTest()
+        yield 'it_makes_WebTestCase_type' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-test/basic_setup',
@@ -80,7 +80,7 @@ class MakeTestTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_PantherTestCase_type' => [$this->getPantherTest()
+        yield 'it_makes_PantherTestCase_type' => [self::getPantherTest()
             ->addExtraDependencies('panther')
             ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
@@ -105,9 +105,9 @@ class MakeTestTest extends MakerTestCase
         ];
     }
 
-    protected function getPantherTest(): MakerTestDetails
+    protected static function getPantherTest(): MakerTestDetails
     {
-        return $this->createMakerTest()
+        return self::buildMakerTest()
             ->skipTest(
                 message: 'Panther test skipped - MAKER_SKIP_PANTHER_TEST set to TRUE.',
                 skipped: getenv('MAKER_SKIP_PANTHER_TEST')

--- a/tests/Maker/MakeTwigComponentTest.php
+++ b/tests/Maker/MakeTwigComponentTest.php
@@ -17,16 +17,16 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 
 class MakeTwigComponentTest extends MakerTestCase
 {
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_twig_component' => [$this->createMakerTest()
+        yield 'it_generates_twig_component' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/ux-twig-component', 'symfony/twig-bundle')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(['Alert']);
 
-                $this->assertStringContainsString('src/Twig/Components/Alert.php', $output);
-                $this->assertStringContainsString('templates/components/Alert.html.twig', $output);
-                $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
+                self::assertStringContainsString('src/Twig/Components/Alert.php', $output);
+                self::assertStringContainsString('templates/components/Alert.html.twig', $output);
+                self::assertStringContainsString('To render the component, use <twig:Alert />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_twig_component.php',
@@ -37,9 +37,9 @@ class MakeTwigComponentTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_twig_component_in_non_default_namespace' => [$this->createMakerTest()
+        yield 'it_generates_twig_component_in_non_default_namespace' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/ux-twig-component', 'symfony/twig-bundle')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-twig-component/custom_twig_component.yaml',
                     'config/packages/twig_component.yaml'
@@ -47,9 +47,9 @@ class MakeTwigComponentTest extends MakerTestCase
 
                 $output = $runner->runMaker(['Alert']);
 
-                $this->assertStringContainsString('src/Site/Twig/Components/Alert.php', $output);
-                $this->assertStringContainsString('templates/components/Alert.html.twig', $output);
-                $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
+                self::assertStringContainsString('src/Site/Twig/Components/Alert.php', $output);
+                self::assertStringContainsString('templates/components/Alert.html.twig', $output);
+                self::assertStringContainsString('To render the component, use <twig:Alert />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_twig_component.php',
@@ -60,14 +60,14 @@ class MakeTwigComponentTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_pascal_case_twig_component' => [$this->createMakerTest()
+        yield 'it_generates_pascal_case_twig_component' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/ux-twig-component', 'symfony/twig-bundle')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(['FormInput']);
 
-                $this->assertStringContainsString('src/Twig/Components/FormInput.php', $output);
-                $this->assertStringContainsString('templates/components/FormInput.html.twig', $output);
-                $this->assertStringContainsString('To render the component, use <twig:FormInput />.', $output);
+                self::assertStringContainsString('src/Twig/Components/FormInput.php', $output);
+                self::assertStringContainsString('templates/components/FormInput.html.twig', $output);
+                self::assertStringContainsString('To render the component, use <twig:FormInput />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_twig_component.php',
@@ -78,14 +78,14 @@ class MakeTwigComponentTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_live_component' => [$this->createMakerTest()
+        yield 'it_generates_live_component' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/ux-live-component', 'symfony/twig-bundle')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(['Alert', 'y']);
 
-                $this->assertStringContainsString('src/Twig/Components/Alert.php', $output);
-                $this->assertStringContainsString('templates/components/Alert.html.twig', $output);
-                $this->assertStringContainsString('To render the component, use <twig:Alert />.', $output);
+                self::assertStringContainsString('src/Twig/Components/Alert.php', $output);
+                self::assertStringContainsString('templates/components/Alert.html.twig', $output);
+                self::assertStringContainsString('To render the component, use <twig:Alert />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_live_component.php',
@@ -96,14 +96,14 @@ class MakeTwigComponentTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_pascal_case_live_component' => [$this->createMakerTest()
+        yield 'it_generates_pascal_case_live_component' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/ux-live-component', 'symfony/twig-bundle')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(['FormInput', 'y']);
 
-                $this->assertStringContainsString('src/Twig/Components/FormInput.php', $output);
-                $this->assertStringContainsString('templates/components/FormInput.html.twig', $output);
-                $this->assertStringContainsString('To render the component, use <twig:FormInput />.', $output);
+                self::assertStringContainsString('src/Twig/Components/FormInput.php', $output);
+                self::assertStringContainsString('templates/components/FormInput.html.twig', $output);
+                self::assertStringContainsString('To render the component, use <twig:FormInput />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_live_component.php',
@@ -114,14 +114,14 @@ class MakeTwigComponentTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_generates_live_component_on_subdirectory' => [$this->createMakerTest()
+        yield 'it_generates_live_component_on_subdirectory' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/ux-live-component', 'symfony/twig-bundle')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker(['Form\Input', 'y']);
 
-                $this->assertStringContainsString('src/Twig/Components/Form/Input.php', $output);
-                $this->assertStringContainsString('templates/components/Form/Input.html.twig', $output);
-                $this->assertStringContainsString('To render the component, use <twig:Form:Input />.', $output);
+                self::assertStringContainsString('src/Twig/Components/Form/Input.php', $output);
+                self::assertStringContainsString('templates/components/Form/Input.html.twig', $output);
+                self::assertStringContainsString('To render the component, use <twig:Form:Input />.', $output);
 
                 $runner->copy(
                     'make-twig-component/tests/it_generates_live_component.php',

--- a/tests/Maker/MakeTwigExtensionTest.php
+++ b/tests/Maker/MakeTwigExtensionTest.php
@@ -22,9 +22,9 @@ class MakeTwigExtensionTest extends MakerTestCase
         return MakeTwigExtension::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_twig_extension' => [$this->createMakerTest()
+        yield 'it_makes_twig_extension' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeUnitTestTest.php
+++ b/tests/Maker/MakeUnitTestTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Maker;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\MakerBundle\Maker\MakeUnitTest;
 use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
 use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
@@ -18,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
 /**
  * @group legacy
  */
+#[Group('legacy')]
 class MakeUnitTestTest extends MakerTestCase
 {
     protected function getMakerClass(): string
@@ -25,9 +27,9 @@ class MakeUnitTestTest extends MakerTestCase
         return MakeUnitTest::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_unit_test' => [$this->createMakerTest()
+        yield 'it_makes_unit_test' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeUserTest.php
+++ b/tests/Maker/MakeUserTest.php
@@ -23,11 +23,11 @@ class MakeUserTest extends MakerTestCase
         return MakeUser::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_generates_entity_with_password' => [$this->createMakerTest()
+        yield 'it_generates_entity_with_password' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-user/standard_setup',
                     ''
@@ -41,14 +41,14 @@ class MakeUserTest extends MakerTestCase
                     'y', // with password
                 ]);
 
-                $this->runUserTest($runner, 'it_generates_entity_with_password.php');
+                self::runUserTest($runner, 'it_generates_entity_with_password.php');
             }),
         ];
 
-        yield 'it_generates_entity_with_password_and_uuid' => [$this->createMakerTest()
+        yield 'it_generates_entity_with_password_and_uuid' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine')
             ->addExtraDependencies('symfony/uid')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-user/standard_setup',
                     ''
@@ -62,14 +62,14 @@ class MakeUserTest extends MakerTestCase
                     'y', // with password
                 ], '--with-uuid');
 
-                $this->runUserTest($runner, 'it_generates_entity_with_password_and_uuid.php');
+                self::runUserTest($runner, 'it_generates_entity_with_password_and_uuid.php');
             }),
         ];
 
-        yield 'it_generates_entity_with_password_and_ulid' => [$this->createMakerTest()
+        yield 'it_generates_entity_with_password_and_ulid' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine')
             ->addExtraDependencies('symfony/uid')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-user/standard_setup',
                     ''
@@ -83,13 +83,13 @@ class MakeUserTest extends MakerTestCase
                     'y', // with password
                 ], '--with-ulid');
 
-                $this->runUserTest($runner, 'it_generates_entity_with_password_and_ulid.php');
+                self::runUserTest($runner, 'it_generates_entity_with_password_and_ulid.php');
             }),
         ];
 
-        yield 'it_generates_non_entity_no_password' => [$this->createMakerTest()
+        yield 'it_generates_non_entity_no_password' => [self::buildMakerTest()
             ->addExtraDependencies('doctrine')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(
                     'make-user/standard_setup',
                     ''
@@ -116,12 +116,12 @@ class MakeUserTest extends MakerTestCase
                     'return (new FunUser())->setUsername($identifier);'
                 );
 
-                $this->runUserTest($runner, 'it_generates_non_entity_no_password.php');
+                self::runUserTest($runner, 'it_generates_non_entity_no_password.php');
             }),
         ];
     }
 
-    private function runUserTest(MakerTestRunner $runner, string $filename): void
+    private static function runUserTest(MakerTestRunner $runner, string $filename): void
     {
         $runner->copy(
             'make-user/tests/'.$filename,

--- a/tests/Maker/MakeValidatorTest.php
+++ b/tests/Maker/MakeValidatorTest.php
@@ -22,9 +22,9 @@ class MakeValidatorTest extends MakerTestCase
         return MakeValidator::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_validator' => [$this->createMakerTest()
+        yield 'it_makes_validator' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [

--- a/tests/Maker/MakeVoterTest.php
+++ b/tests/Maker/MakeVoterTest.php
@@ -23,9 +23,9 @@ class MakeVoterTest extends MakerTestCase
         return MakeVoter::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_voter' => [$this->createMakerTest()
+        yield 'it_makes_voter' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker(
                     [
@@ -41,7 +41,7 @@ class MakeVoterTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_voter_not_final' => [$this->createMakerTest()
+        yield 'it_makes_voter_not_final' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->writeFile(
                     'config/packages/dev/maker.yaml',

--- a/tests/Maker/MakeWebhookTest.php
+++ b/tests/Maker/MakeWebhookTest.php
@@ -22,49 +22,49 @@ class MakeWebhookTest extends MakerTestCase
         return MakeWebhook::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'it_makes_webhook_with_no_prior_config_file' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_webhook_with_no_prior_config_file' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'remote_service',    // webhook name
                     '',                  // skip adding matchers
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $outputExpectations = [
                     'src/Webhook/RemoteServiceRequestParser.php' => 'use Symfony\Component\Webhook\Client\AbstractRequestParser;',
                     'src/RemoteEvent/RemoteServiceWebhookConsumer.php' => '#[AsRemoteEventConsumer(\'remote_service\')]',
                 ];
 
-                $this->assertStringContainsString('created: ', $output);
+                self::assertStringContainsString('created: ', $output);
 
                 foreach ($outputExpectations as $expectedFileName => $expectedContent) {
                     $path = $runner->getPath($expectedFileName);
 
-                    $this->assertStringContainsString($expectedFileName, $output);
-                    $this->assertFileExists($runner->getPath($expectedFileName));
-                    $this->assertStringContainsString($expectedContent, file_get_contents($path));
+                    self::assertStringContainsString($expectedFileName, $output);
+                    self::assertFileExists($runner->getPath($expectedFileName));
+                    self::assertStringContainsString($expectedContent, file_get_contents($path));
                 }
 
                 $securityConfig = $runner->readYaml('config/packages/webhook.yaml');
 
-                $this->assertEquals(
+                self::assertEquals(
                     'App\\Webhook\\RemoteServiceRequestParser',
                     $securityConfig['framework']['webhook']['routing']['remote_service']['service']
                 );
 
-                $this->assertEquals(
+                self::assertEquals(
                     'your_secret_here',
                     $securityConfig['framework']['webhook']['routing']['remote_service']['secret']
                 );
             }),
         ];
 
-        yield 'it_makes_webhook_with_prior_webhook' => [$this->createMakerTest()
+        yield 'it_makes_webhook_with_prior_webhook' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/webhook')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $runner->copy('make-webhook/webhook.yaml', 'config/packages/webhook.yaml');
                 $runner->copy('make-webhook/RemoteServiceRequestParser.php', 'src/Webhook/RemoteServiceRequestParser.php');
                 $runner->copy('make-webhook/RemoteServiceWebhookConsumer.php', 'src/RemoteEvent/RemoteServiceWebhookConsumer.php');
@@ -74,127 +74,127 @@ class MakeWebhookTest extends MakerTestCase
                     '',                          // skip adding matchers
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $outputExpectations = [
                     'src/Webhook/AnotherRemoteServiceRequestParser.php' => 'use Symfony\Component\Webhook\Client\AbstractRequestParser;',
                     'src/RemoteEvent/AnotherRemoteServiceWebhookConsumer.php' => '#[AsRemoteEventConsumer(\'another_remote_service\')]',
                 ];
 
-                $this->assertStringContainsString('created: ', $output);
+                self::assertStringContainsString('created: ', $output);
 
                 foreach ($outputExpectations as $expectedFileName => $expectedContent) {
                     $path = $runner->getPath($expectedFileName);
 
-                    $this->assertStringContainsString($expectedFileName, $output);
-                    $this->assertFileExists($runner->getPath($expectedFileName));
-                    $this->assertStringContainsString($expectedContent, file_get_contents($path));
+                    self::assertStringContainsString($expectedFileName, $output);
+                    self::assertFileExists($runner->getPath($expectedFileName));
+                    self::assertStringContainsString($expectedContent, file_get_contents($path));
                 }
 
                 $securityConfig = $runner->readYaml('config/packages/webhook.yaml');
 
                 // original config should not be modified
-                $this->assertArrayHasKey('remote_service', $securityConfig['framework']['webhook']['routing']);
+                self::assertArrayHasKey('remote_service', $securityConfig['framework']['webhook']['routing']);
 
-                $this->assertEquals(
+                self::assertEquals(
                     'App\\Webhook\\RemoteServiceRequestParser',
                     $securityConfig['framework']['webhook']['routing']['remote_service']['service']
                 );
 
-                $this->assertEquals(
+                self::assertEquals(
                     '%env(REMOTE_SERVICE_WEBHOOK_SECRET)%',
                     $securityConfig['framework']['webhook']['routing']['remote_service']['secret']
                 );
 
                 // new config should be added
-                $this->assertArrayHasKey('another_remote_service', $securityConfig['framework']['webhook']['routing']);
+                self::assertArrayHasKey('another_remote_service', $securityConfig['framework']['webhook']['routing']);
 
-                $this->assertEquals(
+                self::assertEquals(
                     'App\\Webhook\\AnotherRemoteServiceRequestParser',
                     $securityConfig['framework']['webhook']['routing']['another_remote_service']['service']
                 );
 
-                $this->assertEquals(
+                self::assertEquals(
                     'your_secret_here',
                     $securityConfig['framework']['webhook']['routing']['another_remote_service']['secret']
                 );
             }),
         ];
 
-        yield 'it_makes_webhook_with_single_matcher' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_webhook_with_single_matcher' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'remote_service',  // webhook name
                     '4',               // 'IsJsonRequestMatcher',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $outputExpectations = [
                     $parserFileName = 'src/Webhook/RemoteServiceRequestParser.php' => 'use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;',
                     'src/RemoteEvent/RemoteServiceWebhookConsumer.php' => '#[AsRemoteEventConsumer(\'remote_service\')]',
                 ];
 
-                $this->assertStringContainsString('created: ', $output);
+                self::assertStringContainsString('created: ', $output);
 
                 foreach ($outputExpectations as $expectedFileName => $expectedContent) {
                     $path = $runner->getPath($expectedFileName);
 
-                    $this->assertStringContainsString($expectedFileName, $output);
-                    $this->assertFileExists($runner->getPath($expectedFileName));
-                    $this->assertStringContainsString($expectedContent, file_get_contents($path));
+                    self::assertStringContainsString($expectedFileName, $output);
+                    self::assertFileExists($runner->getPath($expectedFileName));
+                    self::assertStringContainsString($expectedContent, file_get_contents($path));
                 }
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'return new IsJsonRequestMatcher();',
                     file_get_contents($runner->getPath($parserFileName))
                 );
             }),
         ];
 
-        yield 'it_makes_webhook_with_multiple_matchers' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'it_makes_webhook_with_multiple_matchers' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'remote_service',  // webhook name
                     '4',               // 'IsJsonRequestMatcher',
                     '6',               // 'PortRequestMatcher',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $outputExpectations = [
                     $parserFileName = 'src/Webhook/RemoteServiceRequestParser.php' => 'use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;',
                     'src/RemoteEvent/RemoteServiceWebhookConsumer.php' => '#[AsRemoteEventConsumer(\'remote_service\')]',
                 ];
 
-                $this->assertStringContainsString('created: ', $output);
+                self::assertStringContainsString('created: ', $output);
 
                 foreach ($outputExpectations as $expectedFileName => $expectedContent) {
                     $path = $runner->getPath($expectedFileName);
 
-                    $this->assertStringContainsString($expectedFileName, $output);
-                    $this->assertFileExists($runner->getPath($expectedFileName));
-                    $this->assertStringContainsString($expectedContent, file_get_contents($path));
+                    self::assertStringContainsString($expectedFileName, $output);
+                    self::assertFileExists($runner->getPath($expectedFileName));
+                    self::assertStringContainsString($expectedContent, file_get_contents($path));
                 }
 
                 $requestParserSource = file_get_contents($runner->getPath($parserFileName));
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\HttpFoundation\RequestMatcher\PortRequestMatcher;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\HttpFoundation\ChainRequestMatcher;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     <<<EOF
                                 return new ChainRequestMatcher([
                                     new IsJsonRequestMatcher(),
@@ -206,60 +206,60 @@ class MakeWebhookTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_makes_webhook_with_expression_language_injection' => [$this->createMakerTest()
+        yield 'it_makes_webhook_with_expression_language_injection' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/expression-language')
-            ->run(function (MakerTestRunner $runner) {
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'remote_service',  // webhook name
                     '4',               // 'IsJsonRequestMatcher',
                     '1',               // 'ExpressionRequestMatcher',
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
 
                 $outputExpectations = [
                     $parserFileName = 'src/Webhook/RemoteServiceRequestParser.php' => 'use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;',
                     'src/RemoteEvent/RemoteServiceWebhookConsumer.php' => '#[AsRemoteEventConsumer(\'remote_service\')]',
                 ];
 
-                $this->assertStringContainsString('created: ', $output);
+                self::assertStringContainsString('created: ', $output);
 
                 foreach ($outputExpectations as $expectedFileName => $expectedContent) {
                     $path = $runner->getPath($expectedFileName);
 
-                    $this->assertStringContainsString($expectedFileName, $output);
-                    $this->assertFileExists($runner->getPath($expectedFileName));
-                    $this->assertStringContainsString($expectedContent, file_get_contents($path));
+                    self::assertStringContainsString($expectedFileName, $output);
+                    self::assertFileExists($runner->getPath($expectedFileName));
+                    self::assertStringContainsString($expectedContent, file_get_contents($path));
                 }
 
                 $requestParserSource = file_get_contents($runner->getPath($parserFileName));
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\HttpFoundation\ChainRequestMatcher;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\ExpressionLanguage\Expression;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     'use Symfony\Component\ExpressionLanguage\ExpressionLanguage;',
                     $requestParserSource
                 );
 
-                $this->assertStringContainsString(
+                self::assertStringContainsString(
                     <<<EOF
                                 return new ChainRequestMatcher([
                                     new IsJsonRequestMatcher(),

--- a/tests/Maker/Security/MakeCustomAuthenticatorTest.php
+++ b/tests/Maker/Security/MakeCustomAuthenticatorTest.php
@@ -25,18 +25,18 @@ class MakeCustomAuthenticatorTest extends MakerTestCase
         return MakeCustomAuthenticator::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'generates_custom_authenticator' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'generates_custom_authenticator' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([
                     'FixtureAuthenticator', // Authenticator Name
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $fixturePath = \dirname(__DIR__, 2).'/fixtures/security/make-custom-authenticator/expected';
 
-                $this->assertFileEquals($fixturePath.'/FixtureAuthenticator.php', $runner->getPath('src/Security/FixtureAuthenticator.php'));
+                self::assertFileEquals($fixturePath.'/FixtureAuthenticator.php', $runner->getPath('src/Security/FixtureAuthenticator.php'));
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
 

--- a/tests/Maker/Security/MakeFormLoginTest.php
+++ b/tests/Maker/Security/MakeFormLoginTest.php
@@ -26,86 +26,86 @@ class MakeFormLoginTest extends MakerTestCase
         return MakeFormLogin::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'generates_form_login_using_defaults' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'generates_form_login_using_defaults' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'SecurityController', // Controller Name
                     'y', // Generate Logout
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $fixturePath = \dirname(__DIR__, 2).'/fixtures/security/make-form-login/expected';
 
-                $this->assertFileEquals($fixturePath.'/SecurityController.php', $runner->getPath('src/Controller/SecurityController.php'));
-                $this->assertFileEquals($fixturePath.'/login.html.twig', $runner->getPath('templates/security/login.html.twig'));
+                self::assertFileEquals($fixturePath.'/SecurityController.php', $runner->getPath('src/Controller/SecurityController.php'));
+                self::assertFileEquals($fixturePath.'/login.html.twig', $runner->getPath('templates/security/login.html.twig'));
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
 
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
-                $this->assertTrue($securityConfig['security']['firewalls']['main']['form_login']['enable_csrf']);
-                $this->assertSame('app_logout', $securityConfig['security']['firewalls']['main']['logout']['path']);
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
+                self::assertTrue($securityConfig['security']['firewalls']['main']['form_login']['enable_csrf']);
+                self::assertSame('app_logout', $securityConfig['security']['firewalls']['main']['logout']['path']);
 
-                $this->runLoginTest($runner);
+                self::runLoginTest($runner);
             }),
         ];
 
-        yield 'generates_form_login_without_logout' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'generates_form_login_without_logout' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'SecurityController', // Controller Name
                     'n', // Generate Logout
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $fixturePath = \dirname(__DIR__, 2).'/fixtures/security/make-form-login/expected';
 
-                $this->assertFileEquals($fixturePath.'/SecurityControllerWithoutLogout.php', $runner->getPath('src/Controller/SecurityController.php'));
-                $this->assertFileEquals($fixturePath.'/login_no_logout.html.twig', $runner->getPath('templates/security/login.html.twig'));
+                self::assertFileEquals($fixturePath.'/SecurityControllerWithoutLogout.php', $runner->getPath('src/Controller/SecurityController.php'));
+                self::assertFileEquals($fixturePath.'/login_no_logout.html.twig', $runner->getPath('templates/security/login.html.twig'));
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
 
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
-                $this->assertFalse(isset($securityConfig['security']['firewalls']['main']['logout']['path']));
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
+                self::assertFalse(isset($securityConfig['security']['firewalls']['main']['logout']['path']));
             }),
         ];
 
-        yield 'generates_form_login_with_custom_controller_name' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
-                $this->makeUser($runner);
+        yield 'generates_form_login_with_custom_controller_name' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'LoginController', // Controller Name
                     'y', // Generate Logout
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $fixturePath = \dirname(__DIR__, 2).'/fixtures/security/make-form-login/expected';
 
-                $this->assertFileEquals($fixturePath.'/LoginController.php', $runner->getPath('src/Controller/LoginController.php'));
-                $this->assertFileEquals($fixturePath.'/login.html.twig', $runner->getPath('templates/login/login.html.twig'));
+                self::assertFileEquals($fixturePath.'/LoginController.php', $runner->getPath('src/Controller/LoginController.php'));
+                self::assertFileEquals($fixturePath.'/login.html.twig', $runner->getPath('templates/login/login.html.twig'));
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
 
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
-                $this->assertSame('app_logout', $securityConfig['security']['firewalls']['main']['logout']['path']);
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
+                self::assertSame('app_logout', $securityConfig['security']['firewalls']['main']['logout']['path']);
             }),
         ];
 
-        yield 'generates_form_login_using_defaults_with_test' => [$this->createMakerTest()
-            ->run(function (MakerTestRunner $runner) {
+        yield 'generates_form_login_using_defaults_with_test' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
                 // Make the UserPasswordHasherInterface available in the test
                 $runner->renderTemplateFile('security/make-form-login/FixtureController.php', 'src/Controller/FixtureController.php', []);
 
-                $this->makeUser($runner);
+                self::makeUser($runner);
 
                 $output = $runner->runMaker([
                     'SecurityController', // Controller Name
@@ -113,18 +113,18 @@ class MakeFormLoginTest extends MakerTestCase
                     'y', // Generate tests
                 ]);
 
-                $this->assertStringContainsString('Success', $output);
+                self::assertStringContainsString('Success', $output);
                 $fixturePath = \dirname(__DIR__, 2).'/fixtures/security/make-form-login/expected';
 
-                $this->assertFileEquals($fixturePath.'/SecurityController.php', $runner->getPath('src/Controller/SecurityController.php'));
-                $this->assertFileEquals($fixturePath.'/login.html.twig', $runner->getPath('templates/security/login.html.twig'));
+                self::assertFileEquals($fixturePath.'/SecurityController.php', $runner->getPath('src/Controller/SecurityController.php'));
+                self::assertFileEquals($fixturePath.'/login.html.twig', $runner->getPath('templates/security/login.html.twig'));
 
                 $securityConfig = $runner->readYaml('config/packages/security.yaml');
 
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
-                $this->assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
-                $this->assertTrue($securityConfig['security']['firewalls']['main']['form_login']['enable_csrf']);
-                $this->assertSame('app_logout', $securityConfig['security']['firewalls']['main']['logout']['path']);
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['check_path']);
+                self::assertTrue($securityConfig['security']['firewalls']['main']['form_login']['enable_csrf']);
+                self::assertSame('app_logout', $securityConfig['security']['firewalls']['main']['logout']['path']);
 
                 $runner->configureDatabase();
                 $runner->runTests();
@@ -132,7 +132,7 @@ class MakeFormLoginTest extends MakerTestCase
         ];
     }
 
-    private function runLoginTest(MakerTestRunner $runner): void
+    private static function runLoginTest(MakerTestRunner $runner): void
     {
         $fixturePath = 'security/make-form-login/';
 
@@ -154,7 +154,7 @@ class MakeFormLoginTest extends MakerTestCase
         $runner->runTests();
     }
 
-    private function makeUser(MakerTestRunner $runner, string $identifier = 'email'): void
+    private static function makeUser(MakerTestRunner $runner, string $identifier = 'email'): void
     {
         $runner->runConsole('make:user', [
             'User', // Class Name

--- a/tests/Maker/TemplateLinterTest.php
+++ b/tests/Maker/TemplateLinterTest.php
@@ -30,9 +30,9 @@ final class TemplateLinterTest extends MakerTestCase
         return MakeVoter::class;
     }
 
-    public function getTestDetails(): \Generator
+    public static function getTestDetails(): \Generator
     {
-        yield 'lints_templates_with_custom_php_cs_fixer_and_config' => [$this->createMakerTest()
+        yield 'lints_templates_with_custom_php_cs_fixer_and_config' => [self::buildMakerTest()
             ->addExtraDependencies('php-cs-fixer/shim')
             ->run(static function (MakerTestRunner $runner) {
                 $runner->copy('template-linter/php-cs-fixer.test.php', 'php-cs-fixer.test.php');
@@ -58,7 +58,7 @@ final class TemplateLinterTest extends MakerTestCase
             }),
         ];
 
-        yield 'lints_templates_with_flex_generated_config_file' => [$this->createMakerTest()
+        yield 'lints_templates_with_flex_generated_config_file' => [self::buildMakerTest()
             ->addExtraDependencies('php-cs-fixer/shim')
             ->run(static function (MakerTestRunner $runner) {
                 $runner->replaceInFile(
@@ -84,7 +84,7 @@ final class TemplateLinterTest extends MakerTestCase
             }),
         ];
 
-        yield 'lints_templates_with_bundled_php_cs_fixer' => [$this->createMakerTest()
+        yield 'lints_templates_with_bundled_php_cs_fixer' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 // Voter class name
                 $output = $runner->runMaker(['FooBar']);

--- a/tests/RegexTest.php
+++ b/tests/RegexTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Maker\MakeWebhook;
 use Symfony\Bundle\MakerBundle\Test\MakerTestEnvironment;
@@ -26,6 +27,7 @@ use Symfony\Bundle\MakerBundle\Test\MakerTestEnvironment;
 class RegexTest extends TestCase
 {
     /** @dataProvider generatedFilesRegexDataProvider */
+    #[DataProvider('generatedFilesRegexDataProvider')]
     public function testMakerTestEnvironmentGeneratedFilesRegex(string $subjectData, array $expectedResult)
     {
         $result = [];
@@ -35,7 +37,7 @@ class RegexTest extends TestCase
         self::assertSame($expectedResult, $result[1]);
     }
 
-    private function generatedFilesRegexDataProvider(): \Generator
+    public static function generatedFilesRegexDataProvider(): \Generator
     {
         yield 'Created Prefix' => ['created: test/something.php', ['test/something.php']];
         yield 'Updated Prefix' => ['updated: test/something.php', ['test/something.php']];
@@ -69,6 +71,7 @@ class RegexTest extends TestCase
     }
 
     /** @dataProvider webhookNameRegexDataProvider */
+    #[DataProvider('webhookNameRegexDataProvider')]
     public function testWebhookNameRegex(string $subjectData, bool $expectedResult)
     {
         $result = preg_match(MakeWebhook::WEBHOOK_NAME_PATTERN, $subjectData);
@@ -76,7 +79,7 @@ class RegexTest extends TestCase
         self::assertSame($expectedResult, (bool) $result);
     }
 
-    private function webhookNameRegexDataProvider(): \Generator
+    public static function webhookNameRegexDataProvider(): \Generator
     {
         // Valid cases
         yield 'Simple word' => ['mywebhook', true];

--- a/tests/Security/InteractiveSecurityHelperTest.php
+++ b/tests/Security/InteractiveSecurityHelperTest.php
@@ -37,7 +37,7 @@ class InteractiveSecurityHelperTest extends TestCase
         );
     }
 
-    public function getFirewallNameTests()
+    public static function getFirewallNameTests()
     {
         yield 'empty_security' => [
             [],
@@ -95,7 +95,7 @@ class InteractiveSecurityHelperTest extends TestCase
         );
     }
 
-    public function getUserClassTests()
+    public static function getUserClassTests()
     {
         yield 'user_from_provider' => [
             ['app_provider' => ['entity' => ['class' => 'App\\Entity\\User']]],
@@ -135,7 +135,7 @@ class InteractiveSecurityHelperTest extends TestCase
         );
     }
 
-    public function getUsernameFieldsTest()
+    public static function getUsernameFieldsTest()
     {
         yield 'guess_with_providers' => [
             'providers' => ['app_provider' => ['entity' => ['property' => 'userEmail']]],
@@ -192,7 +192,7 @@ class InteractiveSecurityHelperTest extends TestCase
         );
     }
 
-    public function guessEmailFieldTest()
+    public static function guessEmailFieldTest()
     {
         yield 'guess_fixture_class' => [
             'expectedEmailField' => 'email',
@@ -217,7 +217,7 @@ class InteractiveSecurityHelperTest extends TestCase
         self::assertEquals($expectedResults, $result);
     }
 
-    public function authenticatorClassProvider(): \Generator
+    public static function authenticatorClassProvider(): \Generator
     {
         yield 'Only Custom Authenticator' => [
             [
@@ -294,7 +294,7 @@ class InteractiveSecurityHelperTest extends TestCase
         );
     }
 
-    public function guessPasswordSetterTest()
+    public static function guessPasswordSetterTest()
     {
         yield 'guess_fixture_class' => [
             'expectedPasswordSetter' => 'setPassword',
@@ -329,7 +329,7 @@ class InteractiveSecurityHelperTest extends TestCase
         );
     }
 
-    public function guessEmailGetterTest()
+    public static function guessEmailGetterTest()
     {
         yield 'guess_fixture_class' => [
             'expectedPasswordSetter' => 'getEmail',

--- a/tests/Security/SecurityConfigUpdaterTest.php
+++ b/tests/Security/SecurityConfigUpdaterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Security;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\MakerBundle\Security\SecurityConfigUpdater;
@@ -29,6 +30,7 @@ class SecurityConfigUpdaterTest extends TestCase
     /**
      * @dataProvider getUserClassTests
      */
+    #[DataProvider('getUserClassTests')]
     public function testUpdateForUserClass(UserClassConfiguration $userConfig, string $expectedSourceFilename, string $startingSourceFilename = 'simple_security.yaml')
     {
         $this->createLogger();
@@ -48,7 +50,7 @@ class SecurityConfigUpdaterTest extends TestCase
         $this->assertSame($expectedSource, $actualSource);
     }
 
-    public function getUserClassTests(): \Generator
+    public static function getUserClassTests(): \Generator
     {
         yield 'entity_email_password' => [
             new UserClassConfiguration(true, 'email', true),
@@ -104,6 +106,7 @@ class SecurityConfigUpdaterTest extends TestCase
     /**
      * @dataProvider getAuthenticatorTests
      */
+    #[DataProvider('getAuthenticatorTests')]
     public function testUpdateForAuthenticator(string $firewallName, $entryPoint, string $expectedSourceFilename, string $startingSourceFilename, bool $logoutSetup, bool $supportRememberMe, bool $alwaysRememberMe)
     {
         $this->createLogger();
@@ -116,7 +119,7 @@ class SecurityConfigUpdaterTest extends TestCase
         $this->assertSame($expectedSource, $actualSource);
     }
 
-    public function getAuthenticatorTests(): \Generator
+    public static function getAuthenticatorTests(): \Generator
     {
         yield 'empty_source' => [
             'main',

--- a/tests/Security/UserClassBuilderTest.php
+++ b/tests/Security/UserClassBuilderTest.php
@@ -44,7 +44,7 @@ class UserClassBuilderTest extends TestCase
         self::assertSame($expectedSource, $manipulator->getSourceCode());
     }
 
-    public function getUserInterfaceTests(): \Generator
+    public static function getUserInterfaceTests(): \Generator
     {
         yield 'entity_with_email_as_identifier' => [
             new UserClassConfiguration(true, 'email', true),

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -11,42 +11,48 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Str;
 
 class StrTest extends TestCase
 {
     /** @dataProvider provideHasSuffix */
+    #[DataProvider('provideHasSuffix')]
     public function testHasSuffix($value, $suffix, $expectedResult)
     {
         $this->assertSame($expectedResult, Str::hasSuffix($value, $suffix));
     }
 
     /** @dataProvider provideAddSuffix */
+    #[DataProvider('provideAddSuffix')]
     public function testAddSuffix($value, $suffix, $expectedResult)
     {
         $this->assertSame($expectedResult, Str::addSuffix($value, $suffix));
     }
 
     /** @dataProvider provideRemoveSuffix */
+    #[DataProvider('provideRemoveSuffix')]
     public function testRemoveSuffix($value, $suffix, $expectedResult)
     {
         $this->assertSame($expectedResult, Str::removeSuffix($value, $suffix));
     }
 
     /** @dataProvider provideAsClassName */
+    #[DataProvider('provideAsClassName')]
     public function testAsClassName($value, $suffix, $expectedResult)
     {
         $this->assertSame($expectedResult, Str::asClassName($value, $suffix));
     }
 
     /** @dataProvider provideAsTwigVariable */
+    #[DataProvider('provideAsTwigVariable')]
     public function testAsTwigVariable($value, $expectedResult)
     {
         $this->assertSame($expectedResult, Str::asTwigVariable($value));
     }
 
-    public function provideHasSuffix()
+    public static function provideHasSuffix()
     {
         yield ['', '', true];
         yield ['GenerateCommand', '', false];
@@ -58,7 +64,7 @@ class StrTest extends TestCase
         yield ['Generate', 'Command', false];
     }
 
-    public function provideAddSuffix()
+    public static function provideAddSuffix()
     {
         yield ['', '', ''];
         yield ['GenerateCommand', '', 'GenerateCommand'];
@@ -72,7 +78,7 @@ class StrTest extends TestCase
         yield ['Generate', 'Command', 'GenerateCommand'];
     }
 
-    public function provideRemoveSuffix()
+    public static function provideRemoveSuffix()
     {
         yield ['', '', ''];
         yield ['GenerateCommand', '', 'GenerateCommand'];
@@ -85,7 +91,7 @@ class StrTest extends TestCase
         yield ['Generate', 'Command', 'Generate'];
     }
 
-    public function provideAsClassName()
+    public static function provideAsClassName()
     {
         yield ['', '', ''];
         yield ['GenerateCommand', '', 'GenerateCommand'];
@@ -98,7 +104,7 @@ class StrTest extends TestCase
         yield ['app:generate:command', 'Command', 'AppGenerateCommand'];
     }
 
-    public function provideAsTwigVariable()
+    public static function provideAsTwigVariable()
     {
         yield ['', '', ''];
         yield ['GenerateCommand', 'generate_command'];
@@ -112,12 +118,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider getCamelCaseToPluralCamelCaseTests
      */
+    #[DataProvider('getCamelCaseToPluralCamelCaseTests')]
     public function testCamelCaseToPluralCamelCase(string $original, string $expected)
     {
         $this->assertSame(Str::singularCamelCaseToPluralCamelCase($original), $expected);
     }
 
-    public function getCamelCaseToPluralCamelCaseTests()
+    public static function getCamelCaseToPluralCamelCaseTests()
     {
         yield ['bar', 'bars'];
         yield ['fooBar', 'fooBars'];
@@ -128,12 +135,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider getPluralCamelCaseToSingularTests
      */
+    #[DataProvider('getPluralCamelCaseToSingularTests')]
     public function testPluralCamelCaseToSingular(string $original, string $expected)
     {
         $this->assertSame(Str::pluralCamelCaseToSingular($original), $expected);
     }
 
-    public function getPluralCamelCaseToSingularTests()
+    public static function getPluralCamelCaseToSingularTests()
     {
         yield ['bar', 'bar'];
         yield ['bars', 'bar'];
@@ -145,12 +153,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider getNamespaceTests
      */
+    #[DataProvider('getNamespaceTests')]
     public function testGetNamespace(string $fullClassName, string $expectedNamespace)
     {
         $this->assertSame($expectedNamespace, Str::getNamespace($fullClassName));
     }
 
-    public function getNamespaceTests()
+    public static function getNamespaceTests()
     {
         yield ['App\\Entity\\Foo', 'App\\Entity'];
         yield ['DateTime', ''];
@@ -159,12 +168,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider getAsCamelCaseTests
      */
+    #[DataProvider('getAsCamelCaseTests')]
     public function testAsCamelCase(string $original, string $expected)
     {
         $this->assertSame($expected, Str::asCamelCase($original));
     }
 
-    public function getAsCamelCaseTests()
+    public static function getAsCamelCaseTests()
     {
         yield ['foo', 'Foo'];
 
@@ -174,12 +184,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider getShortClassNameCaseTests
      */
+    #[DataProvider('getShortClassNameCaseTests')]
     public function testShortClassName(string $original, string $expected)
     {
         $this->assertSame($expected, Str::getShortClassName($original));
     }
 
-    public function getShortClassNameCaseTests()
+    public static function getShortClassNameCaseTests()
     {
         yield ['App\\Entity\\Foo', 'Foo'];
         yield ['Foo', 'Foo'];
@@ -188,12 +199,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider getHumanDiscriminatorBetweenTwoClassesTests
      */
+    #[DataProvider('getHumanDiscriminatorBetweenTwoClassesTests')]
     public function testHumanDiscriminatorBetweenTwoClasses(string $className, string $classNameOther, array $expected)
     {
         $this->assertSame($expected, Str::getHumanDiscriminatorBetweenTwoClasses($className, $classNameOther));
     }
 
-    public function getHumanDiscriminatorBetweenTwoClassesTests()
+    public static function getHumanDiscriminatorBetweenTwoClassesTests()
     {
         yield ['\\User', 'App\\Entity\\User', ['', 'App\\Entity']];
         yield ['App\\Entity\\User', 'App\\Entity\\Friend\\User', ['', 'Friend']];
@@ -206,12 +218,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider asHumanWordsTests
      */
+    #[DataProvider('asHumanWordsTests')]
     public function testAsHumanWords(string $original, string $expected)
     {
         $this->assertSame($expected, Str::asHumanWords($original));
     }
 
-    public function asHumanWordsTests()
+    public static function asHumanWordsTests()
     {
         yield ['fooBar', 'Foo Bar'];
         yield ['FooBar', 'Foo Bar'];
@@ -222,12 +235,13 @@ class StrTest extends TestCase
     /**
      * @dataProvider provideAsRouteName
      */
+    #[DataProvider('provideAsRouteName')]
     public function testAsRouteName(string $value, string $expectedRouteName)
     {
         $this->assertSame($expectedRouteName, Str::asRouteName($value));
     }
 
-    public function provideAsRouteName()
+    public static function provideAsRouteName()
     {
         yield ['Example', 'app_example'];
         yield ['AppExample', 'app_example'];

--- a/tests/Test/MakerTestDetailsTest.php
+++ b/tests/Test/MakerTestDetailsTest.php
@@ -27,8 +27,8 @@ class MakerTestDetailsTest extends TestCase
 {
     public function testAddExtraDependencies()
     {
-        $details = new MakerTestDetails($this->createMock(MakerInterface::class));
-
+        $details = new MakerTestDetails();
+        $details->setMaker($this->createMock(MakerInterface::class));
         $details->addExtraDependencies('twig');
 
         self::assertSame(['twig'], $details->getExtraDependencies());
@@ -40,8 +40,8 @@ class MakerTestDetailsTest extends TestCase
 
     public function testAddRequiredPackageVersions()
     {
-        $details = new MakerTestDetails($this->createMock(MakerInterface::class));
-
+        $details = new MakerTestDetails();
+        $details->setMaker($this->createMock(MakerInterface::class));
         $details->addRequiredPackageVersion('twig', '4.x');
 
         self::assertSame([['name' => 'twig', 'version_constraint' => '4.x']], $details->getRequiredPackageVersions());
@@ -55,8 +55,8 @@ class MakerTestDetailsTest extends TestCase
 
     public function testGetDependencies()
     {
-        $details = new MakerTestDetails(new TestMakerFixture());
-
+        $details = new MakerTestDetails();
+        $details->setMaker(new TestMakerFixture());
         $details->addExtraDependencies('twig');
 
         self::assertSame(['security', 'router', 'twig'], $details->getDependencies());

--- a/tests/Util/ClassSource/ClassDataTest.php
+++ b/tests/Util/ClassSource/ClassDataTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util\ClassSource;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\MakerBundle\Test\MakerTestKernel;
@@ -57,6 +58,7 @@ class ClassDataTest extends TestCase
     }
 
     /** @dataProvider suffixDataProvider */
+    #[DataProvider('suffixDataProvider')]
     public function testSuffix(?string $suffix, string $expectedResult)
     {
         $data = ClassData::create(class: MakerBundle::class, suffix: $suffix);
@@ -64,7 +66,7 @@ class ClassDataTest extends TestCase
         self::assertSame($expectedResult, $data->getClassName());
     }
 
-    public function suffixDataProvider(): \Generator
+    public static function suffixDataProvider(): \Generator
     {
         yield [null, 'MakerBundle'];
         yield ['Testing', 'MakerBundleTesting'];
@@ -72,6 +74,7 @@ class ClassDataTest extends TestCase
     }
 
     /** @dataProvider namespaceDataProvider */
+    #[DataProvider('namespaceDataProvider')]
     public function testNamespace(string $class, ?string $rootNamespace, string $expectedNamespace, string $expectedFullClassName)
     {
         $class = ClassData::create($class);
@@ -84,7 +87,7 @@ class ClassDataTest extends TestCase
         self::assertSame($expectedFullClassName, $class->getFullClassName());
     }
 
-    public function namespaceDataProvider(): \Generator
+    public static function namespaceDataProvider(): \Generator
     {
         yield ['MyController', null, 'App', 'App\MyController'];
         yield ['Controller\MyController', null, 'App\Controller', 'App\Controller\MyController'];
@@ -121,6 +124,7 @@ class ClassDataTest extends TestCase
     }
 
     /** @dataProvider fullClassNameProvider */
+    #[DataProvider('fullClassNameProvider')]
     public function testGetFullClassName(string $class, ?string $rootNamespace, bool $withoutRootNamespace, bool $withoutSuffix, string $expectedFullClassName)
     {
         $class = ClassData::create($class, suffix: 'Controller');
@@ -132,7 +136,7 @@ class ClassDataTest extends TestCase
         self::assertSame($expectedFullClassName, $class->getFullClassName(withoutRootNamespace: $withoutRootNamespace, withoutSuffix: $withoutSuffix));
     }
 
-    public function fullClassNameProvider(): \Generator
+    public static function fullClassNameProvider(): \Generator
     {
         yield ['Controller\MyController', null, false, false, 'App\Controller\MyController'];
         yield ['Controller\MyController', null, true, false, 'Controller\MyController'];

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\FieldMapping;
 use PhpParser\Builder\Param;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToMany;
 use Symfony\Bundle\MakerBundle\Doctrine\RelationManyToOne;
@@ -29,6 +30,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddPropertyTests
      */
+    #[DataProvider('getAddPropertyTests')]
     public function testAddProperty(string $sourceFilename, $propertyName, array $commentLines, $expectedSourceFilename)
     {
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
@@ -40,7 +42,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
     }
 
-    public function getAddPropertyTests(): \Generator
+    public static function getAddPropertyTests(): \Generator
     {
         yield 'normal_property_add' => [
             'User_simple.php',
@@ -77,6 +79,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddGetterTests
      */
+    #[DataProvider('getAddGetterTests')]
     public function testAddGetter(string $sourceFilename, string $propertyName, string $type, array $commentLines, $expectedSourceFilename)
     {
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
@@ -88,7 +91,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
     }
 
-    public function getAddGetterTests(): \Generator
+    public static function getAddGetterTests(): \Generator
     {
         yield 'normal_getter_add' => [
             'User_simple.php',
@@ -145,6 +148,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddSetterTests
      */
+    #[DataProvider('getAddSetterTests')]
     public function testAddSetter(string $sourceFilename, string $propertyName, ?string $type, bool $isNullable, array $commentLines, $expectedSourceFilename)
     {
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
@@ -156,7 +160,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expectedSource, $manipulator->getSourceCode());
     }
 
-    public function getAddSetterTests(): \Generator
+    public static function getAddSetterTests(): \Generator
     {
         yield 'normal_setter_add' => [
             'User_simple.php',
@@ -210,6 +214,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAttributeClassTests
      */
+    #[DataProvider('getAttributeClassTests')]
     public function testAddAttributeToClass(string $sourceFilename, string $expectedSourceFilename, string $attributeClass, array $attributeOptions, ?string $attributePrefix = null)
     {
         $source = file_get_contents(__DIR__.'/fixtures/source/'.$sourceFilename);
@@ -220,7 +225,7 @@ class ClassSourceManipulatorTest extends TestCase
         self::assertSame($expectedSource, $manipulator->getSourceCode());
     }
 
-    public function getAttributeClassTests(): \Generator
+    public static function getAttributeClassTests(): \Generator
     {
         yield 'Empty class' => [
             'User_empty.php',
@@ -240,6 +245,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddEntityFieldTests
      */
+    #[DataProvider('getAddEntityFieldTests')]
     public function testAddEntityField(string $sourceFilename, ClassProperty $propertyModel, $expectedSourceFilename)
     {
         $sourcePath = __DIR__.'/fixtures/source';
@@ -260,7 +266,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expected, $manipulator->getSourceCode());
     }
 
-    public function getAddEntityFieldTests(): \Generator
+    public static function getAddEntityFieldTests(): \Generator
     {
         /** @legacy - Remove when Doctrine/ORM 2.x is no longer supported. */
         $isLegacy = !class_exists(FieldMapping::class);
@@ -311,6 +317,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddManyToOneRelationTests
      */
+    #[DataProvider('getAddManyToOneRelationTests')]
     public function testAddManyToOneRelation(string $sourceFilename, $expectedSourceFilename, RelationManyToOne $manyToOne)
     {
         $sourcePath = __DIR__.'/fixtures/source';
@@ -331,7 +338,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expected, $manipulator->getSourceCode());
     }
 
-    public function getAddManyToOneRelationTests(): \Generator
+    public static function getAddManyToOneRelationTests(): \Generator
     {
         yield 'many_to_one_not_nullable' => [
             'User_simple.php',
@@ -409,6 +416,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddOneToManyRelationTests
      */
+    #[DataProvider('getAddOneToManyRelationTests')]
     public function testAddOneToManyRelation(string $sourceFilename, string $expectedSourceFilename, RelationOneToMany $oneToMany)
     {
         $sourcePath = __DIR__.'/fixtures/source';
@@ -434,7 +442,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expected, $manipulator->getSourceCode());
     }
 
-    public function getAddOneToManyRelationTests(): \Generator
+    public static function getAddOneToManyRelationTests(): \Generator
     {
         yield 'one_to_many_simple' => [
             'User_simple.php',
@@ -475,6 +483,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddManyToManyRelationTests
      */
+    #[DataProvider('getAddManyToManyRelationTests')]
     public function testAddManyToManyRelation(string $sourceFilename, $expectedSourceFilename, RelationManyToMany $manyToMany)
     {
         $sourcePath = __DIR__.'/fixtures/source';
@@ -495,7 +504,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expected, $manipulator->getSourceCode());
     }
 
-    public function getAddManyToManyRelationTests(): \Generator
+    public static function getAddManyToManyRelationTests(): \Generator
     {
         yield 'many_to_many_owning' => [
             'User_simple.php',
@@ -534,6 +543,7 @@ class ClassSourceManipulatorTest extends TestCase
     /**
      * @dataProvider getAddOneToOneRelationTests
      */
+    #[DataProvider('getAddOneToOneRelationTests')]
     public function testAddOneToOneRelation(string $sourceFilename, $expectedSourceFilename, RelationOneToOne $oneToOne)
     {
         $sourcePath = __DIR__.'/fixtures/source';
@@ -554,7 +564,7 @@ class ClassSourceManipulatorTest extends TestCase
         $this->assertSame($expected, $manipulator->getSourceCode());
     }
 
-    public function getAddOneToOneRelationTests(): \Generator
+    public static function getAddOneToOneRelationTests(): \Generator
     {
         /** @legacy - Remove when Doctrine/ORM 2.x is no longer supported. */
         $isLegacy = !class_exists(FieldMapping::class);

--- a/tests/Util/ComposerAutoloaderFinderTest.php
+++ b/tests/Util/ComposerAutoloaderFinderTest.php
@@ -29,7 +29,7 @@ class ComposerAutoloaderFinderTest extends TestCase
         self::$getSplAutoloadFunctions = 'spl_autoload_functions';
     }
 
-    public function providerNamespaces(): \Generator
+    public static function providerNamespaces(): \Generator
     {
         yield 'Configured PSR-0' => [rtrim(static::$rootNamespace, '\\'), null];
         yield 'Configured PSR-4' => [null, static::$rootNamespace];

--- a/tests/Util/MakerFileLinkFormatterTest.php
+++ b/tests/Util/MakerFileLinkFormatterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
@@ -18,7 +19,7 @@ use Symfony\Component\HttpKernel\Debug\FileLinkFormatter as LegacyFileLinkFormat
 
 final class MakerFileLinkFormatterTest extends TestCase
 {
-    public function provideMakeLinkedPath(): \Generator
+    public static function provideMakeLinkedPath(): \Generator
     {
         yield 'no_formatter' => [false, false, './my/relative/path'];
         yield 'with_formatter' => [
@@ -32,6 +33,7 @@ final class MakerFileLinkFormatterTest extends TestCase
     /**
      * @dataProvider provideMakeLinkedPath
      */
+    #[DataProvider('provideMakeLinkedPath')]
     public function testMakeLinkedPath(bool $withFileLinkFormatter, bool $linkFormatterReturnsLink, string $expectedOutput)
     {
         if (getenv('MAKER_DISABLE_FILE_LINKS')) {

--- a/tests/Util/TemplateComponentGeneratorTest.php
+++ b/tests/Util/TemplateComponentGeneratorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
@@ -33,6 +34,7 @@ class TemplateComponentGeneratorTest extends TestCase
     /**
      * @dataProvider routeMethodDataProvider
      */
+    #[DataProvider('routeMethodDataProvider')]
     public function testRouteMethods(string $expected, array $methods)
     {
         $generator = new TemplateComponentGenerator(false, false, 'App');
@@ -44,7 +46,7 @@ class TemplateComponentGeneratorTest extends TestCase
         ));
     }
 
-    public function routeMethodDataProvider(): \Generator
+    public static function routeMethodDataProvider(): \Generator
     {
         yield ["    #[Route('/', name: 'app_home', methods: ['GET'])]\n", ['GET']];
         yield ["    #[Route('/', name: 'app_home', methods: ['GET', 'POST'])]\n", ['GET', 'POST']];
@@ -53,6 +55,7 @@ class TemplateComponentGeneratorTest extends TestCase
     /**
      * @dataProvider routeIndentationDataProvider
      */
+    #[DataProvider('routeIndentationDataProvider')]
     public function testRouteIndentation(string $expected)
     {
         $generator = new TemplateComponentGenerator(false, false, 'App');
@@ -65,7 +68,7 @@ class TemplateComponentGeneratorTest extends TestCase
         ));
     }
 
-    public function routeIndentationDataProvider(): \Generator
+    public static function routeIndentationDataProvider(): \Generator
     {
         yield ["#[Route('/', name: 'app_home')]\n"];
     }
@@ -73,6 +76,7 @@ class TemplateComponentGeneratorTest extends TestCase
     /**
      * @dataProvider routeTrailingNewLineDataProvider
      */
+    #[DataProvider('routeTrailingNewLineDataProvider')]
     public function testRouteTrailingNewLine(string $expected)
     {
         $generator = new TemplateComponentGenerator(false, false, 'App');
@@ -86,7 +90,7 @@ class TemplateComponentGeneratorTest extends TestCase
         ));
     }
 
-    public function routeTrailingNewLineDataProvider(): \Generator
+    public static function routeTrailingNewLineDataProvider(): \Generator
     {
         yield ["#[Route('/', name: 'app_home')]", true];
     }
@@ -94,6 +98,7 @@ class TemplateComponentGeneratorTest extends TestCase
     /**
      * @dataProvider finalClassDataProvider
      */
+    #[DataProvider('finalClassDataProvider')]
     public function testGetFinalClassDeclaration(bool $finalClass, bool $finalEntity, bool $isEntity, string $expectedResult)
     {
         $generator = new TemplateComponentGenerator($finalClass, $finalEntity, 'App');
@@ -105,7 +110,7 @@ class TemplateComponentGeneratorTest extends TestCase
         self::assertSame(\sprintf('%sclass MakerBundle', $expectedResult), $classData->getClassDeclaration());
     }
 
-    public function finalClassDataProvider(): \Generator
+    public static function finalClassDataProvider(): \Generator
     {
         yield 'Not Final Class' => [false, false, false, ''];
         yield 'Not Final Class w/ Entity' => [false, true, false, ''];

--- a/tests/Util/YamlSourceManipulatorTest.php
+++ b/tests/Util/YamlSourceManipulatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
@@ -24,6 +25,8 @@ class YamlSourceManipulatorTest extends TestCase
      * @dataProvider getYamlDataTestsUnixSlashes
      * @dataProvider getYamlDataTestsWindowsSlashes
      */
+    #[DataProvider('getYamlDataTestsUnixSlashes')]
+    #[DataProvider('getYamlDataTestsWindowsSlashes')]
     public function testSetData(string $startingSource, array $newData, string $expectedSource)
     {
         $manipulator = new YamlSourceManipulator($startingSource);
@@ -48,7 +51,7 @@ class YamlSourceManipulatorTest extends TestCase
         $this->assertSame($expectedSource, $actualContents);
     }
 
-    private function getYamlDataTests(): \Generator
+    private static function getYamlDataTests(): \Generator
     {
         $finder = new Finder();
         $finder->in(__DIR__.'/yaml_fixtures')
@@ -66,7 +69,7 @@ class YamlSourceManipulatorTest extends TestCase
             eval($changeCode);
 
             yield $file->getFilename() => [
-                'source' => $source,
+                'startingSource' => $source,
                 'newData' => $data,
                 'expectedSource' => $expected,
             ];
@@ -82,17 +85,17 @@ class YamlSourceManipulatorTest extends TestCase
          */
     }
 
-    public function getYamlDataTestsUnixSlashes(): \Generator
+    public static function getYamlDataTestsUnixSlashes(): \Generator
     {
-        foreach ($this->getYamlDataTests() as $key => $data) {
+        foreach (self::getYamlDataTests() as $key => $data) {
             yield 'unix_'.$key => $data;
         }
     }
 
-    public function getYamlDataTestsWindowsSlashes(): \Generator
+    public static function getYamlDataTestsWindowsSlashes(): \Generator
     {
-        foreach ($this->getYamlDataTests() as $key => $data) {
-            $data['source'] = str_replace("\n", "\r\n", $data['source']);
+        foreach (self::getYamlDataTests() as $key => $data) {
+            $data['startingSource'] = str_replace("\n", "\r\n", $data['startingSource']);
 
             yield 'windows_'.$key => $data;
         }


### PR DESCRIPTION
- Run tests with PHPUnit 11
- Add PHPUnit attributes, in addition to annotations

Making all the data providers static require to make many other methods static in the `tests` directory.

The main point is the `MakerTestCase` that is part of the API and is extended in other projects. Creating a new class is the only way to change abstract methods from non-static to static in a BC way.