### PR TITLE
[make:security:form-login] Fix the crash under --no-interaction

### DIFF
--- a/src/Maker/Security/MakeFormLogin.php
+++ b/src/Maker/Security/MakeFormLogin.php
@@ -36,6 +36,7 @@ use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Attribute\Route;
@@ -56,12 +57,6 @@ final class MakeFormLogin extends AbstractMaker
     use CanGenerateTestsTrait;
 
     private const SECURITY_CONFIG_PATH = 'config/packages/security.yaml';
-    private YamlSourceManipulator $ysm;
-    private string $controllerName;
-    private string $firewallToUpdate;
-    private string $userClass;
-    private string $userNameField;
-    private bool $willLogout;
 
     public function __construct(
         private FileManager $fileManager,
@@ -78,6 +73,11 @@ final class MakeFormLogin extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
+            ->addOption('controller-name', null, InputOption::VALUE_REQUIRED, 'The name of the controller class to create (e.g. <fg=yellow>SecurityController</>)')
+            ->addOption('firewall-name', null, InputOption::VALUE_REQUIRED, 'The firewall to update in <fg=yellow>security.yaml</>')
+            ->addOption('user-class', null, InputOption::VALUE_REQUIRED, 'The class of the user to authenticate (e.g. <fg=yellow>App\\Entity\\User</>)')
+            ->addOption('username-field', null, InputOption::VALUE_REQUIRED, 'The property people enter when logging in (e.g. <fg=yellow>email</>)')
+            ->addOption('logout', null, InputOption::VALUE_NONE, 'Generate a <fg=yellow>/logout</> URL')
             ->setHelp($this->getHelpFileContents('security/MakeFormLogin.txt'))
         ;
 
@@ -109,34 +109,60 @@ final class MakeFormLogin extends AbstractMaker
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
     {
-        if (!$this->fileManager->fileExists(self::SECURITY_CONFIG_PATH)) {
-            throw new RuntimeCommandException(\sprintf('The file "%s" does not exist. PHP & XML configuration formats are currently not supported.', self::SECURITY_CONFIG_PATH));
+        $securityData = $this->readSecurityData();
+        $providers = $securityData['security']['providers'];
+
+        if (!$input->getOption('controller-name')) {
+            $input->setOption('controller-name', $io->ask(
+                'Choose a name for the controller class (e.g. <fg=yellow>SecurityController</>)',
+                'SecurityController',
+                Validator::validateClassName(...)
+            ));
         }
-
-        $this->ysm = new YamlSourceManipulator($this->fileManager->getFileContents(self::SECURITY_CONFIG_PATH));
-        $securityData = $this->ysm->getData();
-
-        if (!isset($securityData['security']['providers']) || !$securityData['security']['providers']) {
-            throw new RuntimeCommandException('To generate a form login authentication, you must configure at least one entry under "providers" in "security.yaml".');
-        }
-
-        $this->controllerName = $io->ask(
-            'Choose a name for the controller class (e.g. <fg=yellow>SecurityController</>)',
-            'SecurityController',
-            Validator::validateClassName(...)
-        );
 
         $securityHelper = new InteractiveSecurityHelper();
-        $this->firewallToUpdate = $securityHelper->guessFirewallName($io, $securityData);
-        $this->userClass = $securityHelper->guessUserClass($io, $securityData['security']['providers']);
-        $this->userNameField = $securityHelper->guessUserNameField($io, $this->userClass, $securityData['security']['providers']);
-        $this->willLogout = $io->confirm('Do you want to generate a \'/logout\' URL?');
+
+        if (!$input->getOption('firewall-name')) {
+            $input->setOption('firewall-name', $securityHelper->guessFirewallName($io, $securityData));
+        }
+
+        if (!$input->getOption('user-class')) {
+            $input->setOption('user-class', $securityHelper->guessUserClass($io, $providers));
+        }
+
+        if (!$input->getOption('username-field')) {
+            $input->setOption('username-field', $securityHelper->guessUserNameField($io, $input->getOption('user-class'), $providers));
+        }
+
+        if (!$input->getOption('logout')) {
+            $input->setOption('logout', $io->confirm('Do you want to generate a \'/logout\' URL?'));
+        }
 
         $this->interactSetGenerateTests($input, $io);
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        $ysm = new YamlSourceManipulator($this->fileManager->getFileContents(self::SECURITY_CONFIG_PATH));
+        $securityData = $this->readSecurityData();
+        $providers = $securityData['security']['providers'];
+        $securityHelper = new InteractiveSecurityHelper();
+
+        $controllerName = $input->getOption('controller-name') ?: 'SecurityController';
+        $firewallToUpdate = $input->getOption('firewall-name') ?: $securityHelper->findFirewallName($securityData);
+        $userClass = $input->getOption('user-class') ?: $securityHelper->findUserClass($providers);
+        $willLogout = $input->getOption('logout');
+
+        if (!$userClass) {
+            throw new RuntimeCommandException('The user class cannot be guessed from "security.yaml", pass it with "--user-class".');
+        }
+
+        $userNameField = $input->getOption('username-field') ?: $securityHelper->findUserNameField($userClass, $providers);
+
+        if (!$userNameField) {
+            throw new RuntimeCommandException(\sprintf('The login field of "%s" cannot be guessed, pass it with "--username-field".', $userClass));
+        }
+
         $useStatements = new UseStatementGenerator([
             AbstractController::class,
             Response::class,
@@ -144,7 +170,7 @@ final class MakeFormLogin extends AbstractMaker
             AuthenticationUtils::class,
         ]);
 
-        $controllerNameDetails = $generator->createClassNameDetails($this->controllerName, 'Controller\\', 'Controller');
+        $controllerNameDetails = $generator->createClassNameDetails($controllerName, 'Controller\\', 'Controller');
         $templatePath = strtolower($controllerNameDetails->getRelativeNameWithoutSuffix());
 
         $controllerPath = $generator->generateController(
@@ -157,7 +183,7 @@ final class MakeFormLogin extends AbstractMaker
             ]
         );
 
-        if ($this->willLogout) {
+        if ($willLogout) {
             $manipulator = new ClassSourceManipulator($generator->getFileContentsForPendingOperation($controllerPath));
 
             $this->securityControllerBuilder->addLogoutMethod($manipulator);
@@ -169,21 +195,21 @@ final class MakeFormLogin extends AbstractMaker
             \sprintf('%s/login.html.twig', $templatePath),
             'security/formLogin/login_form.tpl.php',
             [
-                'logout_setup' => $this->willLogout,
-                'username_label' => Str::asHumanWords($this->userNameField),
-                'username_is_email' => false !== stripos($this->userNameField, 'email'),
+                'logout_setup' => $willLogout,
+                'username_label' => Str::asHumanWords($userNameField),
+                'username_is_email' => false !== stripos($userNameField, 'email'),
             ]
         );
 
-        $securityData = $this->securityConfigUpdater->updateForFormLogin($this->ysm->getContents(), $this->firewallToUpdate, 'app_login', 'app_login');
+        $securityData = $this->securityConfigUpdater->updateForFormLogin($ysm->getContents(), $firewallToUpdate, 'app_login', 'app_login');
 
-        if ($this->willLogout) {
-            $securityData = $this->securityConfigUpdater->updateForLogout($securityData, $this->firewallToUpdate);
+        if ($willLogout) {
+            $securityData = $this->securityConfigUpdater->updateForLogout($securityData, $firewallToUpdate);
         }
 
         if ($this->shouldGenerateTests($input)) {
             $userClassNameDetails = $generator->createClassNameDetails(
-                '\\'.$this->userClass,
+                '\\'.$userClass,
                 'Entity\\'
             );
 
@@ -205,7 +231,7 @@ final class MakeFormLogin extends AbstractMaker
                 templateName: 'security/formLogin/Test.LoginController.tpl.php',
                 variables: [
                     'use_statements' => $useStatements,
-                    'user_class' => $this->userClass,
+                    'user_class' => $userClass,
                     'user_short_name' => $userClassNameDetails->getShortName(),
                 ],
             );
@@ -224,5 +250,23 @@ final class MakeFormLogin extends AbstractMaker
         $io->text([
             \sprintf('Next: Review and adapt the login template: <info>%s/login.html.twig</info> to suit your needs.', $templatePath),
         ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSecurityData(): array
+    {
+        if (!$this->fileManager->fileExists(self::SECURITY_CONFIG_PATH)) {
+            throw new RuntimeCommandException(\sprintf('The file "%s" does not exist. PHP & XML configuration formats are currently not supported.', self::SECURITY_CONFIG_PATH));
+        }
+
+        $securityData = (new YamlSourceManipulator($this->fileManager->getFileContents(self::SECURITY_CONFIG_PATH)))->getData();
+
+        if (!isset($securityData['security']['providers']) || !$securityData['security']['providers']) {
+            throw new RuntimeCommandException('To generate a form login authentication, you must configure at least one entry under "providers" in "security.yaml".');
+        }
+
+        return $securityData;
     }
 }

--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -25,18 +25,11 @@ final class InteractiveSecurityHelper
 {
     public function guessFirewallName(SymfonyStyle $io, array $securityData, ?string $questionText = null): string
     {
-        $realFirewalls = array_filter(
-            $securityData['security']['firewalls'] ?? [],
-            static fn ($item) => !isset($item['security']) || true === $item['security']
-        );
-
-        if (0 === \count($realFirewalls)) {
-            return 'main';
+        if (null !== $firewallName = $this->findFirewallName($securityData)) {
+            return $firewallName;
         }
 
-        if (1 === \count($realFirewalls)) {
-            return key($realFirewalls);
-        }
+        $realFirewalls = $this->realFirewalls($securityData);
 
         return $io->choice(
             $questionText ?? 'Which firewall do you want to update?',
@@ -45,12 +38,36 @@ final class InteractiveSecurityHelper
         );
     }
 
+    /**
+     * The firewall when there is only one sensible answer, null when a person has to pick.
+     */
+    public function findFirewallName(array $securityData): ?string
+    {
+        $realFirewalls = $this->realFirewalls($securityData);
+
+        if (!$realFirewalls) {
+            return 'main';
+        }
+
+        if (1 === \count($realFirewalls)) {
+            return key($realFirewalls);
+        }
+
+        return null;
+    }
+
+    private function realFirewalls(array $securityData): array
+    {
+        return array_filter(
+            $securityData['security']['firewalls'] ?? [],
+            static fn ($item) => !isset($item['security']) || true === $item['security']
+        );
+    }
+
     public function guessUserClass(SymfonyStyle $io, array $providers, ?string $questionText = null): string
     {
-        if (1 === \count($providers) && isset(current($providers)['entity'])) {
-            $entityProvider = current($providers);
-
-            return $entityProvider['entity']['class'];
+        if (null !== $userClass = $this->findUserClass($providers)) {
+            return $userClass;
         }
 
         return $io->ask(
@@ -58,6 +75,18 @@ final class InteractiveSecurityHelper
             $this->guessUserClassDefault(),
             Validator::classIsUserInterface(...)
         );
+    }
+
+    /**
+     * The user class when a single entity provider names one, null when a person has to answer.
+     */
+    public function findUserClass(array $providers): ?string
+    {
+        if (1 === \count($providers) && isset(current($providers)['entity']['class'])) {
+            return current($providers)['entity']['class'];
+        }
+
+        return null;
     }
 
     private function guessUserClassDefault(): string
@@ -75,18 +104,8 @@ final class InteractiveSecurityHelper
 
     public function guessUserNameField(SymfonyStyle $io, string $userClass, array $providers): string
     {
-        if (1 === \count($providers) && isset(current($providers)['entity']) && isset(current($providers)['entity']['property'])) {
-            $entityProvider = current($providers);
-
-            return $entityProvider['entity']['property'];
-        }
-
-        if (property_exists($userClass, 'email') && !property_exists($userClass, 'username')) {
-            return 'email';
-        }
-
-        if (!property_exists($userClass, 'email') && property_exists($userClass, 'username')) {
-            return 'username';
+        if (null !== $userNameField = $this->findUserNameField($userClass, $providers)) {
+            return $userNameField;
         }
 
         $classProperties = [];
@@ -104,6 +123,26 @@ final class InteractiveSecurityHelper
             $classProperties,
             property_exists($userClass, 'username') ? 'username' : (property_exists($userClass, 'email') ? 'email' : null)
         );
+    }
+
+    /**
+     * The login field when the provider or the class names one, null when a person has to pick.
+     */
+    public function findUserNameField(string $userClass, array $providers): ?string
+    {
+        if (1 === \count($providers) && isset(current($providers)['entity']['property'])) {
+            return current($providers)['entity']['property'];
+        }
+
+        if (property_exists($userClass, 'email') && !property_exists($userClass, 'username')) {
+            return 'email';
+        }
+
+        if (!property_exists($userClass, 'email') && property_exists($userClass, 'username')) {
+            return 'username';
+        }
+
+        return null;
     }
 
     public function guessEmailField(SymfonyStyle $io, string $userClass): string

--- a/tests/Maker/Security/MakeFormLoginTest.php
+++ b/tests/Maker/Security/MakeFormLoginTest.php
@@ -54,6 +54,42 @@ class MakeFormLoginTest extends MakerTestCase
             }),
         ];
 
+        yield 'generates_form_login_non_interactively' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $output = $runner->runMaker([], '--no-interaction --logout');
+
+                self::assertStringContainsString('Success', $output);
+                $fixturePath = \dirname(__DIR__, 2).'/fixtures/security/make-form-login/expected';
+
+                // the controller name, the firewall, the user class and the login field all
+                // come out the same as when a person answers with the offered defaults
+                self::assertFileEquals($fixturePath.'/SecurityController.php', $runner->getPath('src/Controller/SecurityController.php'));
+                self::assertFileEquals($fixturePath.'/login.html.twig', $runner->getPath('templates/security/login.html.twig'));
+
+                $securityConfig = $runner->readYaml('config/packages/security.yaml');
+
+                self::assertSame('app_login', $securityConfig['security']['firewalls']['main']['form_login']['login_path']);
+                self::assertSame('app_logout', $securityConfig['security']['firewalls']['main']['logout']['path']);
+            }),
+        ];
+
+        yield 'generates_form_login_non_interactively_without_logout' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                // "--logout" is opt-in here, where the prompt offers yes as its default
+                $runner->runMaker([], '--no-interaction --controller-name=LoginController');
+
+                $securityConfig = $runner->readYaml('config/packages/security.yaml');
+
+                self::assertArrayNotHasKey('logout', $securityConfig['security']['firewalls']['main']);
+                self::assertFileExists($runner->getPath('src/Controller/LoginController.php'));
+                self::assertFileExists($runner->getPath('templates/login/login.html.twig'));
+            }),
+        ];
+
         yield 'generates_form_login_without_logout' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 self::makeUser($runner);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

