### PR TITLE
[make:entity] Fix `--with-uuid` and `--with-ulid` being ignored when name is passed as argument

### DIFF
--- a/src/Maker/Common/UidTrait.php
+++ b/src/Maker/Common/UidTrait.php
@@ -25,9 +25,6 @@ use Symfony\Component\Uid\Uuid;
  */
 trait UidTrait
 {
-    private bool $usesUuid = false;
-    private bool $usesUlid = false;
-
     /**
      * Call this in a maker's configure() to consistently allow entity's with UUID's.
      * This should be called after you calling "setHelp()" in the maker.
@@ -48,29 +45,37 @@ trait UidTrait
 
     /**
      * Call this as early as possible in a maker's interact().
+     *
+     * Only performs the checks to fail fast; generation reads the options from
+     * the input directly, so that they also apply under --no-interaction.
      */
     protected function checkIsUsingUid(InputInterface $input): void
     {
-        if (($this->usesUuid = $input->getOption('with-uuid')) && !class_exists(Uuid::class)) {
-            throw new RuntimeCommandException('You must install symfony/uid to use Uuid\'s as "id" (composer require symfony/uid)');
-        }
-
-        if (($this->usesUlid = $input->getOption('with-ulid')) && !class_exists(Ulid::class)) {
-            throw new RuntimeCommandException('You must install symfony/uid to use Ulid\'s as "id" (composer require symfony/uid)');
-        }
-
-        if ($this->usesUuid && $this->usesUlid) {
-            throw new RuntimeCommandException('Setting --with-uuid & --with-ulid at the same time is not allowed. Please choose only one.');
-        }
+        $this->getIdType($input);
     }
 
-    protected function getIdType(): EntityIdTypeEnum
+    protected function getIdType(InputInterface $input): EntityIdTypeEnum
     {
-        if ($this->usesUuid) {
+        $hasUuid = $input->getOption('with-uuid');
+        $hasUlid = $input->getOption('with-ulid');
+
+        if ($hasUuid && $hasUlid) {
+            throw new RuntimeCommandException('Setting --with-uuid & --with-ulid at the same time is not allowed. Please choose only one.');
+        }
+
+        if ($hasUuid) {
+            if (!class_exists(Uuid::class)) {
+                throw new RuntimeCommandException('You must install symfony/uid to use Uuid\'s as "id" (composer require symfony/uid).');
+            }
+
             return EntityIdTypeEnum::UUID;
         }
 
-        if ($this->usesUlid) {
+        if ($hasUlid) {
+            if (!class_exists(Ulid::class)) {
+                throw new RuntimeCommandException('You must install symfony/uid to use Ulid\'s as "id" (composer require symfony/uid).');
+            }
+
             return EntityIdTypeEnum::ULID;
         }
 

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -110,6 +110,8 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
+        $this->checkIsUsingUid($input);
+
         if (($entityClassName = $input->getArgument('name')) && empty($this->verifyEntityName($entityClassName))) {
             return;
         }
@@ -125,8 +127,6 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
             return;
         }
-
-        $this->checkIsUsingUid($input);
 
         $argument = $command->getDefinition()->getArgument('name');
         $question = $this->createEntityClassQuestion($argument->getDescription());
@@ -211,7 +211,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
                 entityClassDetails: $entityClassDetails,
                 apiResource: $input->getOption('api-resource'),
                 broadcast: $broadcast,
-                useUuidIdentifier: $this->getIdType(),
+                useUuidIdentifier: $this->getIdType($input),
             );
 
             if ($broadcast) {

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -346,7 +346,7 @@ class MakeResetPassword extends AbstractMaker
             ]
         );
 
-        $this->generateRequestEntity($generator, $requestClassNameDetails, $repositoryClassNameDetails, $userClassNameDetails, $userClass);
+        $this->generateRequestEntity($input, $generator, $requestClassNameDetails, $repositoryClassNameDetails, $userClassNameDetails, $userClass);
 
         $this->setBundleConfig($io, $generator, $repositoryClassNameDetails->getFullName());
 
@@ -518,14 +518,14 @@ class MakeResetPassword extends AbstractMaker
         $io->newLine();
     }
 
