### PR TITLE
Dump sequences of mappings compactly regardless of the symfony/yaml version

### DIFF
--- a/src/Util/YamlSourceManipulator.php
+++ b/src/Util/YamlSourceManipulator.php
@@ -709,7 +709,11 @@ class YamlSourceManipulator
             ? intdiv($this->indentationForDepths[$this->depth], $this->depth)
             : 4;
 
-        $newDataString = Yaml::dump($data, 4, $indent);
+        // DUMP_COMPACT_NESTED_MAPPING keeps sequences of mappings in the compact
+        // "- key: value" style on every supported symfony/yaml version: it was
+        // the default for a while (symfony/symfony#62967) before being reverted
+        // (symfony/symfony#65365), and the fixtures rely on it
+        $newDataString = Yaml::dump($data, 4, $indent, Yaml::DUMP_COMPACT_NESTED_MAPPING);
         // new line is appended: remove it
         $newDataString = rtrim($newDataString, "\n");
 

--- a/tests/Util/YamlSourceManipulatorTest.php
+++ b/tests/Util/YamlSourceManipulatorTest.php
@@ -11,14 +11,11 @@
 
 namespace Symfony\Bundle\MakerBundle\Tests\Util;
 
-use Composer\InstalledVersions;
-use Composer\Semver\VersionParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Log\Logger;
 use Symfony\Component\Yaml\Yaml;
 
@@ -30,7 +27,7 @@ class YamlSourceManipulatorTest extends TestCase
      */
     #[DataProvider('getYamlDataTestsUnixSlashes')]
     #[DataProvider('getYamlDataTestsWindowsSlashes')]
-    public function testSetData(string $startingSource, array $newData, string $expectedSource)
+    public function testSetData(string $startingSource, array $newData, string $expectedSource): void
     {
         $manipulator = new YamlSourceManipulator($startingSource);
 
@@ -51,11 +48,7 @@ class YamlSourceManipulatorTest extends TestCase
          */
         $actualContents = $manipulator->getContents();
         $actualContents = str_replace("\r\n", "\n", $actualContents);
-        if (InstalledVersions::satisfies(new VersionParser(), 'symfony/yaml', '<8.1')) {
-            $this->assertSame(preg_replace('/\s+/', '', $expectedSource), preg_replace('/\s+/', '', $actualContents));
-        } else {
-            $this->assertSame($expectedSource, $actualContents);
-        }
+        $this->assertSame($expectedSource, $actualContents);
     }
 
     private static function getYamlDataTests(): \Generator


### PR DESCRIPTION
Fix #1806

The `1.x` nightlies have been red since August 15: symfony/symfony#65365 restored the expanded default dump for sequences of mappings, reverting symfony/symfony#62967 that ce97fb46 had adapted the fixtures to.

Instead of following the default back and forth, `YamlSourceManipulator` now passes `Yaml::DUMP_COMPACT_NESTED_MAPPING`, which produces the compact `- key: value` style on every supported symfony/yaml version (verified against 7.4 and 8.2). The output becomes deterministic, so the version-dependent whitespace-insensitive comparison added to the test can go away too.

Spotted while working on #1804 (the four `YamlSourceManipulatorTest` failures there are these).