### PR TITLE
Use named arguments to create form constraints

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -559,9 +559,9 @@ final class MakeRegistrationForm extends AbstractMaker
                 'options_code' => <<<EOF
                                     'mapped' => false,
                                     'constraints' => [
-                                        new IsTrue([
-                                            'message' => 'You should agree to our terms.',
-                                        ]),
+                                        new IsTrue(
+                                            message: 'You should agree to our terms.',
+                                        ),
                                     ],
                     EOF
             ],
@@ -573,15 +573,15 @@ final class MakeRegistrationForm extends AbstractMaker
                                     'mapped' => false,
                                     'attr' => ['autocomplete' => 'new-password'],
                                     'constraints' => [
-                                        new NotBlank([
-                                            'message' => 'Please enter a password',
-                                        ]),
-                                        new Length([
-                                            'min' => 6,
-                                            'minMessage' => 'Your password should be at least {{ limit }} characters',
+                                        new NotBlank(
+                                            message: 'Please enter a password',
+                                        ),
+                                        new Length(
+                                            min: 6,
+                                            minMessage: 'Your password should be at least {{ limit }} characters',
                                             // max length allowed by Symfony for security reasons
-                                            'max' => 4096,
-                                        ]),
+                                            max: 4096,
+                                        ),
                                     ],
                     EOF
             ],

--- a/templates/resetPassword/ChangePasswordFormType.tpl.php
+++ b/templates/resetPassword/ChangePasswordFormType.tpl.php
@@ -18,15 +18,15 @@ class <?= $class_name ?> extends AbstractType
                 ],
                 'first_options' => [
                     'constraints' => [
-                        new NotBlank([
-                            'message' => 'Please enter a password',
-                        ]),
-                        new Length([
-                            'min' => 12,
-                            'minMessage' => 'Your password should be at least {{ limit }} characters',
+                        new NotBlank(
+                            message: 'Please enter a password',
+                        ),
+                        new Length(
+                            min: 12,
+                            minMessage: 'Your password should be at least {{ limit }} characters',
                             // max length allowed by Symfony for security reasons
-                            'max' => 4096,
-                        ]),
+                            max: 4096,
+                        ),
                         new PasswordStrength(),
                         new NotCompromisedPassword(),
                     ],

--- a/templates/resetPassword/ResetPasswordRequestFormType.tpl.php
+++ b/templates/resetPassword/ResetPasswordRequestFormType.tpl.php
@@ -12,9 +12,9 @@ class <?= $class_name ?> extends AbstractType
             ->add('<?= $email_field ?>', EmailType::class, [
                 'attr' => ['autocomplete' => 'email'],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'Please enter your email',
-                    ]),
+                    new NotBlank(
+                        message: 'Please enter your email',
+                    ),
                 ],
             ])
         ;


### PR DESCRIPTION
Named arguments on validation constraints are supported since Symfony 5.2, and the `$options` array is deprecated since Symfony 7.3.

This is required for the compatibility with Symfony 8.0