### PR TITLE
[make:crud] Fix the crash under --no-interaction and add --controller-class

### DIFF
--- a/config/help/MakeCrud.txt
+++ b/config/help/MakeCrud.txt
@@ -3,3 +3,9 @@ The <info>%command.name%</info> command generates crud controller with templates
 <info>php %command.full_name% BlogPost</info>
 
 If the argument is missing, the command will ask for the entity class name interactively.
+
+The controller class is asked for too, and defaults to the entity name plus
+<comment>Controller</comment>. Pass it up front to skip that question, which is what you want in
+a script or when the terminal is not interactive:
+
+<info>php %command.full_name% BlogPost --controller-class=BlogPostAdminController --no-interaction</info>

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -33,6 +33,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,7 +50,6 @@ final class MakeCrud extends AbstractMaker
     use CanGenerateTestsTrait;
 
     private Inflector $inflector;
-    private string $controllerClassName;
     private bool $generateTests = false;
 
     public function __construct(private DoctrineHelper $doctrineHelper, private FormTypeRenderer $formTypeRenderer)
@@ -71,6 +71,7 @@ final class MakeCrud extends AbstractMaker
     {
         $command
             ->addArgument('entity-class', InputArgument::OPTIONAL, \sprintf('The class name of the entity to create CRUD (e.g. <fg=yellow>%s</>)', Str::asClassName(Str::getRandomTerm())))
+            ->addOption('controller-class', null, InputOption::VALUE_REQUIRED, 'The class name of the controller to create (e.g. <fg=yellow>SweetFoodAdminController</>), defaults to the entity name plus "Controller"')
             ->setHelp($this->getHelpFileContents('MakeCrud.txt'))
         ;
 
@@ -93,12 +94,14 @@ final class MakeCrud extends AbstractMaker
             $input->setArgument('entity-class', $value);
         }
 
-        $defaultControllerClass = Str::asClassName(\sprintf('%s Controller', $input->getArgument('entity-class')));
+        if (null === $input->getOption('controller-class')) {
+            $defaultControllerClass = self::getDefaultControllerClass($input->getArgument('entity-class'));
 
-        $this->controllerClassName = $io->ask(
-            \sprintf('Choose a name for your controller class (e.g. <fg=yellow>%s</>)', $defaultControllerClass),
-            $defaultControllerClass
-        );
+            $input->setOption('controller-class', $io->ask(
+                \sprintf('Choose a name for your controller class (e.g. <fg=yellow>%s</>)', $defaultControllerClass),
+                $defaultControllerClass
+            ));
+        }
 
         $this->interactSetGenerateTests($input, $io);
     }
@@ -109,6 +112,8 @@ final class MakeCrud extends AbstractMaker
             Validator::entityExists($input->getArgument('entity-class'), $this->doctrineHelper->getEntitiesForAutocomplete()),
             'Entity\\'
         );
+
+        $controllerClassName = $input->getOption('controller-class') ?? self::getDefaultControllerClass($input->getArgument('entity-class'));
 
         $entityDoctrineDetails = $this->doctrineHelper->createDoctrineDetails($entityClassDetails->getFullName());
 
@@ -132,7 +137,7 @@ final class MakeCrud extends AbstractMaker
         }
 
         $controllerClassDetails = $generator->createClassNameDetails(
-            $this->controllerClassName,
+            $controllerClassName,
             'Controller\\',
             'Controller'
         );
