### PR TITLE
[make:entity] generate an association entity for ManyToMany relations…

### DIFF
--- a/config/help/MakeEntity.txt
+++ b/config/help/MakeEntity.txt
@@ -22,3 +22,8 @@ for the properties of existing entities:
 You can also *overwrite* any existing methods:
 
 <info>php %command.full_name% --regenerate --overwrite</info>
+
+When adding a ManyToMany relationship, you'll be asked whether it needs additional
+properties (e.g. a "role" or "joinedAt" field). If so, an association entity is
+generated automatically to hold the relationship and its extra properties, instead
+of a direct ManyToMany mapping.

--- a/src/Doctrine/ManyToManyAssociationRequest.php
+++ b/src/Doctrine/ManyToManyAssociationRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MakerBundle\Doctrine;
+
+/**
+ * Signals that a ManyToMany relationship should be represented by a
+ * dedicated association entity instead, because it carries additional
+ * properties.
+ *
+ * @internal
+ */
+final class ManyToManyAssociationRequest
+{
+    public function __construct(
+        private string $owningClass,
+        private string $targetClass,
+    ) {
+    }
+
+    public function getOwningClass(): string
+    {
+        return $this->owningClass;
+    }
+
+    public function getTargetClass(): string
+    {
+        return $this->targetClass;
+    }
+}

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Doctrine\DoctrineHelper;
 use Symfony\Bundle\MakerBundle\Doctrine\EntityClassGenerator;
 use Symfony\Bundle\MakerBundle\Doctrine\EntityRegenerator;
 use Symfony\Bundle\MakerBundle\Doctrine\EntityRelation;
+use Symfony\Bundle\MakerBundle\Doctrine\ManyToManyAssociationRequest;
 use Symfony\Bundle\MakerBundle\Doctrine\ORMDependencyBuilder;
 use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
@@ -28,6 +29,7 @@ use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\Common\UidTrait;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassDetails;
+use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassProperty;
 use Symfony\Bundle\MakerBundle\Util\ClassSourceManipulator;
 use Symfony\Bundle\MakerBundle\Util\CliOutputHelper;
@@ -244,69 +246,16 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
                 $manipulator->addEntityField($newField);
 
                 $currentFields[] = $newField->propertyName;
+            } elseif ($newField instanceof ManyToManyAssociationRequest) {
+                $currentFields[] = $this->createManyToManyAssociationEntity($newField, $manipulator, $generator, $io, $overwrite, $fileManagerOperations);
             } elseif ($newField instanceof EntityRelation) {
-                // both overridden below for OneToMany
-                $newFieldName = $newField->getOwningProperty();
-                if ($newField->isSelfReferencing()) {
-                    $otherManipulatorFilename = $entityPath;
-                    $otherManipulator = $manipulator;
-                } else {
-                    $otherManipulatorFilename = $this->getPathOfClass($newField->getInverseClass());
-                    $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
-                }
-                switch ($newField->getType()) {
-                    case EntityRelation::MANY_TO_ONE:
-                        if ($newField->getOwningClass() === $entityClassDetails->getFullName()) {
-                            // THIS class will receive the ManyToOne
-                            $manipulator->addManyToOneRelation($newField->getOwningRelation());
-
-                            if ($newField->getMapInverseRelation()) {
-                                $otherManipulator->addOneToManyRelation($newField->getInverseRelation());
-                            }
-                        } else {
-                            // the new field being added to THIS entity is the inverse
-                            $newFieldName = $newField->getInverseProperty();
-                            $otherManipulatorFilename = $this->getPathOfClass($newField->getOwningClass());
-                            $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
-
-                            // The *other* class will receive the ManyToOne
-                            $otherManipulator->addManyToOneRelation($newField->getOwningRelation());
-                            if (!$newField->getMapInverseRelation()) {
-                                throw new \Exception('Somehow a OneToMany relationship is being created, but the inverse side will not be mapped?');
-                            }
-                            $manipulator->addOneToManyRelation($newField->getInverseRelation());
-                        }
-
-                        break;
-                    case EntityRelation::MANY_TO_MANY:
-                        $manipulator->addManyToManyRelation($newField->getOwningRelation());
-                        if ($newField->getMapInverseRelation()) {
-                            $otherManipulator->addManyToManyRelation($newField->getInverseRelation());
-                        }
-
-                        break;
-                    case EntityRelation::ONE_TO_ONE:
-                        $manipulator->addOneToOneRelation($newField->getOwningRelation());
-                        if ($newField->getMapInverseRelation()) {
-                            $otherManipulator->addOneToOneRelation($newField->getInverseRelation());
-                        }
-
-                        break;
-                    default:
-                        throw new \Exception('Invalid relation type.');
-                }
-
-                // save the inverse side if it's being mapped
-                if ($newField->getMapInverseRelation()) {
-                    $fileManagerOperations[$otherManipulatorFilename] = $otherManipulator;
-                }
-                $currentFields[] = $newFieldName;
+                $currentFields[] = $this->applyEntityRelation($newField, $manipulator, $entityPath, $entityClassDetails, $io, $overwrite, $fileManagerOperations);
             } else {
                 throw new \Exception('Invalid value.');
             }
 
