### PR TITLE
[make:entity] Specify more types categories

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -292,7 +292,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
                         break;
                     default:
-                        throw new \Exception('Invalid relation type');
+                        throw new \Exception('Invalid relation type.');
                 }
 
                 // save the inverse side if it's being mapped
@@ -454,24 +454,33 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
                 'text' => [],
                 'boolean' => [],
                 'integer' => ['smallint', 'bigint'],
-                'float' => [],
+                'float' => ['smallfloat'],
+                'decimal' => [],
+                'number' => [],
             ],
             'array_object' => [
                 'array' => ['simple_array'],
-                'json' => [],
+                'json' => ['json_object'],
                 'object' => [],
                 'binary' => [],
                 'blob' => [],
+                'json_b' => ['jsonb_object'],
             ],
             'date_time' => [
                 'datetime' => ['datetime_immutable'],
                 'datetimetz' => ['datetimetz_immutable'],
                 'date' => ['date_immutable'],
-                'time' => ['time_immutable'],
+                'date_point' => [],
                 'dateinterval' => [],
+                'day_point' => [],
+                'time' => ['time_immutable'],
+                'time_point' => [],
             ],
             'other' => [
                 'enum' => [],
+                'uuid' => [],
+                'guid' => [],
+                'ulid' => [],
             ],
         ];
 


### PR DESCRIPTION
Fixes https://github.com/symfony/maker-bundle/issues/1780

Additions made according to types defined in:
- https://github.com/doctrine/dbal/blob/5.0.x/src/Types/Type.php
- https://github.com/doctrine/dbal/blob/5.0.x/src/Types/Types.php

Original issue mentions other types such as `date_point`, but I couldn't find them on my environment or in Dbal Types, therefore I did not add them yet. Inputs on this matter are welcomed!