### PR TITLE
Fix configuration in tests for DoctrineBundle v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "composer/semver": "^3.0",
-        "doctrine/doctrine-bundle": "^2.5.0|^3.0.0",
+        "doctrine/doctrine-bundle": "^2.10|^3.0",
         "doctrine/orm": "^2.15|^3",
         "doctrine/persistence": "^3.1|^4.0",
         "symfony/http-client": "^6.4|^7.0|^8.0",

--- a/tests/Doctrine/EntityRegeneratorTest.php
+++ b/tests/Doctrine/EntityRegeneratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Tests\Doctrine;
 
 use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -175,13 +176,12 @@ class TestEntityRegeneratorKernel extends Kernel
             ],
         ];
 
-        if (null !== $doctrineBundleVersion = InstalledVersions::getVersion('doctrine/doctrine-bundle')) {
-            if (version_compare($doctrineBundleVersion, '2.8.0', '>=')) {
-                $orm['enable_lazy_ghost_objects'] = true;
-            }
-            if (\PHP_VERSION_ID >= 80400 && version_compare($doctrineBundleVersion, '2.15.0', '>=')) {
-                $orm['enable_native_lazy_objects'] = true;
-            }
+        if (InstalledVersions::satisfies(new VersionParser(), 'doctrine/doctrine-bundle', '^2.8')) {
+            $orm['enable_lazy_ghost_objects'] = true;
+        }
+
+        if (\PHP_VERSION_ID >= 80400 && InstalledVersions::satisfies(new VersionParser(), 'doctrine/doctrine-bundle', '^2.15')) {
+            $orm['enable_native_lazy_objects'] = true;
         }
 
         $c->prependExtensionConfig('doctrine', [


### PR DESCRIPTION
Options `enable_native_lazy_objects` and `enable_native_lazy_objects` are removed from DoctrineBundle v3. They cannot be set.