### PR TITLE
Update Yaml indentation in tests after symfony/symfony#62967

### DIFF
--- a/tests/Util/YamlSourceManipulatorTest.php
+++ b/tests/Util/YamlSourceManipulatorTest.php
@@ -11,11 +11,14 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Log\Logger;
 use Symfony\Component\Yaml\Yaml;
 
@@ -48,7 +51,11 @@ class YamlSourceManipulatorTest extends TestCase
          */
         $actualContents = $manipulator->getContents();
         $actualContents = str_replace("\r\n", "\n", $actualContents);
-        $this->assertSame($expectedSource, $actualContents);
+        if (InstalledVersions::satisfies(new VersionParser(), 'symfony/yaml', '<8.1')) {
+            $this->assertSame(preg_replace('/\s+/', '', $expectedSource), preg_replace('/\s+/', '', $actualContents));
+        } else {
+            $this->assertSame($expectedSource, $actualContents);
+        }
     }
 
     private static function getYamlDataTests(): \Generator

--- a/tests/Util/yaml_fixtures/simple_sequence_add_array.test
+++ b/tests/Util/yaml_fixtures/simple_sequence_add_array.test
@@ -8,6 +8,5 @@ $data['security']['access_control'][] = ['path' => '^/login$', 'roles' => 'IS_AU
 # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
 security:
     access_control:
-        -
-            path: ^/login$
-            roles: IS_AUTHENTICATED_ANONYMOUSLY
+        - path: ^/login$
+          roles: IS_AUTHENTICATED_ANONYMOUSLY

--- a/tests/Util/yaml_fixtures/simple_sequence_add_array_with_comments.test
+++ b/tests/Util/yaml_fixtures/simple_sequence_add_array_with_comments.test
@@ -10,8 +10,7 @@ $data['security']['access_control'][] = ['path' => '^/login$', 'roles' => 'IS_AU
 # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
 security:
     access_control:
-        -
-            path: ^/login$
-            roles: IS_AUTHENTICATED_ANONYMOUSLY
+        - path: ^/login$
+          roles: IS_AUTHENTICATED_ANONYMOUSLY
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }


### PR DESCRIPTION
https://github.com/symfony/symfony/pull/62967 introduced a change in how YAML files are generated.
For this reason, some tests are broken here (e.g. https://github.com/symfony/maker-bundle/pull/1785).
This PR aims to resolve that.

The modifications are:
- Test files used have been adapted towards the new format
- Special case has been added to `YamlSourceManipulatorTest.php` to address specify of tests in this CI with PHP8.1 and SF6.4.* lowest deps