@@ -148,7 +153,7 @@ final class MakeCrud extends AbstractMaker
         } while (class_exists($formClassDetails->getFullName()));
 
         $controllerClassData = ClassData::create(
-            class: \sprintf('Controller\%s', $this->controllerClassName),
+            class: \sprintf('Controller\%s', $controllerClassName),
             suffix: 'Controller',
             extendsClass: AbstractController::class,
             useStatements: [
@@ -290,6 +295,11 @@ final class MakeCrud extends AbstractMaker
         $this->writeSuccessMessage($io);
 
         $io->text(\sprintf('Next: Check your new CRUD by going to <fg=yellow>%s/</>', Str::asRoutePath($controllerClassDetails->getRelativeNameWithoutSuffix())));
+    }
+
+    private static function getDefaultControllerClass(string $entityClass): string
+    {
+        return Str::asClassName(\sprintf('%s Controller', $entityClass));
     }
 
     public function configureDependencies(DependencyBuilder $dependencies): void

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -65,6 +65,44 @@ class MakeCrudTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_crud_non_interactively_with_a_controller_class' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-crud/SweetFood.php',
+                    'src/Entity/SweetFood.php'
+                );
+
+                $output = $runner->runMaker(
+                    [],
+                    '--no-interaction SweetFood --controller-class=SweetFoodAdminController'
+                );
+
+                self::assertStringContainsString('src/Controller/SweetFoodAdminController.php', $output);
+                self::assertStringContainsString(
+                    'class SweetFoodAdminController',
+                    file_get_contents($runner->getPath('src/Controller/SweetFoodAdminController.php'))
+                );
+
+                self::runCrudTest($runner, 'it_generates_crud_with_custom_controller.php');
+            }),
+        ];
+
+        yield 'it_generates_crud_non_interactively_without_a_controller_class' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-crud/SweetFood.php',
+                    'src/Entity/SweetFood.php'
+                );
+
+                // the name the interactive mode offers as its default, without being asked for it
+                $output = $runner->runMaker([], '--no-interaction SweetFood');
+
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+
+                self::runCrudTest($runner, 'it_generates_basic_crud.php');
+            }),
+        ];
+
         yield 'it_generates_crud_with_tests' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/test-pack')
             ->run(static function (MakerTestRunner $runner) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| License       | MIT

`make:crud` takes its entity as an argument and marks it non-interactive, so it looks
scriptable. It is not: it crashes before generating anything.

```console
$ php bin/console make:crud SweetFood --no-interaction

 [WARNING] "make:crud" is not meant to be run in non-interactive mode.

In MakeCrud.php line 135:
  Typed property Symfony\Bundle\MakerBundle\Maker\MakeCrud::$controllerClassName
  must not be accessed before initialization
```

### Cause

The controller name is the command's only other input, and it was asked for in `interact()`
and stored on the maker:

```php
private string $controllerClassName;   // typed, no default

// interact()
$this->controllerClassName = $io->ask(...);

// generate(), twice
$generator->createClassNameDetails($this->controllerClassName, ...)
```

`Command::run()` skips `interact()` under `--no-interaction`, so the property is never
assigned and the first read in `generate()` throws. There is no way to supply the value from
the command line, so the command simply cannot run without a human at the terminal.

### Fix

The name now travels on the input instead of on the maker, which leaves one source of truth:

- `--controller-class` carries it.
- `interact()` writes the answer into that option rather than into a property, and skips the
  question when the option was already passed.
- `generate()` reads the option and falls back to the same default the prompt offers,
  derived by the one method both paths now call, so the two cannot drift.
- The property is gone.

```console
$ php bin/console make:crud SweetFood --controller-class=SweetFoodAdminController --no-interaction
$ php bin/console make:crud SweetFood --no-interaction   # SweetFoodController
```

Nothing changes for anyone typing at a terminal: the same question, the same default.

I marked this as both a bug fix and a feature. The crash is the bug; `--controller-class` is
the smallest thing that makes the command usable rather than merely non-crashing, since
without it the controller name could never be chosen non-interactively.

### One thing left alone

`--with-tests` has the same shape of problem. `CanGenerateTestsTrait::interactSetGenerateTests()`
is the only place that reads the option, and it is called from `interact()`, so under
`--no-interaction` the flag is silently ignored rather than generating tests. The trait is
shared by five makers (`crud`, `controller`, `reset-password`, `registration-form`,
`form-login`), so fixing it belongs in its own PR. Happy to open one.

### Tests

Two cases in `MakeCrudTest`, both non-interactive: one passing `--controller-class` and
asserting the controller lands at the requested class, one without it asserting the derived
default is used. Both fail on `1.x` with the initialisation error above. The full
`MakeCrudTest` passes.
