### PR TITLE
Fix the failing tests on 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "doctrine/doctrine-bundle": "^2.10|^3.0",
         "doctrine/orm": "^2.15|^3",
         "doctrine/persistence": "^3.1|^4.0",
+        "symfony/doctrine-bridge": "^7.4|^8.1",
         "symfony/http-client": "^7.4|^8.1",
         "symfony/phpunit-bridge": "^7.4|^8.1",
         "symfony/security-core": "^7.4|^8.1",

--- a/tests/Maker/MakeTestTest.php
+++ b/tests/Maker/MakeTestTest.php
@@ -88,6 +88,15 @@ class MakeTestTest extends MakerTestCase
                     ''
                 );
 
+                // Panther serves the app under PANTHER_APP_ENV, which its recipe sets to "panther",
+                // and the Symfony 8 skeleton refuses any environment its kernel does not list
+                $runner->replaceInFile(
+                    'src/Kernel.php',
+                    "return ['prod', 'dev', 'test'];",
+                    "return ['prod', 'dev', 'test', 'panther'];",
+                    allowNotFound: true
+                );
+
                 $runner->runMaker(
                     [
                         // type

--- a/tests/fixtures/make-form/tests/it_generates_form_with_many_to_many_relation.php
+++ b/tests/fixtures/make-form/tests/it_generates_form_with_many_to_many_relation.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class GeneratedFormTest extends TypeTestCase
@@ -74,7 +75,7 @@ class GeneratedFormTest extends TypeTestCase
         ];
     }
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         $mockEntityManager = $this->createMock(EntityManager::class);
         $mockEntityManager->method('getClassMetadata')
@@ -107,6 +108,6 @@ class GeneratedFormTest extends TypeTestCase
         $mockRegistry->method('getManagers')
             ->willReturn([$mockEntityManager]);
 
-        return array_merge(parent::getExtensions(), [new DoctrineOrmExtension($mockRegistry)]);
+        return array_merge(parent::getExtensions($violationMapper), [new DoctrineOrmExtension($mockRegistry)]);
     }
 }

--- a/tests/fixtures/make-form/tests/it_generates_form_with_many_to_one_relation.php
+++ b/tests/fixtures/make-form/tests/it_generates_form_with_many_to_one_relation.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 
@@ -43,7 +44,7 @@ class GeneratedFormTest extends TypeTestCase
         }
     }
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         $mockEntityManager = $this->createMock(EntityManager::class);
         $mockEntityManager->method('getClassMetadata')
@@ -78,6 +79,6 @@ class GeneratedFormTest extends TypeTestCase
             ->willReturn([$mockEntityManager])
         ;
 
-        return array_merge(parent::getExtensions(), [new DoctrineOrmExtension($mockRegistry)]);
+        return array_merge(parent::getExtensions($violationMapper), [new DoctrineOrmExtension($mockRegistry)]);
     }
 }

--- a/tests/fixtures/make-form/tests/it_generates_form_with_one_to_one_relation.php
+++ b/tests/fixtures/make-form/tests/it_generates_form_with_one_to_one_relation.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
+use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 
@@ -43,7 +44,7 @@ class GeneratedFormTest extends TypeTestCase
         }
     }
 
-    protected function getExtensions(): array
+    protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         $mockEntityManager = $this->createMock(EntityManager::class);
         $mockEntityManager->method('getClassMetadata')
@@ -78,6 +79,6 @@ class GeneratedFormTest extends TypeTestCase
             ->willReturn([$mockEntityManager])
         ;
 
-        return array_merge(parent::getExtensions(), [new DoctrineOrmExtension($mockRegistry)]);
+        return array_merge(parent::getExtensions($violationMapper), [new DoctrineOrmExtension($mockRegistry)]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The `CI Linux` workflow has been red on `1.x` for a while — three of its four jobs fail,
for three unrelated reasons. None of them is a bug in a maker; all three are the test
suite (or its dependency constraints) not having caught up with Symfony 8.

### `MakeFormTest`, three relation cases

These copy a fixture test into the generated project and run PHPUnit *in* it. The inner
run reports `OK (1 test, 4 assertions)` and still exits non-zero:

```
Remaining self deprecation notices (1)

  1x: The "App\Tests\GeneratedFormTest::getExtensions()" method will require a new
      "ViolationMapperInterface|null $violationMapper" argument in the next major version
      of its parent class "Symfony\Component\Form\Test\TypeTestCase", not defining it is
      deprecated.
```

`TypeTestCase::getExtensions()` announces the argument with a commented-out signature and
a `@param`, `DebugClassLoader` turns the missing argument into a *self* deprecation, and
`SYMFONY_DEPRECATIONS_HELPER=max[self]=0` makes it fatal. The three fixtures now declare
the argument and forward it. Adding an optional parameter to an override is legal against
the 7.4 parent too, and passing it on to a parent that does not take it is a no-op, so
this stays compatible with both branches.

### `MakeTestTest::it_makes_PantherTestCase_type`

```
Failed asserting that 'Symfony Exception' contains "Hello World".
```

The page Panther actually got is:

> The environment "panther" is not registered as allowed by `App\Kernel::getAllowedEnvs()`.

Panther serves the app under `PANTHER_APP_ENV`, which its recipe sets to `panther`, and
the Symfony 8 skeleton kernel now rejects any environment missing from `getAllowedEnvs()`.
The test adds `panther` to that list, which is what an application would have to do. The
replacement is `allowNotFound`, since the 7.4 skeleton has no such method.

### `PHP 8.2 + @7.4.* lowest deps`

This job dies with a compile error partway through the suite, taking the whole process
down with exit code 255:

```
Declaration of Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer::warmUp(string $cacheDir): array
must be compatible with WarmableInterface::warmUp(string $cacheDir, ?string $buildDir = null): array
```

`symfony/doctrine-bridge` is only pulled in transitively through DoctrineBundle, so nothing
constrains it and `--prefer-lowest` resolves it to `6.4.0` — predating the `$buildDir`
argument `WarmableInterface` has carried since 7.1 — while `symfony/http-kernel` is held at
`7.4` by this package's own constraint. Requiring it in the same range as the other Symfony
components makes `--prefer-lowest` pick `7.4.0`:

```
- Downgrading symfony/doctrine-bridge (8.2.x-dev => v6.4.0)   # before
- Downgrading symfony/doctrine-bridge (8.2.x-dev => v7.4.0)   # after
```

### Verification

Each fix was reproduced locally before and after, against both skeletons
(`SYMFONY_VERSION=8.*` and `SYMFONY_VERSION=7.4.*`):

- the form fixtures: inner PHPUnit exit code `1` → `0`, deprecation gone
- Panther: reproduced the error page, then green on 7.4 and 8
- lowest deps: `composer update --prefer-lowest` now resolves a compatible pair, and
  `ProxyCacheWarmer::warmUp()` and `WarmableInterface::warmUp()` agree by reflection