-    private function generateRequestEntity(Generator $generator, ClassNameDetails $requestClassNameDetails, ClassNameDetails $repositoryClassNameDetails, ClassNameDetails $userClassDetails, string $userClass): void
+    private function generateRequestEntity(InputInterface $input, Generator $generator, ClassNameDetails $requestClassNameDetails, ClassNameDetails $repositoryClassNameDetails, ClassNameDetails $userClassDetails, string $userClass): void
     {
         // Generate ResetPasswordRequest Entity
         $requestEntityPath = $this->entityClassGenerator->generateEntityClass(
             entityClassDetails: $requestClassNameDetails,
             apiResource: false,
             generateRepositoryClass: false,
-            useUuidIdentifier: $this->getIdType()
+            useUuidIdentifier: $this->getIdType($input)
         );
 
         $generator->writeChanges();

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -139,7 +139,7 @@ final class MakeUser extends AbstractMaker
                 entityClassDetails: $userClassNameDetails,
                 apiResource: false, // api resource
                 withPasswordUpgrade: $userClassConfiguration->hasPassword(), // security user
-                useUuidIdentifier: $this->getIdType()
+                useUuidIdentifier: $this->getIdType($input)
             );
         } else {
             $classPath = $generator->generateClass($userClassNameDetails->getFullName(), 'Class.tpl.php');

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -202,6 +202,39 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_creates_a_new_class_with_uuid_when_name_is_passed_as_argument' => [self::createMakeEntityTest()
+            ->addExtraDependencies('symfony/uid')
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->runMaker([
+                    // add no additional fields
+                    '',
+                ], 'User --with-uuid');
+
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
+
+                $content = file_get_contents($runner->getPath('src/Entity/User.php'));
+                self::assertStringContainsString('use Symfony\Component\Uid\Uuid;', $content);
+                self::assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.uuid_generator\')]', $content);
+
+                self::runEntityTest($runner);
+            }),
+        ];
+
+        yield 'it_creates_a_new_class_with_uuid_under_no_interaction' => [self::createMakeEntityTest()
+            ->addExtraDependencies('symfony/uid')
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->runMaker([], '--no-interaction User --with-uuid');
+
+                self::assertFileExists($runner->getPath('src/Entity/User.php'));
+
+                $content = file_get_contents($runner->getPath('src/Entity/User.php'));
+                self::assertStringContainsString('use Symfony\Component\Uid\Uuid;', $content);
+                self::assertStringContainsString('[ORM\CustomIdGenerator(class: \'doctrine.uuid_generator\')]', $content);
+
+                self::runEntityTest($runner);
+            }),
+        ];
+
         yield 'it_creates_a_new_class_with_fields' => [self::createMakeEntityTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->runMaker([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When the entity name is provided as a command argument, `MakeEntity::interact()` returns early before reaching `$this->checkIsUsingUid($input)`. The `$usesUuid` / `$usesUlid` flags are therefore never set, and the entity is always generated with an integer `id`, silently ignoring `--with-uuid` / `--with-ulid`.

```bash
# Before this PR: id is int, options silently ignored
php bin/console make:entity MyEntity --with-uuid
```

The fix moves the call to the top of `interact()`, which:

- Matches the pattern already used in `MakeUser::interact()` and `MakeResetPassword::interact()`.
- Matches the docblock in `UidTrait::checkIsUsingUid()`: *"Call this as early as possible in a maker's interact()."*
- Also surfaces the existing validation (mutually-exclusive `--with-uuid` / `--with-ulid`, missing `symfony/uid`) earlier in non-interactive flows.

Fixes #1789
