### PR TITLE
[Tests] Fix CI failures in invokable controller test

### DIFF
--- a/tests/fixtures/make-controller/tests/it_generates_an_invokable_controller.php
+++ b/tests/fixtures/make-controller/tests/it_generates_an_invokable_controller.php
@@ -3,6 +3,8 @@
 namespace App\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 final class GeneratedControllerTest extends WebTestCase
 {
@@ -16,11 +18,16 @@ final class GeneratedControllerTest extends WebTestCase
 
     public function testControllerInvokability()
     {
-        $kernel = self::bootKernel();
-        $controller = $kernel->getContainer()->get('App\Controller\FooInvokableController');
+        self::bootKernel();
+        $container = static::getContainer();
+
+        $controller = $container->get('App\Controller\FooInvokableController');
         $this->assertIsCallable($controller);
 
+        $request = Request::create('/foo/invokable');
+        $container->get('request_stack')->push($request);
+
         $response = $controller();
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 }


### PR DESCRIPTION
The `testControllerInvokability` fixture was calling the invokable controller directly without a request in the `RequestStack`. After a recent update to the Flex `base.html.twig` recipe that accesses `app.request.server`, this caused `Twig\Error\RuntimeError: Impossible to access an attribute ("server") on a null variable`. Push a synthetic `Request` onto the `RequestStack` before invoking the controller so `app.request` is non-null.