### PR TITLE
[make:entity] Generate a strict setter for non-nullable unidirectional ManyToOne relations

### DIFF
--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -531,12 +531,14 @@ final class ClassSourceManipulator
         $setterNodeBuilder = $this->createSetterNodeBuilder(
             $relation->getPropertyName(),
             $typeHint,
-            // make the type-hint nullable always for ManyToOne to allow the owning
-            // side to be set to null, which is needed for orphanRemoval
-            // (specifically: when you set the inverse side, the generated
-            // code will *also* set the owning side to null - so it needs to be allowed)
-            // e.g. $userAvatarPhoto->setUser(null);
-            $relation instanceof RelationOneToOne ? $relation->isNullable() : true
+            // A ManyToOne setter must stay nullable as soon as the relation maps an
+            // inverse side: the collection remove*() generated on that side sets the
+            // owning side back to null (orphanRemoval), e.g. $userAvatarPhoto->setUser(null);
+            // so null must be allowed there. A non-nullable, *unidirectional* ManyToOne
+            // has no such code path, so its setter can use a strict, non-nullable type-hint.
+            $relation instanceof RelationOneToOne
+                ? $relation->isNullable()
+                : ($relation->isNullable() || $relation->getMapInverseRelation())
         );
 
         // set the *owning* side of the relation

--- a/tests/Util/ClassSourceManipulatorTest.php
+++ b/tests/Util/ClassSourceManipulatorTest.php
@@ -411,6 +411,20 @@ class ClassSourceManipulatorTest extends TestCase
                 isNullable: true,
             ),
         ];
+
+        // A non-nullable, unidirectional ManyToOne has no inverse remove*()
+        // setting the owning side back to null, so its setter can be strict.
+        yield 'many_to_one_not_nullable_no_inverse' => [
+            'User_simple.php',
+            'User_simple_not_nullable_no_inverse.php',
+            new RelationManyToOne(
+                propertyName: 'category',
+                targetClassName: \App\Entity\Category::class,
+                targetPropertyName: 'foods',
+                mapInverseRelation: false,
+                isOwning: true,
+            ),
+        ];
     }
 
     /**

--- a/tests/Util/fixtures/add_many_to_one_relation/User_simple_not_nullable_no_inverse.php
+++ b/tests/Util/fixtures/add_many_to_one_relation/User_simple_not_nullable_no_inverse.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column()]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Category $category = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCategory(): ?Category
+    {
+        return $this->category;
+    }
+
+    public function setCategory(Category $category): static
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## Summary

Concrete design proposal for #198, which reports that generated `ManyToOne` setters accept `null` even when the relation is non-nullable (`setCategory(?Category $category)` for a `nullable: false` association).

The discussion stalled on a real constraint: the setter must stay nullable for **bidirectional** relations, because the collection `remove*()` generated on the inverse side sets the owning side back to null (`$item->setOwner(null)`, orphanRemoval) — making every `ManyToOne` setter strict would break that generated code.

This PR tightens only the **provably-safe subset**: a non-nullable, **unidirectional** `ManyToOne`, which has no such `remove*()` null path:

```php
public function setCategory(Category $category): static  // was: ?Category
```

Bidirectional and explicitly-nullable relations are unchanged. This mirrors what already happens for non-nullable **OneToOne** setters (`$relation->isNullable()`), just extended to the `ManyToOne` case that is provably safe.

## Scope / open questions

- Deliberately **setter-only** (the original report). The backing property stays `?Category $category = null` — consistent with the current OneToOne behavior, and it avoids uninitialized-typed-property pitfalls with Forms.
- Also making the **property** non-nullable (raised again recently re: phpstan-doctrine `doctrine.associationType`) is a bigger discussion — it reopens @javiereguiluz's Forms concern about uninitialized properties — so it's left out here. Happy to follow up if you'd like to go there.

No existing fixtures change (no current test case is non-nullable + unidirectional); a new `many_to_one_not_nullable_no_inverse` case + fixture covers it.
