### PR TITLE
[MakeEntity] Remove dead is_string() branch in generate()

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -305,12 +305,8 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
                 throw new \Exception('Invalid value.');
             }
 
-            foreach ($fileManagerOperations as $path => $manipulatorOrMessage) {
-                if (\is_string($manipulatorOrMessage)) {     /* @phpstan-ignore-line - https://github.com/symfony/maker-bundle/issues/1509 */
-                    $io->comment($manipulatorOrMessage);
-                } else {
-                    $this->fileManager->dumpFile($path, $manipulatorOrMessage->getSourceCode());
-                }
+            foreach ($fileManagerOperations as $path => $manipulator) {
+                $this->fileManager->dumpFile($path, $manipulator->getSourceCode());
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #1509.

As suspected in the issue, the `is_string($manipulatorOrMessage)` check in `MakeEntity::generate()` is always `false`: every value stored in `$fileManagerOperations` comes from `createClassManipulator()` and therefore is a `ClassSourceManipulator`. The string branch (`$io->comment(...)`) is dead code left over from older versions that returned a message — which is exactly why it carried a `@phpstan-ignore-line` pointing to this issue.

This PR drops the dead branch (and the `@phpstan-ignore-line`), and dumps the files directly:

```php
foreach ($fileManagerOperations as $path => $manipulator) {
    $this->fileManager->dumpFile($path, $manipulator->getSourceCode());
}
```

No behavior change — only the unreachable branch is removed. `MakeEntityTest` produces identical results before/after.
