### PR TITLE
[make:entity] Add a --field option to add fields without prompting

### DIFF
--- a/config/help/MakeEntity.txt
+++ b/config/help/MakeEntity.txt
@@ -22,3 +22,22 @@ for the properties of existing entities:
 You can also *overwrite* any existing methods:
 
 <info>php %command.full_name% --regenerate --overwrite</info>
+
+Fields can be passed on the command line instead of being asked for, which is
+what you want in a script or when the terminal is not interactive:
+
+<info>php %command.full_name% BlogPost --field=title:string:100 --field=body:text --field=publishedAt:datetime_immutable?</info>
+
+The format is <comment>name[:type[:length]]</comment>, with a trailing <comment>?</comment> to make the field nullable.
+The type defaults to the same guess the interactive mode makes, so <comment>--field=createdAt</comment>
+becomes a <comment>datetime_immutable</comment>. For <comment>decimal</comment>, the third and fourth parts are the
+precision and the scale: <comment>--field=price:decimal:10:2</comment>.
+
+For <comment>enum</comment>, the third part is the backed enum class. Its short name is enough as
+long as it is unique within <comment>src/</comment>, which saves escaping backslashes in your shell.
+Append <comment>,multiple</comment> to store several values:
+
+<info>php %command.full_name% BlogPost --field=status:enum:Status --field=labels:enum:Label,multiple</info>
+
+Relations are not supported by this option - run the command without <comment>--field</comment>
+to be guided through them.

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -98,6 +98,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             ->addOption('broadcast', 'b', InputOption::VALUE_NONE, 'Add the ability to broadcast entity updates using Symfony UX Turbo?')
             ->addOption('regenerate', null, InputOption::VALUE_NONE, 'Instead of adding new fields, simply generate the methods (e.g. getter/setter) for existing fields')
             ->addOption('overwrite', null, InputOption::VALUE_NONE, 'Overwrite any existing getter/setter methods')
