### PR TITLE
[Validator] Fix PHPDoc of generate file

### DIFF
--- a/templates/validator/Validator.tpl.php
+++ b/templates/validator/Validator.tpl.php
@@ -7,10 +7,11 @@ namespace <?= $class_data->getNamespace(); ?>;
 <?= $class_data->getClassDeclaration(); ?>
 
 {
+    /**
+     * @param <?= $constraint_class_name ?> $constraint
+     */
     public function validate(mixed $value, Constraint $constraint): void
     {
-        /** @var <?= $constraint_class_name ?> $constraint */
-
         if (null === $value || '' === $value) {
             return;
         }

--- a/tests/fixtures/make-validator/expected/FooBarValidator.php
+++ b/tests/fixtures/make-validator/expected/FooBarValidator.php
@@ -7,10 +7,11 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 final class FooBarValidator extends ConstraintValidator
 {
+    /**
+     * @param FooBar $constraint
+     */
     public function validate(mixed $value, Constraint $constraint): void
     {
-        /* @var FooBar $constraint */
-
         if (null === $value || '' === $value) {
             return;
         }


### PR DESCRIPTION
`/**` is replaced by `/*` by php-cs-fixer (or something else) because
the var is not bellow this line.

So this line become useless.

By moving to a `@param` we fix this issue.

---

For reference:

```
>/tmp symfony new --webapp maker-bundle

 INFO  A new Symfony CLI version is available (5.16.1, currently running
5.8.14).

       If you installed the Symfony CLI via a package manager, updates
are going to be automatic.
       If not, upgrade by downloading the new version at
https://github.com/symfony-cli/symfony-cli/releases
       And replace the current binary (symfony) by the new one.

* Creating a new Symfony project with Composer
  (running /home/gregoire/.local/bin/composer create-project
symfony/skeleton /tmp/maker-bundle  --no-interaction)

* Setting up the project under Git version control
  (running git init /tmp/maker-bundle)

  (running /home/gregoire/.local/bin/composer require webapp
--no-interaction)

 [OK] Your project is now ready in /tmp/maker-bundle

>/tmp cd  maker-bundle
/tmp/maker-bundle
>/tmp/maker-bundle(main) bin/console make:validator Foobar
 created: src/Validator/FoobarValidator.php
 created: src/Validator/Foobar.php

  Success!

 Next: Open your new constraint & validators and add your logic.
 Find the documentation at
http://symfony.com/doc/current/validation/custom_constraint.html

>/tmp/maker-bundle(main %) rg constraint src/Validator/
src/Validator/FoobarValidator.php
5:use Symfony\Component\Validator\Constraint;
6:use Symfony\Component\Validator\ConstraintValidator;
8:final class FoobarValidator extends ConstraintValidator
10:    public function validate(mixed $value, Constraint $constraint):
       void
12:        /* @var Foobar $constraint */
19:        $this->context->buildViolation($constraint->message)
```
