### PR TITLE
Redefine the scope of MakerBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@ The MakerBundle is the fastest way to generate the most common code you'll
 need in a Symfony app: commands, controllers, form classes, event subscribers
 and more!
 
+Scope
+-----
+
+This project is aimed at developers who are new to a given Symfony feature and
+want a working starting point without writing boilerplate code. That includes
+absolute Symfony beginners, but also experienced developers picking up an
+unfamiliar component. It generates code that follows the current recommended
+best practices, with sensible defaults and minimal configuration.
+
+A maker is kept even if a project only runs it once, because that single run
+is precisely when the developer benefits the most from a working skeleton. On
+the other hand, makers whose output is fully covered by a Flex recipe, or that
+duplicate another maker, are out of scope.
+
+For any requirement not covered by these defaults (custom templates, alternative
+target directories, extended generators, opinionated code shapes, etc.), we
+recommend using coding agents with dedicated skills, or other code-generation
+tools. See [Symfony Mate][3] for an AI-assisted, skills-based approach.
+
+As a consequence:
+
+- Options and switches that exist only to cover edge cases or personal
+  preferences will not be added. The generated code always reflects our current
+  recommended defaults and may evolve between releases.
+- Requests to make the generators broadly extensible, configurable, or
+  pluggable are out of scope.
+- Only the latest Symfony LTS is supported. The generated code targets that
+  LTS. New makers for post-LTS features may still be added, with a runtime
+  check on the required dependency versions.
+
 Documentation
 -------------
 
@@ -25,6 +55,7 @@ B) The generated code itself may change between minor releases. This
 
 [1]: https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html
 [2]: https://symfony.com/doc/current/contributing/code/bc.html
+[3]: https://symfony.com/doc/current/ai/components/mate.html
 
 ---
 


### PR DESCRIPTION
Following a discussion among Symfony core team members about the future of MakerBundle and its relationship with Symfony Mate (part of `symfony/ai`), this PR documents a clearer, narrower scope for the project.

## Context

Key points that emerged from the discussion:

- MakerBundle has become exceptionally hard to maintain. The test suite is slow and complex to debug (each test spins up a temporary project and runs commands).
- Every new option adds combinatorial complexity, both for users and for maintainers, sometimes turning generators into meta-programming through the CLI.
- Most of the templates are simple boilerplate that require no AI at all. The complexity lives in advanced generators (notably `make:entity`).
- MakerBundle still has real value for newcomers, for training sessions, and for offline / AI-free workflows. Dropping it entirely is not on the table right now.
- Coding agents with dedicated skills (e.g. Symfony Mate, Laravel Boost style) are a better fit for customization, edge cases, and opinionated variations.

## Proposal

Rather than dropping MakerBundle, we narrow its scope:

- Target audience: newcomers starting a Symfony project without writing boilerplate.
- Generate code that reflects our current recommended best practices, with sensible defaults and minimal configuration.
- Reject options and switches that exist only to cover edge cases or personal preferences.
- Redirect requests for extensibility, custom templates, alternative target directories, or opinionated code shapes to coding agents and skills-based tools.

Examples of requests that fall outside this new scope:

- Extending the makers (#1787)
- `make:entity` non-nullable option (#1679)
- Configurable template paths (#1135)
- Changing target directories (#1399)

Example of requests that could be accepted, changing the generated code:
- Invokable command generation (#1746)
- `$form->createView()` in controllers (#1709)
- specify the table name of an entity (#1730)

The README already warns that generated code can change in any version; this PR makes the underlying philosophy explicit.