### PR TITLE
[make:entity] Add a --relation option to add relations without prompting

### DIFF
--- a/config/help/MakeEntity.txt
+++ b/config/help/MakeEntity.txt
@@ -39,5 +39,21 @@ Append <comment>,multiple</comment> to store several values:
 
 <info>php %command.full_name% BlogPost --field=status:enum:Status --field=labels:enum:Label,multiple</info>
 
-Relations are not supported by this option - run the command without <comment>--field</comment>
-to be guided through them.
+Relations use their own option, <comment>name:type:target</comment>, where the target is an entity
+class - its short name is enough:
+
+<info>php %command.full_name% BlogPost --relation=author:ManyToOne:User --relation=tags:ManyToMany:Tag</info>
+
+A trailing <comment>?</comment> makes the relation nullable here too. Note that this differs from the
+interactive mode, which offers <comment>nullable</comment> as its default answer: without a <comment>?</comment> the
+relation is NOT NULL.
+
+By default the property added to the other class is named after this entity, and a
+<comment>OneToOne</comment> does not add one at all - the interactive mode advises against it, because
+Doctrine cannot lazy load an inverse <comment>OneToOne</comment>. Both are controlled with
+<comment>target-field</comment>, and <comment>orphan-removal</comment> activates orphanRemoval on the relations that
+support it:
+
+<info>php %command.full_name% BlogPost --relation=cover:OneToOne:Media,target-field=post</info>
+<info>php %command.full_name% BlogPost --relation=author:ManyToOne:User,target-field=none</info>
+<info>php %command.full_name% BlogPost --relation=comments:OneToMany:Comment,orphan-removal</info>