+            ->addOption('field', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add a field without being asked for it: <fg=yellow>name[:type[:length]][?]</> (e.g. <fg=yellow>title:string:100</>). Repeat the option for each field')
             ->setHelp($this->getHelpFileContents('MakeEntity.txt'))
         ;
 
@@ -173,9 +174,14 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $overwrite = $input->getOption('overwrite');
+        $fieldOptions = $input->getOption('field');
 
         // the regenerate option has entirely custom behavior
         if ($input->getOption('regenerate')) {
+            if ($fieldOptions) {
+                throw new RuntimeCommandException('The "--field" option cannot be combined with "--regenerate", which only generates methods for existing fields.');
+            }
+
             $this->regenerateEntities($input->getArgument('name'), $overwrite, $generator);
             $this->writeSuccessMessage($io);
 
@@ -188,6 +194,13 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         );
 
         $classExists = class_exists($entityClassDetails->getFullName());
+
+        // a class that does not exist yet is about to be generated with an "id" property, so that name is taken
+        $queuedFields = $fieldOptions ? $this->parseFieldOptions(
+            $fieldOptions,
+            $classExists ? $this->getPropertyNames($entityClassDetails->getFullName()) : ['id'],
+        ) : null;
+
         if (!$classExists) {
             $broadcast = $input->getOption('broadcast');
             $entityPath = $this->entityClassGenerator->generateEntityClass(
@@ -230,7 +243,9 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         $isFirstField = true;
         while (true) {
-            $newField = $this->askForNextField($io, $currentFields, $entityClassDetails->getFullName(), $isFirstField);
+            $newField = null === $queuedFields
+                ? $this->askForNextField($io, $currentFields, $entityClassDetails->getFullName(), $isFirstField)
+                : array_shift($queuedFields);
             $isFirstField = false;
 
             if (null === $newField) {
@@ -336,6 +351,191 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         ORMDependencyBuilder::buildDependencies($dependencies);
     }
 
+    /**
+     * @param string[] $definitions
+     * @param string[] $currentFields
+     *
+     * @return ClassProperty[]
+     */
+    private function parseFieldOptions(array $definitions, array $currentFields): array
+    {
+        $properties = [];
+
+        foreach ($definitions as $definition) {
+            $property = $this->parseFieldOption($definition, $currentFields);
+
+            $currentFields[] = $property->propertyName;
+            $properties[] = $property;
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @param string[] $currentFields
+     */
+    private function parseFieldOption(string $definition, array $currentFields): ClassProperty
+    {
+        [$head, $nullable, $modifiers] = $this->splitDefinition($definition);
+
+        $parts = explode(':', $head);
+        $fieldName = array_shift($parts);
+
+        if (!$fieldName) {
+            throw new RuntimeCommandException(\sprintf('The field "%s" is missing a property name.', $definition));
+        }
+
+        if (\in_array($fieldName, $currentFields, true)) {
+            throw new RuntimeCommandException(\sprintf('The "%s" property already exists.', $fieldName));
+        }
+
+        try {
+            Validator::validateDoctrineFieldName($fieldName, $this->doctrineHelper->getRegistry());
+        } catch (\InvalidArgumentException $e) {
+            // the interactive mode asks again, there is nobody to ask here
+            throw new RuntimeCommandException($e->getMessage(), previous: $e);
+        }
+
+        $type = array_shift($parts) ?: $this->guessFieldType($fieldName);
+
+        if ('relation' === $type || \in_array($type, EntityRelation::getValidRelationTypes(), true)) {
+            throw new RuntimeCommandException(\sprintf('The "--field" option cannot add the relation "%s". Run the command without "--field" to be guided through it.', $fieldName));
+        }
+
+        if ('enum' === $type) {
+            // the interactive mode picks the type only after asking, so an enum never goes
+            // through the "string" branch below and never gets a length
+            $classProperty = new ClassProperty(propertyName: $fieldName, type: 'string');
+            $classProperty->enumType = $this->resolveEnumClass(array_shift($parts) ?? '');
+
+            if ($this->takeFlag($modifiers, 'multiple', $definition)) {
+                $classProperty->type = 'simple_array';
+            }
+        } elseif (!\array_key_exists($type, $this->getTypesMap())) {
+            throw new RuntimeCommandException(\sprintf('Invalid type "%s" for field "%s". Run the command without "--field" to see the available types.', $type, $fieldName));
+        } else {
+            $classProperty = new ClassProperty(propertyName: $fieldName, type: $type);
+
+            if ('string' === $type) {
+                $classProperty->length = Validator::validateLength(array_shift($parts) ?: '255');
+            } elseif ('decimal' === $type) {
+                $classProperty->precision = Validator::validatePrecision(array_shift($parts) ?: '10');
+                $classProperty->scale = Validator::validateScale(array_shift($parts) ?: '0');
+            }
+        }
+
+        if ($nullable) {
+            $classProperty->nullable = true;
+        }
+
+        if ($parts) {
+            throw new RuntimeCommandException(\sprintf('The field "%s" has more options than the type "%s" accepts.', $definition, $type));
+        }
+
+        if ($modifiers) {
+            throw new RuntimeCommandException(\sprintf('Unknown modifier "%s" in the field "%s".', array_key_first($modifiers), $definition));
+        }
+
+        return $classProperty;
+    }
+
+    /**
+     * Splits <fieldName>[:<type>...][?][,<modifier>...] into those three parts.
+     *
+     * @return array{string, bool, array<string, string|true>}
+     */
+    private function splitDefinition(string $definition): array
+    {
+        $modifiers = explode(',', $definition);
+        $head = array_shift($modifiers);
+
+        if ($nullable = str_ends_with($head, '?')) {
+            $head = substr($head, 0, -1);
+        }
+
+        $parsedModifiers = [];
+
+        foreach ($modifiers as $modifier) {
+            if (!$modifier) {
+                throw new RuntimeCommandException(\sprintf('The field "%s" has an empty modifier.', $definition));
+            }
+
+            [$name, $value] = explode('=', $modifier, 2) + [1 => true];
+            $parsedModifiers[$name] = $value;
+        }
+
+        return [$head, $nullable, $parsedModifiers];
+    }
+
+    /**
+     * @param array<string, string|true> $modifiers
+     */
+    private function takeFlag(array &$modifiers, string $name, string $definition): bool
+    {
+        $value = $modifiers[$name] ?? null;
+        unset($modifiers[$name]);
+
+        return match ($value) {
+            null => false,
+            true, 'true' => true,
+            'false' => false,
+            default => throw new RuntimeCommandException(\sprintf('The "%s" modifier of the field "%s" takes no value, or "true" or "false".', $name, $definition)),
+        };
+    }
+
+    private function resolveEnumClass(string $enumClass): string
+    {
+        if (!$enumClass) {
+            throw new RuntimeCommandException('An enum field needs the enum class, e.g. "--field=status:enum:App\\Enum\\Status".');
+        }
+
+        if (str_contains($enumClass, '\\')) {
+            return Validator::classIsBackedEnum($enumClass);
+        }
+
+        // a short name spares the caller from escaping backslashes in the shell
+        $enums = (new EnumHelper($this->fileManager->getRootDirectory().'/src', 'App'))->getAllEnums();
+        $matches = array_values(array_filter($enums, static fn (string $enum) => Str::getShortClassName($enum) === $enumClass));
+
+        if (!$matches) {
+            throw new RuntimeCommandException(\sprintf('No backed enum "%s" was found in "src/". Pass its full class name if it lives elsewhere.', $enumClass));
+        }
+
+        if (1 < \count($matches)) {
+            throw new RuntimeCommandException(\sprintf('The enum "%s" is ambiguous, pass a full class name: "%s".', $enumClass, implode('", "', $matches)));
+        }
+
+        return $matches[0];
+    }
+
+    private function guessFieldType(string $fieldName): string
+    {
+        // convert to snake case for simplicity
+        $snakeCasedField = Str::asSnakeCase($fieldName);
+
+        if ('_at' === $suffix = substr($snakeCasedField, -3)) {
+            return 'datetime_immutable';
+        }
+
+        if ('_id' === $suffix) {
+            return 'integer';
+        }
+
+        if (str_starts_with($snakeCasedField, 'is_') || str_starts_with($snakeCasedField, 'has_')) {
+            return 'boolean';
+        }
+
+        if ('uuid' === $snakeCasedField) {
+            return 'uuid';
+        }
+
+        if ('guid' === $snakeCasedField) {
+            return 'guid';
+        }
+
+        return 'string';
+    }
+
     /** @param string[] $fields */
     private function askForNextField(ConsoleStyle $io, array $fields, string $entityClass, bool $isFirstField): EntityRelation|ClassProperty|null
     {
@@ -364,24 +564,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             return null;
         }
 
-        $defaultType = 'string';
-        // try to guess the type by the field name prefix/suffix
-        // convert to snake case for simplicity
-        $snakeCasedField = Str::asSnakeCase($fieldName);
-
-        if ('_at' === $suffix = substr($snakeCasedField, -3)) {
-            $defaultType = 'datetime_immutable';
-        } elseif ('_id' === $suffix) {
-            $defaultType = 'integer';
-        } elseif (str_starts_with($snakeCasedField, 'is_')) {
-            $defaultType = 'boolean';
-        } elseif (str_starts_with($snakeCasedField, 'has_')) {
-            $defaultType = 'boolean';
-        } elseif ('uuid' === $snakeCasedField) {
-            $defaultType = Type::hasType('uuid') ? 'uuid' : 'guid';
-        } elseif ('guid' === $snakeCasedField) {
-            $defaultType = 'guid';
-        }
+        $defaultType = $this->guessFieldType($fieldName);
 
         $type = null;
         $types = $this->getTypesMap();

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -823,6 +823,96 @@ class MakeEntityTest extends MakerTestCase
             self::runEntityTest($runner);
         }),
         ];
+
+        yield 'it_creates_fields_from_the_field_option' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->runMaker(
+                    [],
+                    '--no-interaction User --field=name:string:100 --field=biography:text? --field=balance:decimal:10:2 --field=createdAt?'
+                );
+
+                $entity = file_get_contents($runner->getPath('src/Entity/User.php'));
+
+                self::assertStringContainsString('#[ORM\Column(length: 100)]', $entity);
+                self::assertStringContainsString('private ?string $name = null;', $entity);
+                self::assertStringContainsString('#[ORM\\Column(type: Types::TEXT, nullable: true)]', $entity);
+                self::assertStringContainsString('#[ORM\\Column(type: Types::DECIMAL, precision: 10, scale: 2)]', $entity);
+                // the type of "createdAt" is guessed from its name, exactly as in interactive mode
+                self::assertStringContainsString('private ?\\DateTimeImmutable $createdAt = null;', $entity);
+                // a field that is not marked nullable leaves the attribute alone
+                self::assertStringNotContainsString('nullable: false', $entity);
+
+                self::runEntityTest($runner, ['name' => 'John', 'balance' => '10.50']);
+            }),
+        ];
+
+        yield 'it_creates_enum_fields_from_the_field_option' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'Enum/Role-basic.php');
+
+                // "role" resolves by short name, "otherRoles" by full class name; both are
+                // nullable so that the generated entity test can persist a User without them
+                $runner->runMaker(
+                    [],
+                    // double quotes, because cmd.exe does not treat single quotes as quoting
+                    '--no-interaction User --field=role:enum:Role? --field="otherRoles:enum:App\\Entity\\Enum\\Role?,multiple"'
+                );
+
+                $entity = file_get_contents($runner->getPath('src/Entity/User.php'));
+
+                self::assertStringContainsString('#[ORM\\Column(nullable: true, enumType: Role::class)]', $entity);
+                self::assertStringContainsString('private ?Role $role = null;', $entity);
+                self::assertStringContainsString('Types::SIMPLE_ARRAY', $entity);
+                // an enum is not a string field, so it must not pick up a length
+                self::assertStringNotContainsString('length: 255', $entity);
+
+                self::runEntityTest($runner);
+            }),
+        ];
+
+        yield 'it_rejects_invalid_field_options' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $invalidDefinitions = [
+                    // relations need follow-up questions, so they stay interactive-only
+                    'author:ManyToOne' => 'cannot add the relation "author"',
+                    'status:enum' => 'An enum field needs the enum class',
+                    'status:enum:Nope' => 'No backed enum "Nope" was found',
+                    'name:nope' => 'Invalid type "nope"',
+                    'name:string,multiple' => 'Unknown modifier "multiple"',
+                    'name:string,' => 'has an empty modifier',
+                    // the identifier the entity is about to be generated with is already taken
+                    'id:integer' => 'The "id" property already exists.',
+                    'name:string:abc' => 'Invalid length "abc".',
+                    'body:text:100' => 'has more options than the type',
+                    // reserved words and invalid property names are a clean error, not a stack trace
+                    '1name' => 'is not a valid PHP property name',
+                ];
+
+                foreach ($invalidDefinitions as $definition => $expectedError) {
+                    $output = $runner->runMaker(
+                        [],
+                        \sprintf('--no-interaction User --field=%s', $definition),
+                        allowedToFail: true
+                    );
+
+                    self::assertStringContainsString($expectedError, $output, \sprintf('Definition "%s" was not rejected.', $definition));
+                    // nothing is written before every definition has been parsed
+                    self::assertFileDoesNotExist($runner->getPath('src/Entity/User.php'));
+                }
+            }),
+        ];
+
+        yield 'it_rejects_the_field_option_when_regenerating' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker(
+                    [],
+                    '--no-interaction --regenerate --field=name:string',
+                    allowedToFail: true
+                );
+
+                self::assertStringContainsString('cannot be combined with "--regenerate"', $output);
+            }),
+        ];
     }
 
     /** @param array<string, mixed> $data */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

