### PR TITLE
[MakeEntity] Apply the generate_final_entities config to generated entities

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -89,6 +89,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('maker.generator'),
             service('maker.doctrine_helper'),
+            false, // overridden by the "generate_final_entities" config in MakerBundle::loadExtension()
         ]);
 
     $services->set('maker.user_class_builder', UserClassBuilder::class);

--- a/src/Doctrine/EntityClassGenerator.php
+++ b/src/Doctrine/EntityClassGenerator.php
@@ -37,6 +37,7 @@ final class EntityClassGenerator
     public function __construct(
         private Generator $generator,
         private DoctrineHelper $doctrineHelper,
+        private bool $generateFinalEntities = false,
     ) {
     }
 
@@ -88,6 +89,7 @@ final class EntityClassGenerator
                 'should_escape_table_name' => $this->doctrineHelper->isKeyword($tableName),
                 'table_name' => $tableName,
                 'id_type' => $useUuidIdentifier,
+                'is_final' => $this->generateFinalEntities,
             ]
         );
 

--- a/src/MakerBundle.php
+++ b/src/MakerBundle.php
@@ -63,6 +63,8 @@ class MakerBundle extends AbstractBundle
                 ->arg(0, $config['generate_final_classes'])
                 ->arg(1, $config['generate_final_entities'])
                 ->arg(2, $rootNamespace)
+            ->get('maker.entity_class_generator')
+                ->arg(2, $config['generate_final_entities'])
         ;
 
         $builder

--- a/templates/doctrine/Entity.tpl.php
+++ b/templates/doctrine/Entity.tpl.php
@@ -18,7 +18,7 @@ namespace <?= $namespace ?>;
 <?php if ($broadcast): ?>
 #[Broadcast]
 <?php endif ?>
-class <?= $class_name."\n" ?>
+<?php if ($is_final): ?>final <?php endif ?>class <?= $class_name."\n" ?>
 {
 <?php if (EntityIdTypeEnum::UUID === $id_type): ?>
     #[ORM\Id]

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -68,6 +68,27 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_creates_a_final_class_when_configured' => [self::createMakeEntityTest(withDatabase: false)
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->writeFile(
+                    'config/packages/dev/maker.yaml',
+                    Yaml::dump(['maker' => ['generate_final_entities' => true]])
+                );
+
+                $runner->runMaker([
+                    // entity class name
+                    'User',
+                    // add no additional fields
+                    '',
+                ]);
+
+                self::assertStringContainsString(
+                    'final class User',
+                    file_get_contents($runner->getPath('src/Entity/User.php'))
+                );
+            }),
+        ];
+
         yield 'it_only_shows_supported_types' => [self::createMakeEntityTest()
             ->run(function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([


### PR DESCRIPTION
## Summary

Fixes #1731.

The `maker.generate_final_entities` option was wired into the `TemplateComponentGenerator` (used by makers based on `ClassData`), but **not** into the `EntityClassGenerator`, which generates entities from the legacy `doctrine/Entity.tpl.php` template. As a result, `make:entity` (and `make:user` / `make:reset-password`) always produced non-`final` entities, regardless of the configuration.

This PR passes the configured value to the `EntityClassGenerator` and renders the `final` keyword in the template:

```yaml
maker:
    generate_final_entities: true
```

```php
// before: class User { ... }
// after:  final class User { ... }
```

The option still defaults to `false`, so the default behavior is unchanged. Added a functional test covering the `generate_final_entities: true` case.
