### PR TITLE
Remove the flex project dir when its creation fails

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -138,7 +138,13 @@ final class MakerTestEnvironment
         }
 
         if (!$this->fs->exists($this->flexPath)) {
-            $this->buildFlexSkeleton();
+            try {
+                $this->buildFlexSkeleton();
+            } catch (\Exception $e) {
+                $this->fs->remove($this->flexPath);
+
+                throw $e;
+            }
         }
 
         if (!$this->fs->exists($this->path)) {


### PR DESCRIPTION
Otherwise the next phpunit run assumes the directory has been correctly created.

This is the same pattern applied to the temporary project path just bellow.