### PR TITLE
Specify EntityRepository type in generated tests

### DIFF
--- a/templates/crud/test/Test.EntityManager.tpl.php
+++ b/templates/crud/test/Test.EntityManager.tpl.php
@@ -10,6 +10,7 @@ namespace <?= $namespace ?>;
 {
     private KernelBrowser $client;
     private EntityManagerInterface $manager;
+    /** @var EntityRepository<<?= $entity_class_name; ?>> $<?= lcfirst($entity_var_singular); ?>Repository */
     private EntityRepository $<?= lcfirst($entity_var_singular); ?>Repository;
     private string $path = '<?= $route_path; ?>/';
 


### PR DESCRIPTION
This PR aims to resolve a PHPStan issue and provide more context for IDE. This will improve DX.

It resolves the following PHPStan issue:

```
  15     Property App\Tests\Controller\FooControllerTest::$fooRepository with generic class Doctrine\ORM\EntityRepository does not specify its types: T  
         🪪  missingType.generics
```