### PR TITLE
`EnumHelper.php` : Fix Windows behaviour

### DIFF
--- a/src/Util/EnumHelper.php
+++ b/src/Util/EnumHelper.php
@@ -23,6 +23,7 @@ class EnumHelper
         private string $directory,
         private string $namespace = 'App',
     ) {
+        $this->directory = str_replace(['/', '\\'], \DIRECTORY_SEPARATOR, $directory);
     }
 
     public function getAllEnums(): array
@@ -40,7 +41,7 @@ class EnumHelper
         }
 
         foreach ($finder as $file) {
-            $relativePath = str_replace([$this->directory.'/', '.php'], ['', ''], $file->getRealPath());
+            $relativePath = str_replace([$this->directory.\DIRECTORY_SEPARATOR, '.php'], ['', ''], $file->getRealPath());
             $className = $this->namespace.'\\'.str_replace('/', '\\', $relativePath);
 
             if (enum_exists($className)) {


### PR DESCRIPTION
Behaviour is OK on Linux, but tests have been failing on Windows
Usage of `DIRECTORY_SEPARATOR` in `EnumHelper.php` fixes this.