### PR TITLE
[make:entity] Stop the second relation from overwriting the entity

### DIFF
--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -305,8 +305,8 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
                 throw new \Exception('Invalid value.');
             }
 
-            foreach ($fileManagerOperations as $path => $manipulator) {
-                $this->fileManager->dumpFile($path, $manipulator->getSourceCode());
+            foreach ($fileManagerOperations as $path => $pendingManipulator) {
+                $this->fileManager->dumpFile($path, $pendingManipulator->getSourceCode());
             }
         }
 

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -339,6 +339,50 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_adds_two_relations_in_one_run' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+                self::copyEntity($runner, 'UserAvatarPhoto-basic.php');
+
+                $runner->runMaker([
+                    // entity class name
+                    'Bar',
+                    'author',
+                    'relation',
+                    'User',
+                    'ManyToOne',
+                    // nullable
+                    'n',
+                    // map the inverse side
+                    'y',
+                    // inverse property name - use the default
+                    '',
+                    // orphanRemoval
+                    'n',
+                    'photo',
+                    'relation',
+                    'UserAvatarPhoto',
+                    'ManyToOne',
+                    'n',
+                    'y',
+                    '',
+                    'n',
+                    // finish adding fields
+                    '',
+                ]);
+
+                // writing the second relation used to feed the previous target's manipulator
+                // back into this entity's file, leaving Bar.php with a copy of User
+                self::assertStringContainsString('class Bar', file_get_contents($runner->getPath('src/Entity/Bar.php')));
+                self::assertStringContainsString('class User', file_get_contents($runner->getPath('src/Entity/User.php')));
+                self::assertStringContainsString('class UserAvatarPhoto', file_get_contents($runner->getPath('src/Entity/UserAvatarPhoto.php')));
+
+                $bar = file_get_contents($runner->getPath('src/Entity/Bar.php'));
+                self::assertStringContainsString('private ?User $author = null;', $bar);
+                self::assertStringContainsString('private ?UserAvatarPhoto $photo = null;', $bar);
+            }),
+        ];
+
         yield 'it_adds_many_to_many_simple' => [self::createMakeEntityTest()
             ->run(static function (MakerTestRunner $runner) {
                 self::copyEntity($runner, 'User-basic.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Adding **two relations in a single `make:entity` run** overwrites the entity being created
with a copy of the first relation's target class.

```console
$ php bin/console make:entity
 > Bar
 > author   relation  User             ManyToOne  (not nullable, map the inverse side)
 > photo    relation  UserAvatarPhoto  ManyToOne  (not nullable, map the inverse side)

  Success!

$ head -11 src/Entity/Bar.php
class User
```

`Bar.php` now contains `User`. Purely interactive, no options involved, reproducible on
`1.x` as of 11dce35.

### Cause

`generate()` creates one manipulator for the entity being edited, before the field loop:

```php
$manipulator = $this->createClassManipulator($entityPath, $io, $overwrite);
```

and each pass through the loop queues it, plus the class on the other side of a relation:

```php
$fileManagerOperations[$entityPath] = $manipulator;
// ...
$fileManagerOperations[$otherManipulatorFilename] = $otherManipulator;
```

The loop that writes them out reuses that same variable name:

```php
foreach ($fileManagerOperations as $path => $manipulator) {
    $this->fileManager->dumpFile($path, $manipulator->getSourceCode());
}
```

so once a relation has queued two entries, `$manipulator` is left pointing at the *other*
class. The next pass through the field loop then queues that stale manipulator under
`$entityPath`, and the entity is written with the other class's source.

A single relation per run stays correct, which is why this went unnoticed: with one queued
pair the stale manipulator is only ever reassigned to its own path.

### Fix

Rename the loop variable. The regression test adds two `ManyToOne` relations in one run and
asserts each of the three files still declares its own class; it fails on `1.x` and passes
with the fix.
