### PR TITLE
Add configurable namespaces for generated classes

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -27,19 +27,35 @@ class Generator
     private GeneratorTwigHelper $twigHelper;
     private array $pendingOperations = [];
     private array $generatedFiles = [];
+    private array $configuredNamespaces;
 
     public function __construct(
         private FileManager $fileManager,
         private string $namespacePrefix,
         ?PhpCompatUtil $phpCompatUtil = null,
         private ?TemplateComponentGenerator $templateComponentGenerator = null,
+        array $configuredNamespaces = [],
     ) {
         $this->twigHelper = new GeneratorTwigHelper($fileManager);
         $this->namespacePrefix = trim($namespacePrefix, '\\');
 
+        $defaults = [];
+        foreach (NamespaceType::cases() as $case) {
+            $defaults[$case->value] = $case->defaultNamespace();
+        }
+        $this->configuredNamespaces = array_merge($defaults, $configuredNamespaces);
+
         if (null !== $phpCompatUtil) {
             trigger_deprecation('symfony/maker-bundle', 'v1.44.0', 'Initializing Generator while providing an instance of PhpCompatUtil is deprecated.');
         }
+    }
+
+    /**
+     * Returns the configured namespace prefix for a given type.
+     */
+    public function getNamespace(NamespaceType $type): string
+    {
+        return $this->configuredNamespaces[$type->value];
     }
 
     /**

--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
@@ -330,7 +331,7 @@ final class MakeAuthenticator extends AbstractMaker
 
         $userClassNameDetails = $this->generator->createClassNameDetails(
             '\\'.$userClass,
-            'Entity\\'
+            $this->generator->getNamespace(NamespaceType::Entity).'\\'
         );
 
         $this->generator->generateClass(
@@ -354,7 +355,7 @@ final class MakeAuthenticator extends AbstractMaker
     {
         $controllerClassNameDetails = $this->generator->createClassNameDetails(
             $controllerClass,
-            'Controller\\',
+            $this->generator->getNamespace(NamespaceType::Controller).'\\',
             'Controller'
         );
 

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
@@ -69,7 +70,7 @@ final class MakeCommand extends AbstractMaker
 
         $commandClassNameDetails = $generator->createClassNameDetails(
             $commandNameHasAppPrefix ? substr($commandName, 4) : $commandName,
-            'Command\\',
+            $generator->getNamespace(NamespaceType::Command).'\\',
             'Command',
             \sprintf('The "%s" command name is not valid because it would be implemented by "%s" class, which is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores).', $commandName, Str::asClassName($commandName, 'Command'))
         );

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
@@ -39,9 +40,8 @@ final class MakeController extends AbstractMaker
     use CanGenerateTestsTrait;
 
     private bool $isInvokable;
-    private ClassData $controllerClassData;
     private bool $usesTwigTemplate;
-    private string $twigTemplatePath;
+    private string $controllerClass;
 
     public function __construct(private ?PhpCompatUtil $phpCompatUtil = null)
     {
@@ -80,17 +80,23 @@ final class MakeController extends AbstractMaker
     {
         $this->usesTwigTemplate = $this->isTwigInstalled() && !$input->getOption('no-template');
         $this->isInvokable = (bool) $input->getOption('invokable');
+        $this->controllerClass = $input->getArgument('controller-class');
 
-        $controllerClass = $input->getArgument('controller-class');
-        $controllerClassName = \sprintf('Controller\%s', $controllerClass);
+        $this->interactSetGenerateTests($input, $io);
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $controllerNamespace = $generator->getNamespace(NamespaceType::Controller);
+        $controllerClassName = \sprintf('%s\%s', $controllerNamespace, $this->controllerClass);
 
         // If the class name provided is absolute, we do not assume it will live in src/Controller
         // e.g. src/Custom/Location/For/MyController instead of src/Controller/MyController
-        if ($isAbsoluteNamespace = '\\' === $controllerClass[0]) {
-            $controllerClassName = substr($controllerClass, 1);
+        if ($isAbsoluteNamespace = '\\' === $this->controllerClass[0]) {
+            $controllerClassName = substr($this->controllerClass, 1);
         }
 
-        $this->controllerClassData = ClassData::create(
+        $controllerClassData = ClassData::create(
             class: $controllerClassName,
             suffix: 'Controller',
             extendsClass: AbstractController::class,
@@ -105,47 +111,42 @@ final class MakeController extends AbstractMaker
         // templates/my/controller.html.twig. We do however remove the root_namespace prefix in either case
         // so we don't end up with templates/app/my/controller.html.twig
         $templateName = $isAbsoluteNamespace ?
-            $this->controllerClassData->getFullClassName(withoutRootNamespace: true, withoutSuffix: true) :
-            $this->controllerClassData->getClassName(relative: true, withoutSuffix: true)
+            $controllerClassData->getFullClassName(withoutRootNamespace: true, withoutSuffix: true) :
+            $controllerClassData->getClassName(relative: true, withoutSuffix: true)
         ;
 
         // Convert the Twig template name into a file path where it will be generated.
-        $this->twigTemplatePath = \sprintf('%s%s', Str::asFilePath($templateName), $this->isInvokable ? '.html.twig' : '/index.html.twig');
+        $twigTemplatePath = \sprintf('%s%s', Str::asFilePath($templateName), $this->isInvokable ? '.html.twig' : '/index.html.twig');
 
-        $this->interactSetGenerateTests($input, $io);
-    }
-
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
-    {
-        $controllerPath = $generator->generateClassFromClassData($this->controllerClassData, 'controller/Controller.tpl.php', [
-            'route_path' => Str::asRoutePath($this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
-            'route_name' => Str::AsRouteName($this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+        $controllerPath = $generator->generateClassFromClassData($controllerClassData, 'controller/Controller.tpl.php', [
+            'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+            'route_name' => Str::AsRouteName($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
             'method_name' => $this->isInvokable ? '__invoke' : 'index',
             'with_template' => $this->usesTwigTemplate,
-            'template_name' => $this->twigTemplatePath,
+            'template_name' => $twigTemplatePath,
         ], true);
 
         if ($this->usesTwigTemplate) {
             $generator->generateTemplate(
-                $this->twigTemplatePath,
+                $twigTemplatePath,
                 'controller/twig_template.tpl.php',
                 [
                     'controller_path' => $controllerPath,
                     'root_directory' => $generator->getRootDirectory(),
-                    'class_name' => $this->controllerClassData->getClassName(),
+                    'class_name' => $controllerClassData->getClassName(),
                 ]
             );
         }
 
         if ($this->shouldGenerateTests()) {
             $testClassData = ClassData::create(
-                class: \sprintf('Tests\Controller\%s', $this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+                class: \sprintf('Tests\%s\%s', $controllerNamespace, $controllerClassData->getClassName(relative: true, withoutSuffix: true)),
                 suffix: 'ControllerTest',
                 extendsClass: WebTestCase::class,
             );
 
             $generator->generateClassFromClassData($testClassData, 'controller/test/Test.tpl.php', [
-                'route_path' => Str::asRoutePath($this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+                'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
             ]);
 
             if (!class_exists(WebTestCase::class)) {

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -107,7 +108,7 @@ final class MakeCrud extends AbstractMaker
     {
         $entityClassDetails = $generator->createClassNameDetails(
             Validator::entityExists($input->getArgument('entity-class'), $this->doctrineHelper->getEntitiesForAutocomplete()),
-            'Entity\\'
+            $generator->getNamespace(NamespaceType::Entity).'\\'
         );
 
         $entityDoctrineDetails = $this->doctrineHelper->createDoctrineDetails($entityClassDetails->getFullName());
@@ -118,7 +119,7 @@ final class MakeCrud extends AbstractMaker
         if (null !== $entityDoctrineDetails->getRepositoryClass()) {
             $repositoryClassDetails = $generator->createClassNameDetails(
                 '\\'.$entityDoctrineDetails->getRepositoryClass(),
-                'Repository\\',
+                $generator->getNamespace(NamespaceType::Repository).'\\',
                 'Repository'
             );
 
@@ -133,7 +134,7 @@ final class MakeCrud extends AbstractMaker
 
         $controllerClassDetails = $generator->createClassNameDetails(
             $this->controllerClassName,
-            'Controller\\',
+            $generator->getNamespace(NamespaceType::Controller).'\\',
             'Controller'
         );
 
@@ -141,14 +142,14 @@ final class MakeCrud extends AbstractMaker
         do {
             $formClassDetails = $generator->createClassNameDetails(
                 $entityClassDetails->getRelativeNameWithoutSuffix().($iter ?: '').'Type',
-                'Form\\',
+                $generator->getNamespace(NamespaceType::Form).'\\',
                 'Type'
             );
             ++$iter;
         } while (class_exists($formClassDetails->getFullName()));
 
         $controllerClassData = ClassData::create(
-            class: \sprintf('Controller\%s', $this->controllerClassName),
+            class: \sprintf('%s\%s', $generator->getNamespace(NamespaceType::Controller), $this->controllerClassName),
             suffix: 'Controller',
             extendsClass: AbstractController::class,
             useStatements: [

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 use ApiPlatform\Metadata\ApiResource;
 use Doctrine\DBAL\Types\Type;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator;
@@ -143,7 +144,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (
             !$input->getOption('api-resource')
             && class_exists(ApiResource::class)
-            && !class_exists($this->generator->createClassNameDetails($entityClassName, 'Entity\\')->getFullName())
+            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->generator->getNamespace(NamespaceType::Entity).'\\')->getFullName())
         ) {
             $description = $command->getDefinition()->getOption('api-resource')->getDescription();
             $question = new ConfirmationQuestion($description, false);
@@ -155,7 +156,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         if (
             !$input->getOption('broadcast')
             && class_exists(Broadcast::class)
-            && !class_exists($this->generator->createClassNameDetails($entityClassName, 'Entity\\')->getFullName())
+            && !class_exists($this->generator->createClassNameDetails($entityClassName, $this->generator->getNamespace(NamespaceType::Entity).'\\')->getFullName())
         ) {
             $description = $command->getDefinition()->getOption('broadcast')->getDescription();
             $question = new ConfirmationQuestion($description, false);
@@ -184,7 +185,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         $entityClassDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Entity\\'
+            $generator->getNamespace(NamespaceType::Entity).'\\'
         );
 
         $classExists = class_exists($entityClassDetails->getFullName());

--- a/src/Maker/MakeForm.php
+++ b/src/Maker/MakeForm.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -79,7 +80,7 @@ final class MakeForm extends AbstractMaker
     {
         $formClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'Form\\',
+            $generator->getNamespace(NamespaceType::Form).'\\',
             'Type'
         );
 
@@ -91,7 +92,7 @@ final class MakeForm extends AbstractMaker
         if (null !== $boundClass) {
             $boundClassDetails = $generator->createClassNameDetails(
                 $boundClass,
-                'Entity\\'
+                $generator->getNamespace(NamespaceType::Entity).'\\'
             );
 
             $doctrineEntityDetails = $this->entityHelper->createDoctrineDetails($boundClassDetails->getFullName());

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
@@ -214,8 +215,7 @@ final class MakeRegistrationForm extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $userClassNameDetails = $generator->createClassNameDetails(
-            '\\'.$this->userClass,
-            'Entity\\'
+            '\\'.$this->userClass, $generator->getNamespace(NamespaceType::Entity).'\\'
         );
 
         $userDoctrineDetails = $this->doctrineHelper->createDoctrineDetails($userClassNameDetails->getFullName());
@@ -229,7 +229,7 @@ final class MakeRegistrationForm extends AbstractMaker
         $userRepository = $userDoctrineDetails->getRepositoryClass();
 
         if (null !== $userRepository) {
-            $userRepoClassDetails = $generator->createClassNameDetails('\\'.$userRepository, 'Repository\\', 'Repository');
+            $userRepoClassDetails = $generator->createClassNameDetails('\\'.$userRepository, $generator->getNamespace(NamespaceType::Repository).'\\', 'Repository');
 
             $userRepoVars = [
                 'repository_full_class_name' => $userRepoClassDetails->getFullName(),
@@ -297,7 +297,7 @@ final class MakeRegistrationForm extends AbstractMaker
         // 2) Generate the controller
         $controllerClassNameDetails = $generator->createClassNameDetails(
             'RegistrationController',
-            'Controller\\'
+            $generator->getNamespace(NamespaceType::Controller).'\\'
         );
 
         $useStatements = new UseStatementGenerator([
@@ -549,7 +549,7 @@ final class MakeRegistrationForm extends AbstractMaker
     {
         $formClassDetails = $generator->createClassNameDetails(
             'RegistrationFormType',
-            'Form\\'
+            $generator->getNamespace(NamespaceType::Form).'\\'
         );
 
         $formFields = [

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator;
@@ -209,32 +210,32 @@ class MakeResetPassword extends AbstractMaker
     {
         $userClassNameDetails = $generator->createClassNameDetails(
             '\\'.$this->userClass,
-            'Entity\\'
+            $generator->getNamespace(NamespaceType::Entity).'\\'
         );
 
         $controllerClassNameDetails = $generator->createClassNameDetails(
             'ResetPasswordController',
-            'Controller\\'
+            $generator->getNamespace(NamespaceType::Controller).'\\'
         );
 
         $requestClassNameDetails = $generator->createClassNameDetails(
             'ResetPasswordRequest',
-            'Entity\\'
+            $generator->getNamespace(NamespaceType::Entity).'\\'
         );
 
         $repositoryClassNameDetails = $generator->createClassNameDetails(
             'ResetPasswordRequestRepository',
-            'Repository\\'
+            $generator->getNamespace(NamespaceType::Repository).'\\'
         );
 
         $requestFormTypeClassNameDetails = $generator->createClassNameDetails(
             'ResetPasswordRequestFormType',
-            'Form\\'
+            $generator->getNamespace(NamespaceType::Form).'\\'
         );
 
         $changePasswordFormTypeClassNameDetails = $generator->createClassNameDetails(
             'ChangePasswordFormType',
-            'Form\\'
+            $generator->getNamespace(NamespaceType::Form).'\\'
         );
 
         $useStatements = new UseStatementGenerator([
@@ -359,7 +360,7 @@ class MakeResetPassword extends AbstractMaker
 
             $userRepositoryDetails = $generator->createClassNameDetails(
                 \sprintf('%sRepository', $userClassNameDetails->getShortName()),
-                'Repository\\'
+                $generator->getNamespace(NamespaceType::Repository).'\\'
             );
 
             $useStatements = new UseStatementGenerator([

--- a/src/Maker/MakeSerializerNormalizer.php
+++ b/src/Maker/MakeSerializerNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
@@ -74,7 +75,7 @@ final class MakeSerializerNormalizer extends AbstractMaker
 
         $entityDetails = $generator->createClassNameDetails(
             str_replace('Normalizer', '', $normalizerClassNameDetails->getShortName()),
-            'Entity\\',
+            $generator->getNamespace(NamespaceType::Entity).'\\',
         );
 
         if ($entityExists = class_exists($entityDetails->getFullName())) {

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator;
@@ -130,7 +131,7 @@ final class MakeUser extends AbstractMaker
 
         $userClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            $userClassConfiguration->isEntity() ? 'Entity\\' : 'Security\\'
+            $userClassConfiguration->isEntity() ? $generator->getNamespace(NamespaceType::Entity).'\\' : 'Security\\'
         );
 
         // A) Generate the User class

--- a/src/MakerBundle.php
+++ b/src/MakerBundle.php
@@ -41,6 +41,15 @@ class MakerBundle extends AbstractBundle
                 ->end()
                 ->booleanNode('generate_final_classes')->defaultTrue()->end()
                 ->booleanNode('generate_final_entities')->defaultFalse()->end()
+                ->arrayNode('namespaces')
+                    ->useAttributeAsKey('type')
+                    ->scalarPrototype()
+                        ->validate()
+                            ->ifString()
+                            ->then(Validator::validateClassName(...))
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }
@@ -51,14 +60,17 @@ class MakerBundle extends AbstractBundle
         $container->import('../config/makers.php');
 
         $rootNamespace = trim($config['root_namespace'], '\\');
+        $namespaces = $config['namespaces'] ?? [];
+        $entityNamespace = $namespaces['entity'] ?? 'Entity';
 
         $container->services()
             ->get('maker.autoloader_finder')
                 ->arg(0, $rootNamespace)
             ->get('maker.generator')
                 ->arg(1, $rootNamespace)
+                ->arg(4, $namespaces)
             ->get('maker.doctrine_helper')
-                ->arg(0, \sprintf('%s\\Entity', $rootNamespace))
+                ->arg(0, \sprintf('%s\\%s', $rootNamespace, $entityNamespace))
             ->get('maker.template_component_generator')
                 ->arg(0, $config['generate_final_classes'])
                 ->arg(1, $config['generate_final_entities'])

--- a/src/NamespaceType.php
+++ b/src/NamespaceType.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle;
+
+enum NamespaceType: string
+{
+    case Controller = 'controller';
+    case Command = 'command';
+    case Entity = 'entity';
+    case Form = 'form';
+    case Repository = 'repository';
+
+    public function defaultNamespace(): string
+    {
+        return match ($this) {
+            self::Controller => 'Controller',
+            self::Command => 'Command',
+            self::Entity => 'Entity',
+            self::Form => 'Form',
+            self::Repository => 'Repository',
+        };
+    }
+}

--- a/tests/BundleConfigurationTest.php
+++ b/tests/BundleConfigurationTest.php
@@ -28,6 +28,7 @@ class BundleConfigurationTest extends TestCase
         $this->assertSame('App', $config['root_namespace']);
         $this->assertTrue($config['generate_final_classes']);
         $this->assertFalse($config['generate_final_entities']);
+        $this->assertSame([], $config['namespaces']);
     }
 
     public function testAllOptionsConfigured()
@@ -43,6 +44,25 @@ class BundleConfigurationTest extends TestCase
         $this->assertSame('Custom\\Name\\Space', $config['root_namespace']);
         $this->assertFalse($config['generate_final_classes']);
         $this->assertTrue($config['generate_final_entities']);
+    }
+
+    public function testCustomNamespaces()
+    {
+        $config = $this->processConfiguration([
+            'maker' => [
+                'namespaces' => [
+                    'entity' => 'Domain\\Entity',
+                    'controller' => 'Application\\Controller',
+                    'repository' => 'Infrastructure\\Repository',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('Domain\\Entity', $config['namespaces']['entity']);
+        $this->assertSame('Application\\Controller', $config['namespaces']['controller']);
+        $this->assertSame('Infrastructure\\Repository', $config['namespaces']['repository']);
+        $this->assertArrayNotHasKey('command', $config['namespaces']);
+        $this->assertArrayNotHasKey('form', $config['namespaces']);
     }
 
     public function testInvalidRootNamespaceWithReservedKeyword()

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\NamespaceType;
 
 class GeneratorTest extends TestCase
 {
@@ -102,5 +103,43 @@ class GeneratorTest extends TestCase
             'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
             'Symfony\\Bundle\\MakerBundle\\Tests\\GeneratorTest',
         ];
+    }
+
+    public function testGetNamespaceWithConfiguredValue()
+    {
+        $fileManager = $this->createMock(FileManager::class);
+        $generator = new Generator($fileManager, 'App\\', null, null, [
+            'entity' => 'Domain\\Entity',
+            'controller' => 'Application\\Controller',
+        ]);
+
+        $this->assertSame('Domain\\Entity', $generator->getNamespace(NamespaceType::Entity));
+        $this->assertSame('Application\\Controller', $generator->getNamespace(NamespaceType::Controller));
+    }
+
+    public function testGetNamespaceFallsBackToDefault()
+    {
+        $fileManager = $this->createMock(FileManager::class);
+        $generator = new Generator($fileManager, 'App\\');
+
+        $this->assertSame('Entity', $generator->getNamespace(NamespaceType::Entity));
+        $this->assertSame('Command', $generator->getNamespace(NamespaceType::Command));
+    }
+
+    public function testCreateClassNameDetailsWithConfiguredNamespace()
+    {
+        $fileManager = $this->createMock(FileManager::class);
+        $fileManager->expects($this->any())
+            ->method('getNamespacePrefixForClass')
+            ->willReturn('Foo');
+
+        $generator = new Generator($fileManager, 'App\\', null, null, [
+            'entity' => 'Domain\\Entity',
+        ]);
+
+        $entityNamespace = $generator->getNamespace(NamespaceType::Entity).'\\';
+        $classNameDetails = $generator->createClassNameDetails('User', $entityNamespace);
+
+        $this->assertSame('App\\Domain\\Entity\\User', $classNameDetails->getFullName());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Issues        | #1344
| License       | MIT

This PR is a **proof of concept** to support the discussion in #1344 — it is not intended to be merged as-is, but to serve as a concrete base for the ongoing reflection.

### What it does

Adds an optional `namespaces` configuration to override the default namespace for generated classes:

```yaml
maker:
    namespaces:
        entity: Domain\Entity
        controller: Application\Controller
        repository: Infrastructure\Repository
```

The directory is derived automatically from PSR-4 autoloading rules (no `dir` option needed, as @GromNaN suggested).

### Design choices

- **`NamespaceType` enum** — replaces magic strings with a typed enum for all 5 configurable types (controller, command, entity, form, repository). Provides IDE autocompletion and prevents typos.
- **Defaults centralized in the enum** — each case knows its default via `defaultNamespace()`. The `Generator` merges user config on top of these defaults.
- **Open map via `scalarPrototype`** — the config accepts any key, not a fixed list. Users can override only what they need.
- **Validation** — each namespace value is validated via `Validator::validateClassName()`.
- **10 makers updated** — all makers using the 5 configurable types now go through `$generator->getNamespace(NamespaceType::Entity)` instead of hardcoded `'Entity\\'`.
- **No constructor injection needed** — `Generator` is already available in `generate()`. The `MakeController` logic was moved from `interact()` to `generate()` to avoid adding a constructor dependency.

### What's NOT in scope (possible follow-ups)

- CLI option (`--namespace`) for one-off overrides (mentioned by @GromNaN)
- Additional types beyond the initial 5 (listener, message, voter, etc.)