### PR TITLE
Remove phpunit-bridge symlink

### DIFF
--- a/src/Test/MakerTestEnvironment.php
+++ b/src/Test/MakerTestEnvironment.php
@@ -269,12 +269,6 @@ final class MakerTestEnvironment
         MakerTestProcess::create('composer require phpunit:1.1.* browser-kit symfony/css-selector --prefer-dist --no-progress --no-suggest', $this->flexPath)
                         ->run();
 
-        if (!$this->isWindows) {
-            $this->fs->remove($this->flexPath.'/vendor/symfony/phpunit-bridge');
-
-            $this->fs->symlink($rootPath.'/vendor/symfony/phpunit-bridge', $this->flexPath.'/vendor/symfony/phpunit-bridge');
-        }
-
         $replacements = [
             // temporarily ignoring indirect deprecations - see #237
             [


### PR DESCRIPTION
Tests in temporary projects are run in a distinct php process.

The context in which the tests are performed is different to what is stated in this comment: https://github.com/symfony/maker-bundle/pull/480#discussion_r336846295

Also, that remove the requirement of `symfony/phpunit-bridge` for projects using the MakerTestCase.