```console
$ php bin/console make:security:form-login --no-interaction
Typed property Symfony\Bundle\MakerBundle\Maker\Security\MakeFormLogin::$controllerName
must not be accessed before initialization
```

### Cause

Every answer was kept on the maker, and the command declared no options beyond `--with-tests`. `Command::run()` skips `interact()` under `--no-interaction`, so nothing was ever assigned and `generate()` read six uninitialised properties.

### Fix

Five options carry the answers instead: `--controller-name`, `--firewall-name`, `--user-class`, `--username-field` and `--logout`. `interact()` asks only for what was not passed and writes each answer into its option, `generate()` reads them, and the properties are gone. The `YamlSourceManipulator` was never input, so it is built where it is used.

The interactive dialogue is unchanged: the same questions in the same order with the same defaults, except that passing an option skips its question.

**`--logout` is the one deliberate difference.** The prompt offers yes as its default; the option is opt-in. A flag that has to be spelled out is worth more in a script than matching which answer a prompt happens to preselect. Same reasoning as the nullability decision in #1813.

### The guesses

`--user-class` and `--username-field` are normally not asked at all. `InteractiveSecurityHelper::guessUserClass()` and `guessUserNameField()` return silently when `security.yaml` is unambiguous and prompt otherwise, and the prompting branch cannot be reached without a terminal: those are `choice()` calls with no default, which resolve to `null` and violate the `string` return type.

So the silent halves are extracted as `findUserClass()`, `findUserNameField()` and `findFirewallName()`, returning `null` exactly where a person would have to answer. The `guess*` methods call them first, so their behaviour is unchanged, and `generate()` uses them to fail with a message naming the option to pass rather than reaching for a prompt.

### Why

Part of a series making the makers usable by coding agents, which cannot answer prompts. This is also where the work `make:auth` would have needed goes: that command is deprecated in favour of the `make:security:*` commands, so fixing it there would have been effort spent on a dead entry point.
