### PR TITLE
[make:controller] Honour --with-tests under --no-interaction

### DIFF
--- a/src/Maker/Common/CanGenerateTestsTrait.php
+++ b/src/Maker/Common/CanGenerateTestsTrait.php
@@ -24,8 +24,6 @@ use Symfony\Component\Console\Input\InputOption;
  */
 trait CanGenerateTestsTrait
 {
-    private bool $generateTests = false;
-
     public function configureCommandWithTestsOption(Command $command): Command
     {
         $testsHelp = file_get_contents(\dirname(__DIR__, 3).'/config/help/_WithTests.txt');
@@ -46,15 +44,15 @@ trait CanGenerateTestsTrait
             throw new RuntimeCommandException('Whoops! "--with-tests" option does not exist. Call "addWithTestsOptions()" in the makers "configureCommand().');
         }
 
-        $this->generateTests = $input->getOption('with-tests');
-
-        if (!$this->generateTests) {
-            $this->generateTests = $io->confirm('Do you want to generate PHPUnit tests? [Experimental]', false);
+        if ($input->getOption('with-tests')) {
+            return;
         }
+
+        $input->setOption('with-tests', $io->confirm('Do you want to generate PHPUnit tests? [Experimental]', false));
     }
 
-    public function shouldGenerateTests(): bool
+    public function shouldGenerateTests(InputInterface $input): bool
     {
-        return $this->generateTests;
+        return $input->getOption('with-tests');
     }
 }

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -38,11 +38,6 @@ final class MakeController extends AbstractMaker
 {
     use CanGenerateTestsTrait;
 
-    private bool $isInvokable;
-    private ClassData $controllerClassData;
-    private bool $usesTwigTemplate;
-    private string $twigTemplatePath;
-
     public function __construct(?PhpCompatUtil $phpCompatUtil = null)
     {
         if (null !== $phpCompatUtil) {
@@ -78,8 +73,13 @@ final class MakeController extends AbstractMaker
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
-        $this->usesTwigTemplate = $this->isTwigInstalled() && !$input->getOption('no-template');
-        $this->isInvokable = (bool) $input->getOption('invokable');
+        $this->interactSetGenerateTests($input, $io);
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $usesTwigTemplate = $this->isTwigInstalled() && !$input->getOption('no-template');
+        $isInvokable = (bool) $input->getOption('invokable');
 
         $controllerClass = $input->getArgument('controller-class');
         $controllerClassName = \sprintf('Controller\%s', $controllerClass);
@@ -90,12 +90,12 @@ final class MakeController extends AbstractMaker
             $controllerClassName = substr($controllerClass, 1);
         }
 
-        $this->controllerClassData = ClassData::create(
+        $controllerClassData = ClassData::create(
             class: $controllerClassName,
             suffix: 'Controller',
             extendsClass: AbstractController::class,
             useStatements: [
-                $this->usesTwigTemplate ? Response::class : JsonResponse::class,
+                $usesTwigTemplate ? Response::class : JsonResponse::class,
                 Route::class,
             ]
         );
@@ -105,47 +105,42 @@ final class MakeController extends AbstractMaker
         // templates/my/controller.html.twig. We do however remove the root_namespace prefix in either case
         // so we don't end up with templates/app/my/controller.html.twig
         $templateName = $isAbsoluteNamespace ?
-            $this->controllerClassData->getFullClassName(withoutRootNamespace: true, withoutSuffix: true) :
-            $this->controllerClassData->getClassName(relative: true, withoutSuffix: true)
+            $controllerClassData->getFullClassName(withoutRootNamespace: true, withoutSuffix: true) :
+            $controllerClassData->getClassName(relative: true, withoutSuffix: true)
         ;
 
         // Convert the Twig template name into a file path where it will be generated.
-        $this->twigTemplatePath = \sprintf('%s%s', Str::asFilePath($templateName), $this->isInvokable ? '.html.twig' : '/index.html.twig');
+        $twigTemplatePath = \sprintf('%s%s', Str::asFilePath($templateName), $isInvokable ? '.html.twig' : '/index.html.twig');
 
-        $this->interactSetGenerateTests($input, $io);
-    }
-
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
-    {
-        $controllerPath = $generator->generateClassFromClassData($this->controllerClassData, 'controller/Controller.tpl.php', [
-            'route_path' => Str::asRoutePath($this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
-            'route_name' => Str::AsRouteName($this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
-            'method_name' => $this->isInvokable ? '__invoke' : 'index',
-            'with_template' => $this->usesTwigTemplate,
-            'template_name' => $this->twigTemplatePath,
+        $controllerPath = $generator->generateClassFromClassData($controllerClassData, 'controller/Controller.tpl.php', [
+            'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+            'route_name' => Str::AsRouteName($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+            'method_name' => $isInvokable ? '__invoke' : 'index',
+            'with_template' => $usesTwigTemplate,
+            'template_name' => $twigTemplatePath,
         ], true);
 
-        if ($this->usesTwigTemplate) {
+        if ($usesTwigTemplate) {
             $generator->generateTemplate(
-                $this->twigTemplatePath,
+                $twigTemplatePath,
                 'controller/twig_template.tpl.php',
                 [
                     'controller_path' => $controllerPath,
                     'root_directory' => $generator->getRootDirectory(),
-                    'class_name' => $this->controllerClassData->getClassName(),
+                    'class_name' => $controllerClassData->getClassName(),
                 ]
             );
         }
 
-        if ($this->shouldGenerateTests()) {
+        if ($this->shouldGenerateTests($input)) {
             $testClassData = ClassData::create(
-                class: \sprintf('Tests\Controller\%s', $this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+                class: \sprintf('Tests\Controller\%s', $controllerClassData->getClassName(relative: true, withoutSuffix: true)),
                 suffix: 'ControllerTest',
                 extendsClass: WebTestCase::class,
             );
 
             $generator->generateClassFromClassData($testClassData, 'controller/test/Test.tpl.php', [
-                'route_path' => Str::asRoutePath($this->controllerClassData->getClassName(relative: true, withoutSuffix: true)),
+                'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
             ]);
 
             if (!class_exists(WebTestCase::class)) {

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -50,7 +50,6 @@ final class MakeCrud extends AbstractMaker
     use CanGenerateTestsTrait;
 
     private Inflector $inflector;
-    private bool $generateTests = false;
 
     public function __construct(private DoctrineHelper $doctrineHelper, private FormTypeRenderer $formTypeRenderer)
     {
@@ -251,7 +250,7 @@ final class MakeCrud extends AbstractMaker
             );
         }
 
-        if ($this->shouldGenerateTests()) {
+        if ($this->shouldGenerateTests($input)) {
             $testClassData = ClassData::create(
                 class: \sprintf('Tests\Controller\%s', $entityClassDetails->getRelativeNameWithoutSuffix()),
                 suffix: 'ControllerTest',

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -414,7 +414,7 @@ final class MakeRegistrationForm extends AbstractMaker
         }
 
         // Generate PHPUnit Tests
-        if ($this->shouldGenerateTests()) {
+        if ($this->shouldGenerateTests($input)) {
             $testClassDetails = $generator->createClassNameDetails(
                 'RegistrationControllerTest',
                 'Test\\'

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -351,7 +351,7 @@ class MakeResetPassword extends AbstractMaker
         );
 
         // Generate PHPUnit tests
-        if ($this->shouldGenerateTests()) {
+        if ($this->shouldGenerateTests($input)) {
             $testClassDetails = $generator->createClassNameDetails(
                 'ResetPasswordControllerTest',
                 'Test\\',

--- a/src/Maker/Security/MakeFormLogin.php
+++ b/src/Maker/Security/MakeFormLogin.php
@@ -181,7 +181,7 @@ final class MakeFormLogin extends AbstractMaker
             $securityData = $this->securityConfigUpdater->updateForLogout($securityData, $this->firewallToUpdate);
         }
 
-        if ($this->shouldGenerateTests()) {
+        if ($this->shouldGenerateTests($input)) {
             $userClassNameDetails = $generator->createClassNameDetails(
                 '\\'.$this->userClass,
                 'Entity\\'

--- a/tests/Maker/MakeControllerTest.php
+++ b/tests/Maker/MakeControllerTest.php
@@ -65,6 +65,17 @@ class MakeControllerTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_a_controller_with_tests_non_interactively' => [self::buildMakerTest()
+            ->addExtraDependencies('symfony/test-pack')
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([], 'FooBar --with-tests --no-interaction');
+
+                self::assertStringContainsString('src/Controller/FooBarController.php', $output);
+                self::assertStringContainsString('tests/Controller/FooBarControllerTest.php', $output);
+                self::assertFileExists($runner->getPath('tests/Controller/FooBarControllerTest.php'));
+            }),
+        ];
+
         yield 'it_generates_a_controller__no_input' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $output = $runner->runMaker([], 'FooBar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

`--with-tests` is accepted by five makers and silently ignored by all of them when the command runs non-interactively. `make:controller` additionally crashes before it gets that far. Both have the same cause: state that only `interact()` ever produces, read back later from the maker.

### `--with-tests` is dropped

`CanGenerateTestsTrait` read the option in `interactSetGenerateTests()`, stored the answer on the maker, and handed it back through `shouldGenerateTests()`:

```php
private bool $generateTests = false;

public function interactSetGenerateTests(InputInterface $input, ConsoleStyle $io): void
{
    $this->generateTests = $input->getOption('with-tests');

    if (!$this->generateTests) {
        $this->generateTests = $io->confirm('Do you want to generate PHPUnit tests? [Experimental]', false);
    }
}
```

`Command::run()` skips `interact()` under `--no-interaction`, so the property keeps its `false` default and the flag never reaches `generate()`. No error, no tests.

The answer now lives on the input instead: `interact()` writes the confirmation into the option rather than into a property, and `shouldGenerateTests(InputInterface $input)` reads the option, so both paths end up in the same place. The property is gone, along with the copy of it `MakeCrud` carried alongside the trait's.

### `make:controller` never reached it

```console
$ php bin/console make:controller FooBar --with-tests --no-interaction

 [WARNING] "make:controller" is not meant to be run in non-interactive mode.

  Typed property Symfony\Bundle\MakerBundle\Maker\MakeController::$controllerClassData
  must not be accessed before initialization
```

Its `interact()` asked nothing at all. It only derived the class data, the invokable flag and the Twig template path from the argument and the options, and `generate()` read them back off the maker. That derivation is now in `generate()`, where its inputs already are, and the four properties are gone. Nothing changes for anyone typing at a terminal, because none of it was ever a question.

### Deliberately left alone

The three remaining makers using the trait (`registration-form`, `reset-password`, `form-login`) still cannot run non-interactively. They ask for a user class, field names, email addresses and a firewall, and keep the answers on the maker in the same way. Giving them a non-interactive path is a feature rather than a fix, so it belongs in its own PR.

`make:crud` has the same crash, fixed separately in #1814. The two do not depend on each other.

### Note on the signature

`shouldGenerateTests()` gained an `InputInterface` argument. The trait is `@internal` and all five call sites are in this repository, each already inside `generate()` with the input in scope.

### Tests

`MakeControllerTest` gains one case running `FooBar --with-tests --no-interaction` and asserting the test class is generated. It fails on `1.x` with the initialisation error above. The suites of all five affected makers pass.
