### PR TITLE
[make:constant] add new command to add a constant to an existing class

### DIFF
--- a/config/help/MakeConstant.txt
+++ b/config/help/MakeConstant.txt
@@ -1,0 +1,23 @@
+The <info>%command.name%</info> command adds a constant to an existing PHP class in your <comment>src/</comment>
+directory (an entity, a service, a controller, a DTO, ...) using PHP's AST parser, so your
+existing code formatting is preserved.
+
+<info>php %command.full_name% Order STATUS_PENDING pending</info>
+
+If any of the arguments are missing, the command will ask for them interactively - with
+autocompletion for the target class.
+
+You may also provide the fully-qualified class name:
+
+<info>php %command.full_name% "App\Entity\Order" STATUS_PENDING pending</info>
+
+By default, the type of the constant is guessed from its value. You can be explicit about it
+with the <comment>--type</comment> option, which also enables writing a native type declaration on the
+constant (requires PHP 8.3+):
+
+<info>php %command.full_name% Order MAX_ITEMS_PER_ORDER 50 --type=int</info>
+
+Other options let you control the visibility, add a PHPDoc description, or mark the constant
+<comment>final</comment> (requires PHP 8.1+):
+
+<info>php %command.full_name% Order STATUS_PENDING pending --visibility=private --comment="The default order status" --final</info>

--- a/config/makers.php
+++ b/config/makers.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\MakerBundle\Maker\MakeAuthenticator;
 use Symfony\Bundle\MakerBundle\Maker\MakeCommand;
+use Symfony\Bundle\MakerBundle\Maker\MakeConstant;
 use Symfony\Bundle\MakerBundle\Maker\MakeController;
 use Symfony\Bundle\MakerBundle\Maker\MakeCrud;
 use Symfony\Bundle\MakerBundle\Maker\MakeDockerDatabase;