`make:entity` is the only maker with no non-interactive path. The entity name can be passed
as an argument, but every field is asked for in a `while (true)` loop, so the command can't
be scripted, can't run in a non-interactive shell, and can't be used by anything that isn't
a person at a terminal.

This adds a repeatable `--field` option:

```console
$ php bin/console make:entity BlogPost \
    --field=title:string:100 \
    --field=body:text \
    --field=price:decimal:10:2 \
    --field=publishedAt \
    --field=status:enum:Status \
    --no-interaction
```

The format is `name[:type[:length]]` with a trailing `?` for nullable. Each option adds one
field, exactly as one pass through the interactive loop does.

A few details worth pointing out:

- **The type is optional.** When it's left out, the same guess the interactive mode makes
  applies, so `--field=publishedAt` yields a `datetime_immutable` and `--field=isActive` a
  `boolean`. That heuristic was inline in `askForNextField()`; it's now a small private
  method both paths call, which is the only change to existing behaviour.
- **Enums take their class as the third part**, and a short name is enough while it is
  unique within `src/` — `--field=status:enum:Status` — which spares the caller from
  escaping backslashes in the shell. `--field=labels:enum:Label,multiple` stores several
  values. One subtlety worth flagging for review: the interactive mode settles the column
  type *inside* its enum branch, which runs after the branch that assigns a length, so an
  enum never carries a `length`. The parser mirrors that rather than falling through the
  `string` branch, and a test asserts it.