-            foreach ($fileManagerOperations as $path => $manipulator) {
-                $this->fileManager->dumpFile($path, $manipulator->getSourceCode());
+            foreach ($fileManagerOperations as $path => $manipulatorToDump) {
+                $this->fileManager->dumpFile($path, $manipulatorToDump->getSourceCode());
             }
         }
 
@@ -336,8 +285,186 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         ORMDependencyBuilder::buildDependencies($dependencies);
     }
 
+    /**
+     * Applies a relation field to $manipulator's entity, creating/updating the other side as needed.
+     *
+     * @param array<string, ClassSourceManipulator> $fileManagerOperations
+     *
+     * @return string the name of the property that was added to $manipulator's entity
+     */
+    private function applyEntityRelation(EntityRelation $newField, ClassSourceManipulator $manipulator, string $entityPath, ClassNameDetails $entityClassDetails, ConsoleStyle $io, bool $overwrite, array &$fileManagerOperations): string
+    {
+        // both overridden below for OneToMany
+        $newFieldName = $newField->getOwningProperty();
+        if ($newField->isSelfReferencing()) {
+            $otherManipulatorFilename = $entityPath;
+            $otherManipulator = $manipulator;
+        } else {
+            $otherManipulatorFilename = $this->getPathOfClass($newField->getInverseClass());
+            $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
+        }
+        switch ($newField->getType()) {
+            case EntityRelation::MANY_TO_ONE:
+                if ($newField->getOwningClass() === $entityClassDetails->getFullName()) {
+                    // THIS class will receive the ManyToOne
+                    $manipulator->addManyToOneRelation($newField->getOwningRelation());
+
+                    if ($newField->getMapInverseRelation()) {
+                        $otherManipulator->addOneToManyRelation($newField->getInverseRelation());
+                    }
+                } else {
+                    // the new field being added to THIS entity is the inverse
+                    $newFieldName = $newField->getInverseProperty();
+                    $otherManipulatorFilename = $this->getPathOfClass($newField->getOwningClass());
+                    $otherManipulator = $this->createClassManipulator($otherManipulatorFilename, $io, $overwrite);
+
+                    // The *other* class will receive the ManyToOne
+                    $otherManipulator->addManyToOneRelation($newField->getOwningRelation());
+                    if (!$newField->getMapInverseRelation()) {
+                        throw new \Exception('Somehow a OneToMany relationship is being created, but the inverse side will not be mapped?');
+                    }
+                    $manipulator->addOneToManyRelation($newField->getInverseRelation());
+                }
+
+                break;
+            case EntityRelation::MANY_TO_MANY:
+                $manipulator->addManyToManyRelation($newField->getOwningRelation());
+                if ($newField->getMapInverseRelation()) {
+                    $otherManipulator->addManyToManyRelation($newField->getInverseRelation());
+                }
+
+                break;
+            case EntityRelation::ONE_TO_ONE:
+                $manipulator->addOneToOneRelation($newField->getOwningRelation());
+                if ($newField->getMapInverseRelation()) {
+                    $otherManipulator->addOneToOneRelation($newField->getInverseRelation());
+                }
+
+                break;
+            default:
+                throw new \Exception('Invalid relation type.');
+        }
+
+        // save the inverse side if it's being mapped
+        if ($newField->getMapInverseRelation()) {
+            $fileManagerOperations[$otherManipulatorFilename] = $otherManipulator;
+        }
+
+        return $newFieldName;
+    }
+
+    /**
+     * Turns a ManyToMany relationship into a dedicated association entity, since it needs
+     * to carry additional properties.
+     *
+     * The association entity gets a ManyToOne relation to both sides of the original
+     * relationship (with a simple auto-generated identifier and a unique constraint on
+     * the pair), and the caller is then asked for the additional properties it should hold.
+     *
+     * @param array<string, ClassSourceManipulator> $fileManagerOperations
+     *
+     * @return string the name of the property that was added to $manipulator's entity
+     */
+    private function createManyToManyAssociationEntity(ManyToManyAssociationRequest $request, ClassSourceManipulator $manipulator, Generator $generator, ConsoleStyle $io, bool $overwrite, array &$fileManagerOperations): string
+    {
+        $owningClass = $request->getOwningClass();
+        $targetClass = $request->getTargetClass();
+
+        if ($owningClass === $targetClass) {
+            throw new RuntimeCommandException('A ManyToMany relationship with additional properties between an entity and itself is not currently supported.');
+        }
+
+        $associationClassDetails = $this->generator->createClassNameDetails(
+            Str::getShortClassName($owningClass).Str::getShortClassName($targetClass),
+            'Entity\\'
+        );
+
+        $ownerPropertyName = Str::asLowerCamelCase(Str::getShortClassName($owningClass));
+        $targetPropertyName = Str::asLowerCamelCase(Str::getShortClassName($targetClass));
+        $inversePropertyName = Str::asLowerCamelCase(Str::singularCamelCaseToPluralCamelCase($associationClassDetails->getShortName()));
+
+        $associationExists = class_exists($associationClassDetails->getFullName());
+
+        $io->comment(\sprintf(
+            'A <comment>%s</comment> entity will %s to represent this relationship and hold its additional properties.',
+            $associationClassDetails->getShortName(),
+            $associationExists ? 'be used' : 'be created'
+        ));
+
+        if ($associationExists) {
+            $associationPath = $this->getPathOfClass($associationClassDetails->getFullName());
+        } else {
+            $associationPath = $this->entityClassGenerator->generateEntityClass(
+                entityClassDetails: $associationClassDetails,
+                apiResource: false,
+            );
+            $generator->writeChanges();
+        }
+
+        $associationManipulator = $this->createClassManipulator($associationPath, $io, $overwrite);
+
+        // the owning side of the original relationship gets a ManyToOne to the association entity,
+        // and the association entity gets the inverse OneToMany
+        $ownerRelation = new EntityRelation(EntityRelation::MANY_TO_ONE, $associationClassDetails->getFullName(), $owningClass);
+        $ownerRelation->setOwningProperty($ownerPropertyName);
+        $ownerRelation->setInverseProperty($inversePropertyName);
+        $ownerRelation->setIsNullable(false);
+        $ownerRelation->setOrphanRemoval(true);
+
+        $associationManipulator->addManyToOneRelation($ownerRelation->getOwningRelation());
+        $manipulator->addOneToManyRelation($ownerRelation->getInverseRelation());
+
+        // same thing for the target side of the original relationship
+        $targetRelation = new EntityRelation(EntityRelation::MANY_TO_ONE, $associationClassDetails->getFullName(), $targetClass);
+        $targetRelation->setOwningProperty($targetPropertyName);
+        $targetRelation->setInverseProperty($inversePropertyName);
+        $targetRelation->setIsNullable(false);
+        $targetRelation->setOrphanRemoval(true);
+
+        $targetPath = $this->getPathOfClass($targetClass);
+        $targetManipulator = $this->createClassManipulator($targetPath, $io, $overwrite);
+
+        $associationManipulator->addManyToOneRelation($targetRelation->getOwningRelation());
+        $targetManipulator->addOneToManyRelation($targetRelation->getInverseRelation());
+
+        // now ask for the additional properties the association entity should hold
+        $associationFields = $associationExists
+            ? $this->getPropertyNames($associationClassDetails->getFullName())
+            : [$ownerPropertyName, $targetPropertyName];
+        $isFirstAssociationField = true;
+        while (true) {
+            $associationField = $this->askForNextField($io, $associationFields, $associationClassDetails->getFullName(), $isFirstAssociationField);
+            $isFirstAssociationField = false;
+
+            if (null === $associationField) {
+                break;
+            }
+
+            if ($associationField instanceof ClassProperty) {
+                $associationManipulator->addEntityField($associationField);
+                $associationFields[] = $associationField->propertyName;
+            } elseif ($associationField instanceof EntityRelation) {
+                $associationFields[] = $this->applyEntityRelation($associationField, $associationManipulator, $associationPath, $associationClassDetails, $io, $overwrite, $fileManagerOperations);
+            } else {
+                throw new RuntimeCommandException('A ManyToMany relationship with additional properties cannot itself have another such relationship.');
+            }
+        }
+
+        if (!$associationExists) {
+            $associationManipulator->addAttributeToClass('ORM\\UniqueConstraint', [
+                'name' => Str::asSnakeCase($associationClassDetails->getShortName()).'_unique',
+                'fields' => [$ownerPropertyName, $targetPropertyName],
+            ]);
+        }
+
+        $fileManagerOperations[$associationPath] = $associationManipulator;
+        $fileManagerOperations[$targetPath] = $targetManipulator;
+
+        return $inversePropertyName;
+    }
+
     /** @param string[] $fields */