@@ -53,6 +54,13 @@ return static function (ContainerConfigurator $container) {
         ->tag('maker.command');
 
     $services->set('maker.maker.make_command', MakeCommand::class)
+        ->tag('maker.command');
+
+    $services->set('maker.maker.make_constant', MakeConstant::class)
+        ->args([
+            service('maker.file_manager'),
+            service('maker.generator'),
+        ])
         ->tag('maker.command');
 
     $services->set('maker.maker.make_twig_component', MakeTwigComponent::class)

--- a/src/Maker/MakeConstant.php
+++ b/src/Maker/MakeConstant.php
@@ -1,0 +1,312 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\FileManager;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
+use Symfony\Bundle\MakerBundle\Validator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author Stephanot Zafindratafa
+ *
+ * @internal
+ */
+final class MakeConstant extends AbstractMaker
+{
+    private const VALID_TYPES = ['string', 'int', 'float', 'bool', 'array'];
+    private const VALID_VISIBILITIES = ['public', 'protected', 'private'];
+
+    public function __construct(
+        private FileManager $fileManager,
+        private Generator $generator,
+    ) {
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:constant';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Add a constant to an existing PHP class';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->addArgument('class', InputArgument::OPTIONAL, 'The class where the constant will be added (e.g. <fg=yellow>Order</> or <fg=yellow>App\Entity\Order</>)')
+            ->addArgument('name', InputArgument::OPTIONAL, 'The name of the constant, in <fg=yellow>UPPER_SNAKE_CASE</> (e.g. <fg=yellow>STATUS_PENDING</>)')
+            ->addArgument('value', InputArgument::OPTIONAL, 'The value of the constant (e.g. <fg=yellow>pending</>)')
+            ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'The type of the constant: string, int, float, bool or array (guessed from the value when not provided)')
+            ->addOption('visibility', null, InputOption::VALUE_REQUIRED, 'The visibility of the constant: public, protected or private', 'public')
+            ->addOption('comment', 'c', InputOption::VALUE_REQUIRED, 'An optional PHPDoc description for the constant')
+            ->addOption('final', null, InputOption::VALUE_NONE, 'Mark the constant as final (requires PHP 8.1+)')
+            ->setHelp($this->getHelpFileContents('MakeConstant.txt'))
+        ;
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        if (null === $input->getArgument('class')) {
+            $argument = $command->getDefinition()->getArgument('class');
+
+            $question = new Question($argument->getDescription());
+            $question->setAutocompleterValues($this->getExistingClassesForAutocomplete());
+            $question->setValidator($this->resolveClassName(...));
+            $question->setMaxAttempts(3);
+
+            $input->setArgument('class', $io->askQuestion($question));
+        }
+
+        if (null === $input->getArgument('name')) {
+            $name = $io->ask(
+                $command->getDefinition()->getArgument('name')->getDescription(),
+                null,
+                Validator::validateConstantName(...)
+            );
+
+            $input->setArgument('name', $name);
+        }
+
+        if (null === $input->getArgument('value')) {
+            $value = $io->ask(
+                $command->getDefinition()->getArgument('value')->getDescription(),
+                null,
+                Validator::notBlank(...)
+            );
+
+            $input->setArgument('value', $value);
+        }
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $className = $this->resolveClassName($input->getArgument('class'));
+        $constantName = Validator::validateConstantName($input->getArgument('name'));
+
+        $visibility = $input->getOption('visibility');
+        if (!\in_array($visibility, self::VALID_VISIBILITIES, true)) {
+            throw new RuntimeCommandException(\sprintf('Invalid visibility "%s": expected one of "public", "protected" or "private".', $visibility));
+        }
+
+        $reflectionClass = new \ReflectionClass($className);
+
+        if ($reflectionClass->isInterface() || $reflectionClass->isEnum() || $reflectionClass->isTrait()) {
+            throw new RuntimeCommandException(\sprintf('"%s" is not a regular class: constants can only be added to classes.', $className));
+        }
+
+        $path = $reflectionClass->getFileName();
+        if (!$path) {
+            throw new RuntimeCommandException(\sprintf('Cannot determine the file where class "%s" is defined.', $className));
+        }
+
+        [$value, $type] = $this->resolveValueAndType($input->getArgument('value'), $input->getOption('type'));
+
+        $manipulator = new ClassSourceManipulator(
+            sourceCode: $this->fileManager->getFileContents($path),
+            overwrite: false,
+        );
+        $manipulator->setIo($io);
+
+        if ($manipulator->constantExists($constantName)) {
+            throw new RuntimeCommandException(\sprintf('A constant named "%s" already exists in class "%s".', $constantName, $className));
+        }
+
+        $manipulator->addConstant(
+            name: $constantName,
+            value: $value,
+            // only add a native type declaration when the user explicitly asked for one:
+            // typed class constants require PHP 8.3+ and we don't know the target project's PHP version
+            type: $input->getOption('type') ? $type : null,
+            visibility: $visibility,
+            comments: $input->getOption('comment') ? [$input->getOption('comment')] : [],
+            final: $input->getOption('final'),
+        );
+
+        $generator->dumpFile($path, $manipulator->getSourceCode());
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $io->text(\sprintf(
+            'Next: Open your <info>%s</info> class and use the new <info>%s::%s</info> constant.',
+            $reflectionClass->getShortName(),
+            $reflectionClass->getShortName(),
+            $constantName
+        ));
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+    }
+
+    /**
+     * @return array{0: string|int|float|bool|array, 1: string}
+     */
+    private function resolveValueAndType(string $rawValue, ?string $requestedType): array
+    {
+        $type = $requestedType ? strtolower($requestedType) : $this->guessType($rawValue);
+
+        if (!\in_array($type, self::VALID_TYPES, true)) {
+            throw new RuntimeCommandException(\sprintf('Invalid type "%s": expected one of "string", "int", "float", "bool" or "array".', $type));
+        }
+
+        $value = match ($type) {
+            'int' => $this->castToInt($rawValue),
+            'float' => $this->castToFloat($rawValue),
+            'bool' => $this->castToBool($rawValue),
+            'array' => $this->castToArray($rawValue),
+            default => $rawValue,
+        };
+
+        return [$value, $type];
+    }
+
+    private function guessType(string $rawValue): string
+    {
+        if (\in_array(strtolower($rawValue), ['true', 'false'], true)) {
+            return 'bool';
+        }
+
+        if (preg_match('/^-?\d+$/', $rawValue)) {
+            return 'int';
+        }
+
+        if (is_numeric($rawValue)) {
+            return 'float';
+        }
+
+        return 'string';
+    }
+
+    private function castToInt(string $rawValue): int
+    {
+        if (!preg_match('/^-?\d+$/', $rawValue)) {
+            throw new RuntimeCommandException(\sprintf('"%s" is not a valid integer value.', $rawValue));
+        }
+
+        return (int) $rawValue;
+    }
+
+    private function castToFloat(string $rawValue): float
+    {
+        if (!is_numeric($rawValue)) {
+            throw new RuntimeCommandException(\sprintf('"%s" is not a valid float value.', $rawValue));
+        }
+
+        return (float) $rawValue;
+    }
+
+    private function castToBool(string $rawValue): bool
+    {
+        return match (strtolower($rawValue)) {
+            'true', '1' => true,
+            'false', '0' => false,
+            default => throw new RuntimeCommandException(\sprintf('"%s" is not a valid boolean value: use "true" or "false".', $rawValue)),
+        };
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function castToArray(string $rawValue): array
+    {
+        $decoded = json_decode($rawValue, true);
+
+        if (\JSON_ERROR_NONE === json_last_error() && \is_array($decoded)) {
+            return $decoded;
+        }
+
+        return array_map('trim', explode(',', $rawValue));
+    }
+
+    /**
+     * Resolves the user-provided class name (short name or FQCN) to an
+     * existing, fully-qualified class name.
+     */
+    private function resolveClassName(string $rawClassName): string
+    {
+        $rawClassName = ltrim(trim($rawClassName), '\\');
+
+        if (class_exists($rawClassName)) {
+            return $rawClassName;
+        }
+
+        $rootNamespace = trim($this->generator->getRootNamespace(), '\\');
+
+        if (class_exists($rootNamespace.'\\'.$rawClassName)) {
+            return $rootNamespace.'\\'.$rawClassName;
+        }
+
+        $matches = [];
+        foreach ($this->getExistingClassesForAutocomplete() as $existingClass) {
+            if (Str::getShortClassName($existingClass) === $rawClassName) {
+                $matches[] = $existingClass;
+            }
+        }
+
+        if (1 === \count($matches)) {
+            return $matches[0];
+        }
+
+        if (\count($matches) > 1) {
+            throw new RuntimeCommandException(\sprintf('Several classes named "%s" were found, please provide the fully-qualified class name: "%s".', $rawClassName, implode('", "', $matches)));
+        }
+
+        throw new RuntimeCommandException(\sprintf('Class "%s" doesn\'t exist. This command only adds a constant to an existing class: create the class first.', $rawClassName));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getExistingClassesForAutocomplete(): array
+    {
+        $rootNamespace = trim($this->generator->getRootNamespace(), '\\');
+        $srcDirectory = $this->fileManager->getRootDirectory().'/src';
+
+        $finder = new Finder();
+
+        try {
+            $finder->files()->in($srcDirectory)->name('*.php');
+        } catch (DirectoryNotFoundException) {
+            return [];
+        }
+
+        $classes = [];
+        foreach ($finder as $file) {
+            $relativePath = str_replace([$srcDirectory.'/', '.php'], ['', ''], str_replace('\\', '/', $file->getRealPath()));
+            $className = $rootNamespace.'\\'.str_replace('/', '\\', $relativePath);
+
+            if (class_exists($className)) {
+                $classes[] = $className;
+            }
+        }
+
+        sort($classes);
+
+        return $classes;
+    }
+}

--- a/src/Util/ClassSourceManipulator.php
+++ b/src/Util/ClassSourceManipulator.php
@@ -403,6 +403,51 @@ final class ClassSourceManipulator
         $this->addNodeAfterProperties($newPropertyNode);
     }
 
+    /**
+     * @param array<int, string> $comments
+     */
+    public function addConstant(string $name, string|int|float|bool|array $value, ?string $type = null, string $visibility = 'public', array $comments = [], bool $final = false): void
+    {
+        $constantBuilder = new Builder\ClassConst($name, $value);
+
+        match ($visibility) {
+            'protected' => $constantBuilder->makeProtected(),
+            'private' => $constantBuilder->makePrivate(),
+            default => $constantBuilder->makePublic(),
+        };
+
+        if ($final) {
+            $constantBuilder->makeFinal();
+        }
+
+        if (null !== $type) {
+            $constantBuilder->setType($type);
+        }
+
+        if ($comments) {
+            $constantBuilder->setDocComment($this->createDocBlock($comments));
+        }
+
+        $this->addNodeAmongConstants($constantBuilder->getNode());
+    }
+
+    public function constantExists(string $constantName): bool
+    {
+        foreach ($this->getClassNode()->stmts as $node) {
+            if (!$node instanceof Node\Stmt\ClassConst) {
+                continue;
+            }
+
+            foreach ($node->consts as $const) {
+                if ($const->name->toString() === $constantName) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public function addAttributeToClass(string $attributeClass, array $options): void
     {
         $this->addUseStatementIfNecessary($attributeClass);
@@ -1174,6 +1219,44 @@ final class ClassSourceManipulator
             array_unshift($classNode->stmts, $this->createBlankLineNode(self::CONTEXT_CLASS));
         }
         array_unshift($classNode->stmts, $newNode);
+        $this->updateSourceCodeFromNewStmts();
+    }
+
+    /**
+     * Adds this new constant node where a new constant should go: after the
+     * last existing constant, otherwise right before the first property,
+     * otherwise after the last trait, otherwise at the top of the class.
+     */
+    private function addNodeAmongConstants(Node\Stmt\ClassConst $newNode): void
+    {
+        $classNode = $this->getClassNode();
+
+        $lastConstIndex = null;
+        $firstPropertyIndex = null;
+        $lastTraitIndex = null;
+
+        foreach ($classNode->stmts as $index => $stmt) {
+            if ($stmt instanceof Node\Stmt\ClassConst) {
+                $lastConstIndex = $index;
+            } elseif ($stmt instanceof Node\Stmt\Property && null === $firstPropertyIndex) {
+                $firstPropertyIndex = $index;
+            } elseif ($stmt instanceof Node\Stmt\TraitUse) {
+                $lastTraitIndex = $index;
+            }
+        }
+
+        if (null !== $lastConstIndex) {
+            array_splice($classNode->stmts, $lastConstIndex + 1, 0, [$this->createBlankLineNode(self::CONTEXT_CLASS), $newNode]);
+        } elseif (null !== $firstPropertyIndex) {
+            array_splice($classNode->stmts, $firstPropertyIndex, 0, [$newNode, $this->createBlankLineNode(self::CONTEXT_CLASS)]);
+        } elseif (null !== $lastTraitIndex) {
+            array_splice($classNode->stmts, $lastTraitIndex + 1, 0, [$this->createBlankLineNode(self::CONTEXT_CLASS), $newNode]);
+        } elseif (!empty($classNode->stmts)) {
+            array_unshift($classNode->stmts, $newNode, $this->createBlankLineNode(self::CONTEXT_CLASS));
+        } else {
+            array_unshift($classNode->stmts, $newNode);
+        }
+
         $this->updateSourceCodeFromNewStmts();
     }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -155,6 +155,21 @@ final class Validator
         return $name;
     }
 
+    public static function validateConstantName(string $name): string
+    {
+        self::notBlank($name);
+
+        if (!preg_match('/^[A-Z_][A-Z0-9_]*$/', $name)) {
+            throw new RuntimeCommandException(\sprintf('"%s" is not a valid constant name: it must be written in UPPER_SNAKE_CASE (e.g. "STATUS_PENDING") and contain only uppercase letters, numbers and underscores.', $name));
+        }
+
+        if ('CLASS' === $name) {
+            throw new RuntimeCommandException('"CLASS" is a reserved constant name and cannot be used.');
+        }
+
+        return $name;
+    }
+
     public static function validateDoctrineFieldName(string $name, ManagerRegistry $registry): string
     {
         // check reserved words

--- a/tests/Maker/MakeConstantTest.php
+++ b/tests/Maker/MakeConstantTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Tests\Maker;
+
+use Symfony\Bundle\MakerBundle\Maker\MakeConstant;
+use Symfony\Bundle\MakerBundle\Test\MakerTestCase;
+use Symfony\Bundle\MakerBundle\Test\MakerTestRunner;
+
+class MakeConstantTest extends MakerTestCase
+{
+    protected function getMakerClass(): string
+    {
+        return MakeConstant::class;
+    }
+
+    public static function getTestDetails(): \Generator
+    {
+        yield 'it_adds_a_constant_interactively' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy('make-constant/Product.php', 'src/Entity/Product.php');
+
+                $output = $runner->runMaker([
+                    // class
+                    'Product',
+                    // constant name
+                    'STATUS_PENDING',
+                    // constant value
+                    'pending',
+                ]);
+
+                self::assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-constant/ProductWithConstant.php',
+                    $runner->getPath('src/Entity/Product.php')
+                );
+            }),
+        ];
+
+        yield 'it_adds_a_typed_final_private_constant_via_options' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy('make-constant/ProductCatalog.php', 'src/Entity/ProductCatalog.php');
+
+                $output = $runner->runMaker(
+                    [],
+                    'ProductCatalog MAX_ITEMS_PER_ORDER 50 --type=int --visibility=private --final --comment="Maximum number of items allowed per order"'
+                );
+
+                self::assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-constant/ProductCatalogWithConstant.php',
+                    $runner->getPath('src/Entity/ProductCatalog.php')
+                );
+            }),
+        ];
+
+        yield 'it_guesses_the_type_from_the_value_when_no_type_is_given' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy('make-constant/Product.php', 'src/Entity/Product.php');
+
+                $runner->runMaker(
+                    [],
+                    'Product MAX_QUANTITY 25'
+                );
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-constant/ProductWithGuessedIntConstant.php',
+                    $runner->getPath('src/Entity/Product.php')
+                );
+            }),
+        ];
+
+        yield 'it_fails_when_the_class_does_not_exist' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker(
+                    [],
+                    'NotFoundClass STATUS_PENDING pending',
+                    allowedToFail: true
+                );
+
+                self::assertStringContainsString('doesn\'t exist', $output);
+            }),
+        ];
+
+        yield 'it_fails_when_the_constant_name_is_invalid' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy('make-constant/Product.php', 'src/Entity/Product.php');
+
+                $output = $runner->runMaker(
+                    [],
+                    'Product statusPending pending',
+                    allowedToFail: true
+                );
+
+                self::assertStringContainsString('UPPER_SNAKE_CASE', $output);
+            }),
+        ];
+
+        yield 'it_fails_when_the_constant_already_exists' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy('make-constant/ProductCatalog.php', 'src/Entity/ProductCatalog.php');
+
+                $output = $runner->runMaker(
+                    [],
+                    'ProductCatalog DEFAULT_CURRENCY USD',
+                    allowedToFail: true
+                );
+
+                self::assertStringContainsString('already exists', $output);
+            }),
+        ];
+    }
+}