- **Relations are rejected** with a message pointing back to the interactive mode. They
  need follow-up questions (target entity, direction, inverse side, orphan removal) that
  don't compress into a single string without inventing a syntax nobody asked for. Scoping
  them out keeps this addition reviewable; a follow-up PR adds a `--relation` option.
- **Definitions are parsed before anything is written**, so an invalid one fails without
  leaving a half-created entity behind. That includes a definition colliding with the `id`
  the entity is about to be generated with.
- **Nullable is only set when asked for**, matching the interactive path — otherwise the
  generated attribute picks up a redundant `nullable: false`.
- **Errors stay errors.** `Validator::validateDoctrineFieldName()` throws an
  `\InvalidArgumentException`, which the interactive question validator catches to re-ask.
  With no one to ask, it is wrapped in a `RuntimeCommandException` so a reserved word or an
  invalid property name prints a clean error box instead of a stack trace.

Tests cover the happy path (including the type guess and the absence of `nullable: false`),
enum fields resolved both by short name and by full class name, and the rejected
definitions — relation, missing or unknown enum class, unknown type, `id` collision,
invalid length, a surplus segment, an unknown modifier and an invalid property name.

### Why

Coding agents are the immediate motivation. An agent asked to add an entity today either
drives an interactive prompt it can't see, or gives up and hand-writes the class — which is
how projects end up with entities that don't look like the ones `make:entity` produces. The
same applies to any script, Makefile or fixture setup that wants to scaffold without a
human present.