-    private function askForNextField(ConsoleStyle $io, array $fields, string $entityClass, bool $isFirstField): EntityRelation|ClassProperty|null
+    private function askForNextField(ConsoleStyle $io, array $fields, string $entityClass, bool $isFirstField): EntityRelation|ClassProperty|ManyToManyAssociationRequest|null
     {
         $io->writeln('');
 
@@ -591,7 +718,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         return $question;
     }
 
-    private function askRelationDetails(ConsoleStyle $io, string $generatedEntityClass, string $type, string $newFieldName): EntityRelation
+    private function askRelationDetails(ConsoleStyle $io, string $generatedEntityClass, string $type, string $newFieldName): EntityRelation|ManyToManyAssociationRequest
     {
         // ask the targetEntity
         $targetEntityClass = null;
@@ -762,6 +889,15 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
                 break;
             case EntityRelation::MANY_TO_MANY:
+                // self-referencing associations, and associations to a vendor class we
+                // cannot modify, are not offered the additional-properties workflow
+                if ($generatedEntityClass !== $targetEntityClass
+                    && !$this->isClassInVendor($targetEntityClass)
+                    && $io->confirm('Does this relationship have additional properties (e.g. a "role" or "joinedAt" field)?', false)
+                ) {
+                    return new ManyToManyAssociationRequest($generatedEntityClass, $targetEntityClass);
+                }
+
                 $relation = new EntityRelation(
                     EntityRelation::MANY_TO_MANY,
                     $generatedEntityClass,

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -354,6 +354,8 @@ class MakeEntityTest extends MakerTestCase
                     'User',
                     // relation type
                     'ManyToMany',
+                    // additional properties?
+                    '',
                     // inverse side?
                     'y',
                     // field name on opposite side - use default 'courses'
@@ -387,6 +389,8 @@ class MakeEntityTest extends MakerTestCase
                     'User',
                     // relation type
                     'ManyToMany',
+                    // additional properties?
+                    '',
                     // inverse side?
                     'y',
                     // field name on opposite side - use default 'courses'
@@ -415,6 +419,8 @@ class MakeEntityTest extends MakerTestCase
                     'Friend\\User',
                     // relation type
                     'ManyToMany',
+                    // additional properties?
+                    '',
                     // inverse side?
                     'y',
                     // field name on opposite side - use default 'courses'
@@ -435,6 +441,160 @@ class MakeEntityTest extends MakerTestCase
                 self::assertStringContainsString('Each Friend\User also relates to (has) exactly one User.', $output);
 
                 // self::runCustomTest($runner, 'it_adds_many_to_many_between_same_entity_name_different_namespace.php');
+            }),
+        ];
+
+        yield 'it_adds_many_to_many_with_additional_properties' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+                self::copyEntity($runner, 'Group-basic.php');
+
+                $output = $runner->runMaker([
+                    // entity class name
+                    'User',
+                    // field name
+                    'groups',
+                    // add a relationship field
+                    'relation',
+                    // the target entity
+                    'Group',
+                    // relation type
+                    'ManyToMany',
+                    // additional properties?
+                    'y',
+                    // [UserGroup] new property name
+                    'role',
+                    // [UserGroup] field type
+                    'string',
+                    // [UserGroup] field length (default 255)
+                    '',
+                    // [UserGroup] nullable? (default no)
+                    '',
+                    // [UserGroup] add another property? (stop)
+                    '',
+                    // finish adding fields on User
+                    '',
+                ]);
+
+                self::assertStringContainsString('src/Entity/UserGroup.php', $output);
+
+                $userGroupSource = file_get_contents($runner->getPath('src/Entity/UserGroup.php'));
+                self::assertStringContainsString('private ?int $id = null;', $userGroupSource);
+                self::assertStringContainsString('private ?User $user = null;', $userGroupSource);
+                self::assertStringContainsString('private ?Group $group = null;', $userGroupSource);
+                self::assertStringContainsString('private ?string $role = null;', $userGroupSource);
+                self::assertStringContainsString('#[ORM\UniqueConstraint(', $userGroupSource);
+
+                $userSource = file_get_contents($runner->getPath('src/Entity/User.php'));
+                self::assertStringContainsString('private Collection $userGroups;', $userSource);
+                // the direct ManyToMany mapping must not exist: the association entity replaces it
+                self::assertStringNotContainsString('ManyToMany', $userSource);
+                // unrelated, pre-existing code must be preserved
+                self::assertStringContainsString('function getFirstName()', $userSource);
+
+                $groupSource = file_get_contents($runner->getPath('src/Entity/Group.php'));
+                self::assertStringContainsString('private Collection $userGroups;', $groupSource);
+                self::assertStringNotContainsString('ManyToMany', $groupSource);
+                self::assertStringContainsString('function getName()', $groupSource);
+
+                self::runCustomTest($runner, 'it_adds_many_to_many_with_additional_properties.php');
+            }),
+        ];
+
+        yield 'it_adds_many_to_many_with_multiple_additional_properties' => [self::createMakeEntityTest(withDatabase: false)
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+                self::copyEntity($runner, 'Group-basic.php');
+
+                $runner->runMaker([
+                    // entity class name
+                    'User',
+                    // field name
+                    'groups',
+                    // add a relationship field
+                    'relation',
+                    // the target entity
+                    'Group',
+                    // relation type
+                    'ManyToMany',
+                    // additional properties?
+                    'y',
+                    // [UserGroup] property 1
+                    'role',
+                    'string',
+                    '',
+                    '',
+                    // [UserGroup] property 2
+                    'joinedAt',
+                    // use default datetime_immutable
+                    '',
+                    '',
+                    // [UserGroup] property 3
+                    'isActive',
+                    'boolean',
+                    '',
+                    // stop
+                    '',
+                    // finish adding fields on User
+                    '',
+                ]);
+
+                $userGroupSource = file_get_contents($runner->getPath('src/Entity/UserGroup.php'));
+                self::assertStringContainsString('private ?string $role = null;', $userGroupSource);
+                self::assertStringContainsString('private ?\DateTimeImmutable $joinedAt = null;', $userGroupSource);
+                self::assertStringContainsString('private ?bool $isActive = null;', $userGroupSource);
+            }),
+        ];
+
+        yield 'it_reuses_an_existing_association_entity' => [self::createMakeEntityTest(withDatabase: false)
+            ->run(static function (MakerTestRunner $runner) {
+                // simulates the state left behind by an earlier "User -> Group" run:
+                // User/Group don't have their inverse OneToMany side yet, but the
+                // association entity already exists, with its own "role" property
+                // and unique constraint.
+                self::copyEntity($runner, 'User-basic.php');
+                self::copyEntity($runner, 'Group-basic.php');
+                self::copyEntity($runner, 'UserGroup-basic.php');
+
+                $output = $runner->runMaker([
+                    // entity class name
+                    'User',
+                    // field name
+                    'groups',
+                    // add a relationship field
+                    'relation',
+                    // the target entity
+                    'Group',
+                    // relation type
+                    'ManyToMany',
+                    // additional properties?
+                    'y',
+                    // [UserGroup] new property
+                    'joinedAt',
+                    // use default datetime_immutable
+                    '',
+                    '',
+                    // stop
+                    '',
+                    // finish adding fields on User
+                    '',
+                ]);
+
+                self::assertStringContainsString('A UserGroup entity will be used', $output);
+
+                $userGroupSource = file_get_contents($runner->getPath('src/Entity/UserGroup.php'));
+                // the property present from the "earlier run" must be preserved
+                self::assertStringContainsString('private ?string $role = null;', $userGroupSource);
+                // the new property must have been added
+                self::assertStringContainsString('private ?\DateTimeImmutable $joinedAt = null;', $userGroupSource);
+                // the unique constraint from the earlier run must not be duplicated
+                self::assertSame(1, substr_count($userGroupSource, '#[ORM\UniqueConstraint('));
+
+                $userSource = file_get_contents($runner->getPath('src/Entity/User.php'));
+                self::assertStringContainsString('private Collection $userGroups;', $userSource);
+
+                $groupSource = file_get_contents($runner->getPath('src/Entity/Group.php'));
+                self::assertStringContainsString('private Collection $userGroups;', $groupSource);
             }),
         ];
 