--- a/tests/fixtures/make-constant/Product.php
+++ b/tests/fixtures/make-constant/Product.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Entity;
+
+class Product
+{
+}

--- a/tests/fixtures/make-constant/ProductCatalog.php
+++ b/tests/fixtures/make-constant/ProductCatalog.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entity;
+
+class ProductCatalog
+{
+    public const DEFAULT_CURRENCY = 'EUR';
+
+    private string $name;
+}

--- a/tests/fixtures/make-constant/ProductCatalogWithConstant.php
+++ b/tests/fixtures/make-constant/ProductCatalogWithConstant.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity;
+
+class ProductCatalog
+{
+    public const DEFAULT_CURRENCY = 'EUR';
+
+    /**
+     * Maximum number of items allowed per order
+     */
+    final private const int MAX_ITEMS_PER_ORDER = 50;
+
+    private string $name;
+}

--- a/tests/fixtures/make-constant/ProductWithConstant.php
+++ b/tests/fixtures/make-constant/ProductWithConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Entity;
+
+class Product
+{
+    public const STATUS_PENDING = 'pending';
+}

--- a/tests/fixtures/make-constant/ProductWithGuessedIntConstant.php
+++ b/tests/fixtures/make-constant/ProductWithGuessedIntConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Entity;
+
+class Product
+{
+    public const MAX_QUANTITY = 25;
+}


### PR DESCRIPTION
Adds a `make:constant` command that inserts a class constant into any existing PHP class under src/ (entity, service, controller, DTO, ...) using the AST manipulator, preserving the file's existing formatting.

- Interactive prompts for class (with autocompletion), name and value when not passed as arguments.
- --type/-t, --visibility, --comment/-c and --final options.
- Type is guessed from the value when --type is not provided.
- ClassSourceManipulator gains addConstant()/constantExists() and places the new constant after existing constants, otherwise before the first property, otherwise after traits, otherwise at the top.
- Validator gains validateConstantName() (UPPER_SNAKE_CASE).