### PR TITLE
[make:security:custom] Fix the crash under --no-interaction

### DIFF
--- a/src/Maker/Security/MakeCustomAuthenticator.php
+++ b/src/Maker/Security/MakeCustomAuthenticator.php
@@ -19,11 +19,10 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Maker\Common\InstallDependencyTrait;
-use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
-use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -47,8 +46,6 @@ final class MakeCustomAuthenticator extends AbstractMaker
 
     private const SECURITY_CONFIG_PATH = 'config/packages/security.yaml';
 
-    private ClassNameDetails $authenticatorClassName;
-
     public function __construct(
         private FileManager $fileManager,
         private Generator $generator,
@@ -68,6 +65,7 @@ final class MakeCustomAuthenticator extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
+            ->addArgument('name', InputArgument::OPTIONAL, 'What is the class name of the authenticator (e.g. <fg=yellow>CustomAuthenticator</>)')
             ->setHelp($this->getHelpFileContents('security/MakeCustom.txt'))
         ;
     }
@@ -80,32 +78,40 @@ final class MakeCustomAuthenticator extends AbstractMaker
             composerPackage: 'symfony/security-bundle'
         );
 
-        if (!$this->fileManager->fileExists(self::SECURITY_CONFIG_PATH)) {
-            throw new RuntimeCommandException(\sprintf('The file "%s" does not exist. PHP & XML configuration formats are currently not supported.', self::SECURITY_CONFIG_PATH));
-        }
-
-        $name = $io->ask(
-            question: 'What is the class name of the authenticator (e.g. <fg=yellow>CustomAuthenticator</>)',
-            validator: static function (mixed $answer) {
-                return Validator::notBlank($answer);
-            }
-        );
-
-        $this->authenticatorClassName = $this->generator->createClassNameDetails(
-            name: $name,
-            namespacePrefix: 'Security\\',
-            suffix: 'Authenticator'
-        );
+        $this->checkSecurityConfigExists();
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        // interact() may already have installed the bundle in this same process. A second
+        // composer require here would corrupt the container cache, because class_exists()
+        // cannot see a package installed earlier in the same run, so it would install again.
+        if (!$this->fileManager->fileExists(self::SECURITY_CONFIG_PATH)) {
+            $this->installDependencyIfNeeded(
+                io: $io,
+                expectedClassToExist: AbstractAuthenticator::class,
+                composerPackage: 'symfony/security-bundle'
+            );
+        }
+
+        $this->checkSecurityConfigExists();
+
+        if (!$name = $input->getArgument('name')) {
+            throw new RuntimeCommandException('The "name" argument is required in non-interactive mode.');
+        }
+
+        $authenticatorClassName = $this->generator->createClassNameDetails(
+            name: $name,
+            namespacePrefix: 'Security\\',
+            suffix: 'Authenticator'
+        );
+
         // Configure security to use custom authenticator
         $securityConfig = ($ysm = new YamlSourceManipulator(
             $this->fileManager->getFileContents(self::SECURITY_CONFIG_PATH)
         ))->getData();
 
-        $securityConfig['security']['firewalls']['main']['custom_authenticators'] = [$this->authenticatorClassName->getFullName()];
+        $securityConfig['security']['firewalls']['main']['custom_authenticators'] = [$authenticatorClassName->getFullName()];
 
         $ysm->setData($securityConfig);
         $generator->dumpFile(self::SECURITY_CONFIG_PATH, $ysm->getContents());
@@ -125,11 +131,11 @@ final class MakeCustomAuthenticator extends AbstractMaker
         ]);
 
         $generator->generateClass(
-            className: $this->authenticatorClassName->getFullName(),
+            className: $authenticatorClassName->getFullName(),
             templateName: 'security/custom/Authenticator.tpl.php',
             variables: [
                 'use_statements' => $useStatements,
-                'class_short_name' => $this->authenticatorClassName->getShortName(),
+                'class_short_name' => $authenticatorClassName->getShortName(),
             ]
         );
 
@@ -140,5 +146,12 @@ final class MakeCustomAuthenticator extends AbstractMaker
 
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
+    }
+
+    private function checkSecurityConfigExists(): void
+    {
+        if (!$this->fileManager->fileExists(self::SECURITY_CONFIG_PATH)) {
+            throw new RuntimeCommandException(\sprintf('The file "%s" does not exist. PHP & XML configuration formats are currently not supported.', self::SECURITY_CONFIG_PATH));
+        }
     }
 }

--- a/tests/Maker/Security/MakeCustomAuthenticatorTest.php
+++ b/tests/Maker/Security/MakeCustomAuthenticatorTest.php
@@ -44,5 +44,19 @@ class MakeCustomAuthenticatorTest extends MakerTestCase
                 self::assertSame(['App\Security\FixtureAuthenticator'], $mainFirewall['custom_authenticators']);
             }),
         ];
+
+        yield 'generates_custom_authenticator_non_interactively' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([], 'FixtureAuthenticator --no-interaction');
+
+                self::assertStringContainsString('Success', $output);
+
+                $fixturePath = \dirname(__DIR__, 2).'/fixtures/security/make-custom-authenticator/expected';
+                self::assertFileEquals($fixturePath.'/FixtureAuthenticator.php', $runner->getPath('src/Security/FixtureAuthenticator.php'));
+
+                $securityConfig = $runner->readYaml('config/packages/security.yaml');
+                self::assertSame(['App\Security\FixtureAuthenticator'], $securityConfig['security']['firewalls']['main']['custom_authenticators']);
+            }),
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

`make:security:custom` cannot run without a terminal, in either of two ways:

```console
$ php bin/console make:security:custom CustomAuthenticator --no-interaction
No arguments expected for "make:security:custom" command, got "CustomAuthenticator"

$ php bin/console make:security:custom --no-interaction
Typed property Symfony\Bundle\MakerBundle\Maker\Security\MakeCustomAuthenticator::$authenticatorClassName
must not be accessed before initialization
```

### Cause

The authenticator name is the command's only input. It was asked for in `interact()` and kept on the maker, and `configureCommand()` declared nothing but help text, so there was no way to supply it from the command line. `Command::run()` skips `interact()` under `--no-interaction`, so the property was never assigned and the first read in `generate()` threw.

### Fix

The name travels on the input as an optional `name` argument, marked non-interactive so `MakerCommand`'s generic prompt does not duplicate the maker's own question. `interact()` asks only when the argument is absent and writes the answer there, `generate()` builds the `ClassNameDetails` from it, and the property is gone.

Two guards lived in `interact()` and therefore disappeared without a terminal:

- The `security.yaml` existence check moved into a method both paths call.
- The `symfony/security-bundle` install turned out to be load-bearing rather than convenience, because its recipe is what writes `security.yaml` in the first place. `generate()` performs it when the file is missing, which also keeps it from issuing a second `composer require` after `interact()` already installed the bundle.

### Why

Part of a series making the makers usable by coding agents, which cannot answer prompts. Same framing as #1814 and #1815.