--- a/tests/fixtures/make-entity/entities/attributes/Group-basic.php
+++ b/tests/fixtures/make-entity/entities/attributes/Group-basic.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`group`')]
+class Group
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $name = null;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/fixtures/make-entity/entities/attributes/UserGroup-basic.php
+++ b/tests/fixtures/make-entity/entities/attributes/UserGroup-basic.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\UniqueConstraint(name: 'user_group_unique', fields: ['user', 'group'])]
+class UserGroup
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Group $group = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $role = null;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user)
+    {
+        $this->user = $user;
+    }
+
+    public function getGroup(): ?Group
+    {
+        return $this->group;
+    }
+
+    public function setGroup(?Group $group)
+    {
+        $this->group = $group;
+    }
+
+    public function getRole(): ?string
+    {
+        return $this->role;
+    }
+
+    public function setRole(?string $role)
+    {
+        $this->role = $role;
+    }
+}

--- a/tests/fixtures/make-entity/tests/it_adds_many_to_many_with_additional_properties.php
+++ b/tests/fixtures/make-entity/tests/it_adds_many_to_many_with_additional_properties.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Tests;
+
+use App\Entity\Group;
+use App\Entity\User;
+use App\Entity\UserGroup;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class GeneratedEntityTest extends KernelTestCase
+{
+    public function testGeneratedEntity()
+    {
+        self::bootKernel();
+        /** @var EntityManager $em */
+        $em = self::$kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->cleanUp($em);
+
+        $user = new User();
+        $em->persist($user);
+
+        $group = new Group();
+        $em->persist($group);
+
+        $userGroup = new UserGroup();
+        $userGroup->setUser($user);
+        $userGroup->setGroup($group);
+        $userGroup->setRole('admin');
+        $em->persist($userGroup);
+
+        $em->flush();
+        $em->clear();
+
+        $actualUsers = $em->getRepository(User::class)->findAll();
+        $this->assertCount(1, $actualUsers);
+        $this->assertCount(1, $actualUsers[0]->getUserGroups());
+
+        /** @var UserGroup $actualUserGroup */
+        $actualUserGroup = $actualUsers[0]->getUserGroups()->first();
+        $this->assertSame('admin', $actualUserGroup->getRole());
+        $this->assertSame($actualUsers[0]->getId(), $actualUserGroup->getUser()->getId());
+
+        $actualGroups = $em->getRepository(Group::class)->findAll();
+        $this->assertCount(1, $actualGroups);
+        $this->assertCount(1, $actualGroups[0]->getUserGroups());
+        $this->assertSame($actualGroups[0]->getId(), $actualUserGroup->getGroup()->getId());
+
+        // removing the association from the owning collection should delete it (orphanRemoval)
+        $actualUsers[0]->getUserGroups()->removeElement($actualUserGroup);
+        $em->flush();
+
+        $this->assertCount(0, $em->getRepository(UserGroup::class)->findAll());
+    }
+
+    public function testUniqueConstraintIsEnforced()
+    {
+        self::bootKernel();
+        /** @var EntityManager $em */
+        $em = self::$kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->cleanUp($em);
+
+        $user = new User();
+        $em->persist($user);
+
+        $group = new Group();
+        $em->persist($group);
+
+        $userGroup = new UserGroup();
+        $userGroup->setUser($user);
+        $userGroup->setGroup($group);
+        $userGroup->setRole('admin');
+        $em->persist($userGroup);
+        $em->flush();
+
+        $duplicateUserGroup = new UserGroup();
+        $duplicateUserGroup->setUser($user);
+        $duplicateUserGroup->setGroup($group);
+        $duplicateUserGroup->setRole('member');
+        $em->persist($duplicateUserGroup);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $em->flush();
+    }
+
+    private function cleanUp(EntityManager $em): void
+    {
+        $em->createQuery('DELETE FROM App\\Entity\\UserGroup ug')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\User u')->execute();
+        $em->createQuery('DELETE FROM App\\Entity\\Group g')->execute();
+    }
+}


### PR DESCRIPTION
… with additional properties

When adding a ManyToMany relationship, ask whether it needs additional properties (e.g. a "role" or "joinedAt" field). If so, generate a dedicated association entity (e.g. User + Group -> UserGroup) instead of a direct ManyToMany mapping, following the Doctrine-recommended pattern:

- the association entity gets a simple auto-generated id, a ManyToOne to each side of the relationship, and a unique constraint on the pair;
- both original entities get the OneToMany inverse side automatically;
- additional properties are collected by reusing the existing field-adding loop, so nested relations on the association entity work for free;
- re-running the command against an already-generated association entity reuses it (existing properties/relations/methods are preserved, and the unique constraint is not duplicated);
- self-referencing relations and vendor targets are not offered this workflow and keep the existing ManyToMany behavior unchanged.

Also fixes a latent bug where the loop dumping generated files reused the $manipulator variable name, corrupting it for any relation added afterwards in the same make:entity run.