--- a/src/Maker/MakeEntity.php
+++ b/src/Maker/MakeEntity.php
@@ -99,6 +99,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             ->addOption('regenerate', null, InputOption::VALUE_NONE, 'Instead of adding new fields, simply generate the methods (e.g. getter/setter) for existing fields')
             ->addOption('overwrite', null, InputOption::VALUE_NONE, 'Overwrite any existing getter/setter methods')
             ->addOption('field', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add a field without being asked for it: <fg=yellow>name[:type[:length]][?]</> (e.g. <fg=yellow>title:string:100</>). Repeat the option for each field')
+            ->addOption('relation', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add a relation without being asked for it: <fg=yellow>name:type:target[?]</> (e.g. <fg=yellow>author:ManyToOne:User</>). Repeat the option for each relation')
             ->setHelp($this->getHelpFileContents('MakeEntity.txt'))
         ;
 
@@ -175,11 +176,12 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
     {
         $overwrite = $input->getOption('overwrite');
         $fieldOptions = $input->getOption('field');
+        $relationOptions = $input->getOption('relation');
 
         // the regenerate option has entirely custom behavior
         if ($input->getOption('regenerate')) {
-            if ($fieldOptions) {
-                throw new RuntimeCommandException('The "--field" option cannot be combined with "--regenerate", which only generates methods for existing fields.');
+            if ($fieldOptions || $relationOptions) {
+                throw new RuntimeCommandException('The "--field" and "--relation" options cannot be combined with "--regenerate", which only generates methods for existing fields.');
             }
 
             $this->regenerateEntities($input->getArgument('name'), $overwrite, $generator);
@@ -196,8 +198,10 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         $classExists = class_exists($entityClassDetails->getFullName());
 
         // a class that does not exist yet is about to be generated with an "id" property, so that name is taken
-        $queuedFields = $fieldOptions ? $this->parseFieldOptions(
+        $queuedFields = $fieldOptions || $relationOptions ? $this->parseDefinitions(
             $fieldOptions,
+            $relationOptions,
+            $entityClassDetails->getFullName(),
             $classExists ? $this->getPropertyNames($entityClassDetails->getFullName()) : ['id'],
         ) : null;
 
@@ -262,7 +266,9 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             } elseif ($newField instanceof EntityRelation) {
                 // both overridden below for OneToMany
                 $newFieldName = $newField->getOwningProperty();
-                if ($newField->isSelfReferencing()) {
+                if ($newField->isSelfReferencing() || $newField->getInverseClass() === $entityClassDetails->getFullName()) {
+                    // either the relation is self referencing, or it is a OneToMany, whose
+                    // branch below resolves the owning class itself and discards what is set here
                     $otherManipulatorFilename = $entityPath;
                     $otherManipulator = $manipulator;
                 } else {
@@ -352,23 +358,246 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
     }
 
     /**
-     * @param string[] $definitions
+     * @param string[] $fieldDefinitions
+     * @param string[] $relationDefinitions
      * @param string[] $currentFields
      *
-     * @return ClassProperty[]
+     * @return array<ClassProperty|EntityRelation>
      */
-    private function parseFieldOptions(array $definitions, array $currentFields): array
+    private function parseDefinitions(array $fieldDefinitions, array $relationDefinitions, string $entityClass, array $currentFields): array
     {
-        $properties = [];
+        $queued = [];
 
-        foreach ($definitions as $definition) {
+        foreach ($fieldDefinitions as $definition) {
             $property = $this->parseFieldOption($definition, $currentFields);
 
             $currentFields[] = $property->propertyName;
-            $properties[] = $property;
+            $queued[] = $property;
         }
 
-        return $properties;
+        // the properties the queued relations add to classes on the other side, so that two
+        // relations sharing a target cannot both fall back to the same name on it
+        $claimedTargetFields = [];
+
+        foreach ($relationDefinitions as $definition) {
+            $relation = $this->parseRelationOption($definition, $entityClass, $currentFields, $claimedTargetFields);
+
+            if ($relation->getOwningClass() === $entityClass) {
+                $currentFields[] = $relation->getOwningProperty();
+            }
+
+            if ($relation->getMapInverseRelation() && $relation->getInverseClass() === $entityClass) {
+                $currentFields[] = $relation->getInverseProperty();
+            }
+
+            $queued[] = $relation;
+        }
+
+        return $queued;
+    }
+
+    /**
+     * @param string[]                $currentFields
+     * @param array<string, string[]> $claimedTargetFields
+     */
+    private function parseRelationOption(string $definition, string $entityClass, array $currentFields, array &$claimedTargetFields): EntityRelation
+    {
+        [$head, $nullable, $modifiers] = $this->splitDefinition($definition);
+
+        $parts = explode(':', $head);
+        $fieldName = $this->parsePropertyName(array_shift($parts), $definition, $currentFields);
+        $type = array_shift($parts) ?? '';
+
+        if (!\in_array($type, EntityRelation::getValidRelationTypes(), true)) {
+            throw new RuntimeCommandException(\sprintf('Invalid relation type "%s" in "%s". Expected one of: "%s".', $type, $definition, implode('", "', EntityRelation::getValidRelationTypes())));
+        }
+
+        $targetClass = $this->resolveRelationTarget(array_shift($parts) ?? '', $entityClass, $definition);
+
+        if ($parts) {
+            throw new RuntimeCommandException(\sprintf('The relation "%s" has more options than "%s" accepts.', $definition, $type));
+        }
+
+        $targetField = $modifiers['target-field'] ?? null;
+        unset($modifiers['target-field']);
+
+        if (true === $targetField) {
+            throw new RuntimeCommandException(\sprintf('The "target-field" modifier of "%s" needs a value: a property name, or "none".', $definition));
+        }
+
+        $orphanRemoval = $this->takeFlag($modifiers, 'orphan-removal', $definition);
+
+        if ($modifiers) {
+            throw new RuntimeCommandException(\sprintf('Unknown modifier "%s" in the relation "%s".', array_key_first($modifiers), $definition));
+        }
+
+        $shortName = Str::getShortClassName($entityClass);
+
+        switch ($type) {
+            case EntityRelation::MANY_TO_ONE:
+                $relation = new EntityRelation(EntityRelation::MANY_TO_ONE, $entityClass, $targetClass);
+                $relation->setOwningProperty($fieldName);
+                $relation->setIsNullable($nullable);
+
+                $this->mapRelationInverseSide($relation, $targetField, Str::singularCamelCaseToPluralCamelCase($shortName), true, $definition, $currentFields, $claimedTargetFields);
+
+                // orphan removal only applies if the inverse relation is set
+                $this->setRelationOrphanRemoval($relation, $orphanRemoval, $definition, $relation->getMapInverseRelation() && !$nullable);
+
+                break;
+
+            case EntityRelation::ONE_TO_MANY:
+                // a OneToMany is really a ManyToOne owned by the class on the other side
+                $relation = new EntityRelation(EntityRelation::MANY_TO_ONE, $targetClass, $entityClass);
+                $relation->setInverseProperty($fieldName);
+                $relation->setIsNullable($nullable);
+
+                if ('none' === $targetField) {
+                    throw new RuntimeCommandException(\sprintf('The relation "%s" cannot use "target-field=none": a OneToMany exists only through the property it adds to the other class.', $definition));
+                }
+
+                if (!$relation->isSelfReferencing() && $this->isClassInVendor($targetClass)) {
+                    throw new RuntimeCommandException(\sprintf('The relation "%s" has to add a property to "%s", which lives in vendor/.', $definition, $targetClass));
+                }
+
+                $relation->setOwningProperty($this->claimTargetField(
+                    $targetField ?? Str::asLowerCamelCase($shortName),
+                    $targetClass,
+                    $definition,
+                    $relation->isSelfReferencing() ? $currentFields : [],
+                    $claimedTargetFields,
+                ));
+
+                $this->setRelationOrphanRemoval($relation, $orphanRemoval, $definition, !$nullable);
+
+                break;
+
+            case EntityRelation::MANY_TO_MANY:
+                if ($nullable) {
+                    throw new RuntimeCommandException(\sprintf('The relation "%s" cannot be nullable: a ManyToMany is a collection, which is empty rather than null.', $definition));
+                }
+
+                $relation = new EntityRelation(EntityRelation::MANY_TO_MANY, $entityClass, $targetClass);
+                $relation->setOwningProperty($fieldName);
+
+                $this->mapRelationInverseSide($relation, $targetField, Str::singularCamelCaseToPluralCamelCase($shortName), true, $definition, $currentFields, $claimedTargetFields);
+                $this->setRelationOrphanRemoval($relation, $orphanRemoval, $definition, false);
+
+                break;
+
+            case EntityRelation::ONE_TO_ONE:
+                $relation = new EntityRelation(EntityRelation::ONE_TO_ONE, $entityClass, $targetClass);
+                $relation->setOwningProperty($fieldName);
+                $relation->setIsNullable($nullable);
+
+                // the interactive mode recommends against mapping the inverse side of a
+                // OneToOne, because Doctrine cannot lazy load it
+                $this->mapRelationInverseSide($relation, $targetField, Str::asLowerCamelCase($shortName), false, $definition, $currentFields, $claimedTargetFields);
+                $this->setRelationOrphanRemoval($relation, $orphanRemoval, $definition, false);
+
+                break;
+
+            default:
+                throw new \LogicException(\sprintf('Unhandled relation type "%s".', $type));
+        }
+
+        return $relation;
+    }
+
+    /**
+     * Decides which property the relation adds to the class on the other side, and whether
+     * that side is mapped at all.
+     *
+     * @param string[]                $currentFields
+     * @param array<string, string[]> $claimedTargetFields
+     */
+    private function mapRelationInverseSide(EntityRelation $relation, ?string $targetField, string $default, bool $mapByDefault, string $definition, array $currentFields, array &$claimedTargetFields): void
+    {
+        $inverseClass = $relation->getInverseClass();
+
+        if (!$relation->isSelfReferencing() && $this->isClassInVendor($inverseClass)) {
+            if (null !== $targetField && 'none' !== $targetField) {
+                throw new RuntimeCommandException(\sprintf('The relation "%s" cannot add a property to "%s", which lives in vendor/.', $definition, $inverseClass));
+            }
+
+            $relation->setMapInverseRelation(false);
+
+            return;
+        }
+
+        if ('none' === $targetField || (null === $targetField && !$mapByDefault)) {
+            $relation->setMapInverseRelation(false);
+
+            return;
+        }
+
+        $relation->setInverseProperty($this->claimTargetField(
+            $targetField ?? $default,
+            $inverseClass,
+            $definition,
+            $relation->isSelfReferencing() ? $currentFields : [],
+            $claimedTargetFields,
+        ));
+    }
+
+    private function setRelationOrphanRemoval(EntityRelation $relation, bool $orphanRemoval, string $definition, bool $applies): void
+    {
+        if (!$orphanRemoval) {
+            return;
+        }
+
+        if (!$applies) {
+            throw new RuntimeCommandException(\sprintf('The relation "%s" cannot use "orphan-removal": it only applies to a ManyToOne or OneToMany that maps both sides and is not nullable.', $definition));
+        }
+
+        $relation->setOrphanRemoval(true);
+    }
+
+    /**
+     * @param string[]                $currentFields
+     * @param array<string, string[]> $claimedTargetFields
+     */
+    private function claimTargetField(string $propertyName, string $targetClass, string $definition, array $currentFields, array &$claimedTargetFields): string
+    {
+        try {
+            Validator::validateDoctrineFieldName($propertyName, $this->doctrineHelper->getRegistry());
+        } catch (\InvalidArgumentException $e) {
+            throw new RuntimeCommandException($e->getMessage(), previous: $e);
+        }
+
+        $taken = array_merge($currentFields, $claimedTargetFields[$targetClass] ?? []);
+
+        if (\in_array($propertyName, $taken, true) || (class_exists($targetClass) && property_exists($targetClass, $propertyName))) {
+            throw new RuntimeCommandException(\sprintf('The "%s" class already has a "%s" property; name the one "%s" adds with "target-field=".', $targetClass, $propertyName, $definition));
+        }
+
+        $claimedTargetFields[$targetClass][] = $propertyName;
+
+        return $propertyName;
+    }
+
+    private function resolveRelationTarget(string $target, string $entityClass, string $definition): string
+    {
+        if (!$target) {
+            throw new RuntimeCommandException(\sprintf('The relation "%s" is missing the class it relates to.', $definition));
+        }
+
+        // a new entity is generated after this runs, so it cannot be looked up yet
+        if ($target === $entityClass || $target === Str::getShortClassName($entityClass)) {
+            return $entityClass;
+        }
+
+        // give the Entity namespace priority over the full class name, to avoid issues with
+        // classes like "Directory" that exist in PHP's core
+        if (class_exists($namespaced = $this->getEntityNamespace().'\\'.$target)) {
+            return $namespaced;
+        }
+
+        if (class_exists($target)) {
+            return $target;
+        }
+
+        throw new RuntimeCommandException(\sprintf('Unknown class "%s" in the relation "%s".', $target, $definition));
     }
 
     /**
@@ -379,27 +608,11 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
         [$head, $nullable, $modifiers] = $this->splitDefinition($definition);
 
         $parts = explode(':', $head);
-        $fieldName = array_shift($parts);
-
-        if (!$fieldName) {
-            throw new RuntimeCommandException(\sprintf('The field "%s" is missing a property name.', $definition));
-        }
-
-        if (\in_array($fieldName, $currentFields, true)) {
-            throw new RuntimeCommandException(\sprintf('The "%s" property already exists.', $fieldName));
-        }
-
-        try {
-            Validator::validateDoctrineFieldName($fieldName, $this->doctrineHelper->getRegistry());
-        } catch (\InvalidArgumentException $e) {
-            // the interactive mode asks again, there is nobody to ask here
-            throw new RuntimeCommandException($e->getMessage(), previous: $e);
-        }
-
+        $fieldName = $this->parsePropertyName(array_shift($parts), $definition, $currentFields);
         $type = array_shift($parts) ?: $this->guessFieldType($fieldName);
 
         if ('relation' === $type || \in_array($type, EntityRelation::getValidRelationTypes(), true)) {
-            throw new RuntimeCommandException(\sprintf('The "--field" option cannot add the relation "%s". Run the command without "--field" to be guided through it.', $fieldName));
+            throw new RuntimeCommandException(\sprintf('The "--field" option cannot add the relation "%s", use "--relation=%s:%s:<target>" instead.', $fieldName, $fieldName, 'relation' === $type ? 'ManyToOne' : $type));
         }
 
         if ('enum' === $type) {
@@ -440,7 +653,28 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
     }
 
     /**
-     * Splits <fieldName>[:<type>...][?][,<modifier>...] into those three parts.
+     * @param string[] $currentFields
+     */
+    private function parsePropertyName(string $propertyName, string $definition, array $currentFields): string
+    {
+        if (!$propertyName) {
+            throw new RuntimeCommandException(\sprintf('The definition "%s" is missing a property name.', $definition));
+        }
+
+        if (\in_array($propertyName, $currentFields, true)) {
+            throw new RuntimeCommandException(\sprintf('The "%s" property already exists.', $propertyName));
+        }
+
+        try {
+            return Validator::validateDoctrineFieldName($propertyName, $this->doctrineHelper->getRegistry());
+        } catch (\InvalidArgumentException $e) {
+            // the interactive mode asks again, there is nobody to ask here
+            throw new RuntimeCommandException($e->getMessage(), previous: $e);
+        }
+    }
+
+    /**
+     * Splits <name>[:<part>...][?][,<modifier>...] into those three parts.
      *
      * @return array{string, bool, array<string, string|true>}
      */
@@ -457,7 +691,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
 
         foreach ($modifiers as $modifier) {
             if (!$modifier) {
-                throw new RuntimeCommandException(\sprintf('The field "%s" has an empty modifier.', $definition));
+                throw new RuntimeCommandException(\sprintf('The definition "%s" has an empty modifier.', $definition));
             }
 
             [$name, $value] = explode('=', $modifier, 2) + [1 => true];
@@ -479,7 +713,7 @@ final class MakeEntity extends AbstractMaker implements InputAwareMakerInterface
             null => false,
             true, 'true' => true,
             'false' => false,
-            default => throw new RuntimeCommandException(\sprintf('The "%s" modifier of the field "%s" takes no value, or "true" or "false".', $name, $definition)),
+            default => throw new RuntimeCommandException(\sprintf('The "%s" modifier of "%s" takes no value, or "true" or "false".', $name, $definition)),
         };
     }
 

--- a/tests/Maker/MakeEntityTest.php
+++ b/tests/Maker/MakeEntityTest.php
@@ -870,6 +870,79 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_creates_relations_from_the_relation_option' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+
+                $runner->runMaker(
+                    [],
+                    '--no-interaction BlogPost'
+                    .' --relation=author:ManyToOne:User'
+                    .' --relation=editors:ManyToMany:User,target-field=editedPosts'
+                    .' --relation=comments:OneToMany:User,target-field=commentedPost'
+                    .' --relation=cover:OneToOne:User?'
+                    .' --relation=parent:ManyToOne:BlogPost?,target-field=children'
+                );
+
+                $blogPost = file_get_contents($runner->getPath('src/Entity/BlogPost.php'));
+                $user = file_get_contents($runner->getPath('src/Entity/User.php'));
+
+                self::assertStringContainsString('#[ORM\\ManyToOne(inversedBy: \'blogPosts\')]', $blogPost);
+                // without a "?" a relation is NOT NULL, which is where this differs from the
+                // interactive mode - there, nullable is the default answer
+                self::assertStringContainsString('#[ORM\\JoinColumn(nullable: false)]', $blogPost);
+                self::assertStringContainsString('private ?User $author = null;', $blogPost);
+                self::assertStringContainsString('#[ORM\\ManyToMany(targetEntity: User::class, inversedBy: \'editedPosts\')]', $blogPost);
+                self::assertStringContainsString('#[ORM\\OneToMany(targetEntity: User::class, mappedBy: \'commentedPost\')]', $blogPost);
+                self::assertStringContainsString('private ?User $cover = null;', $blogPost);
+                // a self reference resolves even though the class is generated afterwards
+                self::assertStringContainsString('#[ORM\\ManyToOne(targetEntity: self::class, inversedBy: \'children\')]', $blogPost);
+                self::assertStringContainsString('#[ORM\\OneToMany(targetEntity: self::class, mappedBy: \'parent\')]', $blogPost);
+
+                // the property added to the other class is named after this entity by default
+                self::assertStringContainsString('#[ORM\\OneToMany(targetEntity: BlogPost::class, mappedBy: \'author\')]', $user);
+                self::assertStringContainsString('private Collection $blogPosts;', $user);
+                self::assertStringContainsString('#[ORM\\ManyToMany(targetEntity: BlogPost::class, mappedBy: \'editors\')]', $user);
+                self::assertStringContainsString('private ?BlogPost $commentedPost = null;', $user);
+                // a OneToOne does not map its inverse side unless asked to
+                self::assertStringNotContainsString('$cover', $user);
+
+                // and Doctrine accepts every mapping that came out of it
+                $runner->updateSchema();
+            }),
+        ];
+
+        yield 'it_rejects_invalid_relation_options' => [self::createMakeEntityTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::copyEntity($runner, 'User-basic.php');
+
+                $invalidRelations = [
+                    '--relation=author:ManyToOne' => 'is missing the class it relates to',
+                    '--relation=author:ManyToOne:Nope' => 'Unknown class "Nope"',
+                    '--relation=author:Wrong:User' => 'Invalid relation type "Wrong"',
+                    '--relation=tags:ManyToMany:User?' => 'cannot be nullable',
+                    '--relation=author:ManyToOne:User?,orphan-removal' => 'orphan-removal',
+                    '--relation=comments:OneToMany:User,target-field=none' => 'target-field=none',
+                    '--relation=author:ManyToOne:User,target-field' => 'needs a value',
+                    '--relation=author:ManyToOne:User,nope' => 'Unknown modifier "nope"',
+                    // both would name their property on User after this entity
+                    '--relation=createdBy:ManyToOne:User --relation=updatedBy:ManyToOne:User' => 'blogPosts',
+                ];
+
+                foreach ($invalidRelations as $arguments => $expectedError) {
+                    $output = $runner->runMaker(
+                        [],
+                        \sprintf('--no-interaction BlogPost %s', $arguments),
+                        allowedToFail: true
+                    );
+
+                    self::assertStringContainsString($expectedError, $output, \sprintf('"%s" was not rejected.', $arguments));
+                    // nothing is written before every definition has been parsed
+                    self::assertFileDoesNotExist($runner->getPath('src/Entity/BlogPost.php'));
+                }
+            }),
+        ];
+
         yield 'it_rejects_invalid_field_options' => [self::createMakeEntityTest()
             ->run(static function (MakerTestRunner $runner) {
                 $invalidDefinitions = [
@@ -902,15 +975,17 @@ class MakeEntityTest extends MakerTestCase
             }),
         ];
 
-        yield 'it_rejects_the_field_option_when_regenerating' => [self::createMakeEntityTest()
+        yield 'it_rejects_the_field_and_relation_options_when_regenerating' => [self::createMakeEntityTest()
             ->run(static function (MakerTestRunner $runner) {
-                $output = $runner->runMaker(
-                    [],
-                    '--no-interaction --regenerate --field=name:string',
-                    allowedToFail: true
-                );
+                foreach (['--field=name:string', '--relation=author:ManyToOne:User'] as $option) {
+                    $output = $runner->runMaker(
+                        [],
+                        \sprintf('--no-interaction --regenerate %s', $option),
+                        allowedToFail: true
+                    );
 
-                self::assertStringContainsString('cannot be combined with "--regenerate"', $output);
+                    self::assertStringContainsString('cannot be combined with', $output, \sprintf('"%s" was not rejected.', $option));
+                }
             }),
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

> [!NOTE]
> Built on #1810 (`--field`) and #1812 (a relation-writing bug that makes this unusable
> otherwise). Both appear in the diff until they are merged — review them first.

#1810 gave `make:entity` a non-interactive path for columns. Relations still need a person
at a prompt: `askRelationDetails()` asks for the target entity, the direction, nullability,
whether to map the inverse side and under which name, and orphan removal.

```console
$ php bin/console make:entity BlogPost \
    --relation=author:ManyToOne:User \
    --relation=comments:OneToMany:Comment \
    --relation=tags:ManyToMany:Tag \
    --no-interaction
```

The format is `name:type:target`, repeatable. The target may be a short name — it is
resolved against the entity namespace first, exactly as the prompt does — which spares
escaping backslashes in a shell. A trailing `?` makes the relation nullable, and two
modifiers cover the rest:

| Modifier | Meaning | Applies to | Default |
| --- | --- | --- | --- |
| `target-field=<prop>` | name of the property added to the **other** class | all | named after this entity |
| `target-field=none` | leave the other class alone | MTO, MTM, OTO | — |
| `orphan-removal` | activate orphanRemoval | MTO, OTM | off |

```console
--relation=author:ManyToOne:User?,target-field=posts
--relation=cover:OneToOne:Media,target-field=owner
--relation=comments:OneToMany:Comment,orphan-removal
```

### Decisions worth reviewing

- **Nullability is the one deliberate difference from the prompt.** `SymfonyStyle::confirm()`
  defaults to `true`, so the interactive mode preselects *nullable* for a relation while
  `--field` asks with `false` for a column. On the command line both follow the same rule
  instead: no `?` means NOT NULL. A prompt default is a suggestion, not a semantic — there
  is no single "what a human would have produced", since that depends on whether they hit
  enter. One rule that reads the same for a column and a relation seemed worth more, and it
  is called out in the help text.
- **`target-field`, not `inverse`.** For a `OneToMany` the property created on the target is
  the *owning* side, so calling it `inverse` would be wrong Doctrine terminology.
  `target-field` describes the same thing correctly for all four types.
- **A `OneToOne` does not map its inverse side by default**, following the interactive
  recommendation — that one encodes a real trade-off, since Doctrine cannot lazy load an
  inverse `OneToOne`.
- **Errors instead of silent no-ops.** The prompt simply does not ask about orphan removal
  when it cannot apply, and silently forces the inverse side off for a class in `vendor/`.
  In a script both would be traps, so they are rejected: an unknown target, a nullable
  `ManyToMany`, `orphan-removal` on a relation that cannot carry it, a `target-field` on a
  vendor class, and two relations whose properties on a shared target would collide
  (`createdBy` and `updatedBy` both defaulting to `blogPosts` on `User`).

### One thing the interactive mode gets away with

Resolving the target has to cope with the entity not existing yet, so a self reference is
matched against the class about to be generated instead of being looked up.

The same problem bit `generate()` one level down. It resolves the class on the other side
of a relation through reflection, which fails for an entity created moments earlier: the
`class_exists()` at the top of `generate()` poisons Composer's `missingClasses` cache before
the file is written. The interactive mode never notices, because asking for the target
entity calls `getEntitiesForAutocomplete()` → `getMetadata()`, which loads every entity
class as a side effect. Nothing does that when the relation comes from an option.

That lookup is discarded for a `OneToMany` anyway — the branch below recomputes both the
filename and the manipulator from the owning class — so it is now skipped when the class on
the other side is the entity being edited.

### Tests

One case generates all four relation types plus a self reference in a single run, asserts
the attributes on *both* classes, and finishes with `doctrine:schema:update` so Doctrine
itself validates every mapping. A second walks the rejected definitions listed above.
