### PR TITLE
[make:registration-form] Fix the crash under --no-interaction

### DIFF
--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -45,6 +45,7 @@ use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -74,19 +75,6 @@ final class MakeRegistrationForm extends AbstractMaker
 {
     use CanGenerateTestsTrait;
 
-    private string $userClass;
-    private string $usernameField;
-    private string $passwordField;
-    private bool $willVerifyEmail = false;
-    private bool $verifyEmailAnonymously = false;
-    private string $idGetter;
-    private string $emailGetter;
-    private string $fromEmailAddress;
-    private string $fromEmailName;
-    private ?Authenticator $autoLoginAuthenticator = null;
-    private string $redirectRouteName;
-    private bool $addUniqueEntityConstraint = false;
-
     public function __construct(
         private FileManager $fileManager,
         private FormTypeRenderer $formTypeRenderer,
@@ -111,6 +99,22 @@ final class MakeRegistrationForm extends AbstractMaker
             ->setHelp($this->getHelpFileContents('MakeRegistrationForm.txt'))
         ;
 
+        $command
+            ->addOption('user-class', null, InputOption::VALUE_REQUIRED, 'The User class to create during registration (e.g. <fg=yellow>App\\Entity\\User</>)')
+            ->addOption('username-field', null, InputOption::VALUE_REQUIRED, 'The property people enter when logging in (e.g. <fg=yellow>email</>)')
+            ->addOption('password-field', null, InputOption::VALUE_REQUIRED, 'The property holding the hashed password (e.g. <fg=yellow>password</>)')
+            ->addOption('unique-entity', null, InputOption::VALUE_NONE, 'Add a <fg=yellow>#[UniqueEntity]</> attribute to the User class')
+            ->addOption('verify-email', null, InputOption::VALUE_NONE, 'Send an email to verify the address after registration')
+            ->addOption('verify-anonymously', null, InputOption::VALUE_NONE, 'Embed the user id in the verification link, allowing verification without logging in')
+            ->addOption('id-getter', null, InputOption::VALUE_REQUIRED, 'The method returning the user identifier (e.g. <fg=yellow>getId</>)')
+            ->addOption('email-getter', null, InputOption::VALUE_REQUIRED, 'The method returning the email address (e.g. <fg=yellow>getEmail</>)')
+            ->addOption('from-email-address', null, InputOption::VALUE_REQUIRED, 'The address confirmations are sent from (e.g. <fg=yellow>mailer@your-domain.com</>)')
+            ->addOption('from-email-name', null, InputOption::VALUE_REQUIRED, 'The name associated with that address (e.g. <fg=yellow>Acme Mail Bot</>)')
+            ->addOption('auto-login', null, InputOption::VALUE_NONE, 'Authenticate the user right after registering')
+            ->addOption('authenticator', null, InputOption::VALUE_REQUIRED, 'The authenticator to log the user in with, when more than one is configured')
+            ->addOption('redirect-route', null, InputOption::VALUE_REQUIRED, 'The route to redirect to after registration, when the user is not logged in automatically')
+        ;
+
         $this->configureCommandWithTestsOption($command);
     }
 
@@ -118,6 +122,98 @@ final class MakeRegistrationForm extends AbstractMaker
     {
         $interactiveSecurityHelper = new InteractiveSecurityHelper();
 
+        $securityData = $this->readSecurityData();
+        $providersData = $securityData['security']['providers'] ?? [];
+
+        if (!$input->getOption('user-class')) {
+            $input->setOption('user-class', $interactiveSecurityHelper->guessUserClass(
+                $io,
+                $providersData,
+                'Enter the User class that you want to create during registration (e.g. <fg=yellow>App\\Entity\\User</>)'
+            ));
+        }
+
+        $userClass = $input->getOption('user-class');
+        $io->text(\sprintf('Creating a registration form for <info>%s</info>', $userClass));
+
+        if (!$input->getOption('username-field')) {
+            $input->setOption('username-field', $interactiveSecurityHelper->guessUserNameField($io, $userClass, $providersData));
+        }
+
+        if (!$input->getOption('password-field')) {
+            $input->setOption('password-field', $interactiveSecurityHelper->guessPasswordField($io, $userClass));
+        }
+
+        // see if it makes sense to add the UniqueEntity constraint
+        $userClassDetails = new ClassDetails($userClass);
+
+        if (!$input->getOption('unique-entity') && !$userClassDetails->hasAttribute(UniqueEntity::class)) {
+            $input->setOption('unique-entity', (bool) $io->confirm(\sprintf('Do you want to add a <comment>#[UniqueEntity]</comment> validation attribute to your <comment>%s</comment> class to make sure duplicate accounts aren\'t created?', Str::getShortClassName($userClass))));
+        }
+
+        if (!$input->getOption('verify-email')) {
+            $input->setOption('verify-email', (bool) $io->confirm('Do you want to send an email to verify the user\'s email address after registration?'));
+        }
+
+        if ($input->getOption('verify-email')) {
+            $this->checkComponentsExist($io);
+
+            $emailText[] = 'By default, users are required to be authenticated when they click the verification link that is emailed to them.';
+            $emailText[] = 'This prevents the user from registering on their laptop, then clicking the link on their phone, without';
+            $emailText[] = 'having to log in. To allow multi device email verification, we can embed a user id in the verification link.';
+            $io->text($emailText);
+            $io->newLine();
+
+            if (!$input->getOption('verify-anonymously')) {
+                $input->setOption('verify-anonymously', (bool) $io->confirm('Would you like to include the user id in the verification link to allow anonymous email verification?', false));
+            }
+
+            if (!$input->getOption('id-getter')) {
+                $input->setOption('id-getter', $interactiveSecurityHelper->guessIdGetter($io, $userClass));
+            }
+
+            if (!$input->getOption('email-getter')) {
+                $input->setOption('email-getter', $interactiveSecurityHelper->guessEmailGetter($io, $userClass, 'email'));
+            }
+
+            if (!$input->getOption('from-email-address')) {
+                $input->setOption('from-email-address', $io->ask(
+                    'What email address will be used to send registration confirmations? (e.g. <fg=yellow>mailer@your-domain.com</>)',
+                    null,
+                    Validator::validateEmailAddress(...)
+                ));
+            }
+
+            if (!$input->getOption('from-email-name')) {
+                $input->setOption('from-email-name', $io->ask(
+                    'What "name" should be associated with that email address? (e.g. <fg=yellow>Acme Mail Bot</>)',
+                    null,
+                    Validator::notBlank(...)
+                ));
+            }
+        }
+
+        if (!$input->getOption('auto-login') && !$input->getOption('authenticator')) {
+            $input->setOption('auto-login', (bool) $io->confirm('Do you want to automatically authenticate the user after registration?'));
+        }
+
+        if ($input->getOption('auto-login') || $input->getOption('authenticator')) {
+            $this->interactAuthenticatorQuestions($input, $io, $interactiveSecurityHelper, $securityData);
+        }
+
+        if (!$input->getOption('authenticator') && !$input->getOption('redirect-route')) {
+            $routeNames = array_keys($this->router->getRouteCollection()->all());
+            $input->setOption('redirect-route', $io->choice('What route should the user be redirected to after registration?', $routeNames));
+        }
+
+        $this->interactSetGenerateTests($input, $io);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSecurityData(): array
+    {
         if (null === $this->router) {
             throw new RuntimeCommandException('Router have been explicitly disabled in your configuration. This command needs to use the router.');
         }
@@ -126,95 +222,115 @@ final class MakeRegistrationForm extends AbstractMaker
             throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. PHP & XML configuration formats are currently not supported.');
         }
 
-        $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));
-        $securityData = $manipulator->getData();
-        $providersData = $securityData['security']['providers'] ?? [];
-
-        $this->userClass = $interactiveSecurityHelper->guessUserClass(
-            $io,
-            $providersData,
-            'Enter the User class that you want to create during registration (e.g. <fg=yellow>App\\Entity\\User</>)'
-        );
-        $io->text(\sprintf('Creating a registration form for <info>%s</info>', $this->userClass));
-
-        $this->usernameField = $interactiveSecurityHelper->guessUserNameField($io, $this->userClass, $providersData);
-
-        $this->passwordField = $interactiveSecurityHelper->guessPasswordField($io, $this->userClass);
-
-        // see if it makes sense to add the UniqueEntity constraint
-        $userClassDetails = new ClassDetails($this->userClass);
-
-        if (!$userClassDetails->hasAttribute(UniqueEntity::class)) {
-            $this->addUniqueEntityConstraint = (bool) $io->confirm(\sprintf('Do you want to add a <comment>#[UniqueEntity]</comment> validation attribute to your <comment>%s</comment> class to make sure duplicate accounts aren\'t created?', Str::getShortClassName($this->userClass)));
-        }
-
-        $this->willVerifyEmail = (bool) $io->confirm('Do you want to send an email to verify the user\'s email address after registration?');
-
-        if ($this->willVerifyEmail) {
-            $this->checkComponentsExist($io);
-
-            $emailText[] = 'By default, users are required to be authenticated when they click the verification link that is emailed to them.';
-            $emailText[] = 'This prevents the user from registering on their laptop, then clicking the link on their phone, without';
-            $emailText[] = 'having to log in. To allow multi device email verification, we can embed a user id in the verification link.';
-            $io->text($emailText);
-            $io->newLine();
-            $this->verifyEmailAnonymously = (bool) $io->confirm('Would you like to include the user id in the verification link to allow anonymous email verification?', false);
-
-            $this->idGetter = $interactiveSecurityHelper->guessIdGetter($io, $this->userClass);
-            $this->emailGetter = $interactiveSecurityHelper->guessEmailGetter($io, $this->userClass, 'email');
-
-            $this->fromEmailAddress = $io->ask(
-                'What email address will be used to send registration confirmations? (e.g. <fg=yellow>mailer@your-domain.com</>)',
-                null,
-                Validator::validateEmailAddress(...)
-            );
-
-            $this->fromEmailName = $io->ask(
-                'What "name" should be associated with that email address? (e.g. <fg=yellow>Acme Mail Bot</>)',
-                null,
-                Validator::notBlank(...)
-            );
-        }
-
-        if ($io->confirm('Do you want to automatically authenticate the user after registration?')) {
-            $this->interactAuthenticatorQuestions(
-                $io,
-                $interactiveSecurityHelper,
-                $securityData
-            );
-        }
-
-        if (!$this->autoLoginAuthenticator) {
-            $routeNames = array_keys($this->router->getRouteCollection()->all());
-            $this->redirectRouteName = $io->choice('What route should the user be redirected to after registration?', $routeNames);
-        }
-
-        $this->interactSetGenerateTests($input, $io);
+        return (new YamlSourceManipulator($this->fileManager->getFileContents($path)))->getData();
     }
 
     /** @param array<string, mixed> $securityData */
-    private function interactAuthenticatorQuestions(ConsoleStyle $io, InteractiveSecurityHelper $interactiveSecurityHelper, array $securityData): void
+    private function resolveAuthenticator(InputInterface $input, ConsoleStyle $io, InteractiveSecurityHelper $securityHelper, array $securityData): ?Authenticator
     {
+        $authenticators = $securityHelper->getAuthenticatorsFromConfig($securityData['security']['firewalls'] ?? []);
+
+        if ($name = $input->getOption('authenticator')) {
+            foreach ($authenticators as $authenticator) {
+                if ($name === (string) $authenticator) {
+                    return $authenticator;
+                }
+            }
+
+            throw new RuntimeCommandException(\sprintf('No authenticator named "%s" is configured. Available: "%s".', $name, implode('", "', $authenticators)));
+        }
+
+        if (!$input->getOption('auto-login')) {
+            return null;
+        }
+
+        if (!$authenticators) {
+            $io->note('No authenticators found - so your user won\'t be automatically authenticated after registering.');
+
+            return null;
+        }
+
+        if (1 === \count($authenticators)) {
+            return $authenticators[0];
+        }
+
+        throw new RuntimeCommandException(\sprintf('Multiple authenticators are configured, pass one with "--authenticator". Available: "%s".', implode('", "', $authenticators)));
+    }
+
+    /** @param array<string, mixed> $securityData */
+    private function interactAuthenticatorQuestions(InputInterface $input, ConsoleStyle $io, InteractiveSecurityHelper $interactiveSecurityHelper, array $securityData): void
+    {
+        if ($input->getOption('authenticator')) {
+            return;
+        }
+
         // get list of authenticators
         $authenticators = $interactiveSecurityHelper->getAuthenticatorsFromConfig($securityData['security']['firewalls'] ?? []);
 
-        if (empty($authenticators)) {
+        if (!$authenticators) {
             $io->note('No authenticators found - so your user won\'t be automatically authenticated after registering.');
 
             return;
         }
 
-        $this->autoLoginAuthenticator =
+        $input->setOption('authenticator', (string) (
             1 === \count($authenticators) ? $authenticators[0] : $io->choice(
                 'Which authenticator should be used to login the user?',
                 $authenticators
-            );
+            )
+        ));
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        $securityHelper = new InteractiveSecurityHelper();
+        $securityData = $this->readSecurityData();
+        $providersData = $securityData['security']['providers'] ?? [];
+
+        $userClass = $input->getOption('user-class') ?: $securityHelper->findUserClass($providersData);
+
+        if (!$userClass) {
+            throw new RuntimeCommandException('The User class cannot be guessed from "security.yaml", pass it with "--user-class".');
+        }
+
+        $usernameField = $input->getOption('username-field') ?: $securityHelper->findUserNameField($userClass, $providersData);
+
+        if (!$usernameField) {
+            throw new RuntimeCommandException(\sprintf('The login field of "%s" cannot be guessed, pass it with "--username-field".', $userClass));
+        }
+
+        $passwordField = $input->getOption('password-field') ?: $securityHelper->findPasswordField($userClass);
+
+        if (!$passwordField) {
+            throw new RuntimeCommandException(\sprintf('The password property of "%s" cannot be guessed, pass it with "--password-field".', $userClass));
+        }
+
+        $addUniqueEntityConstraint = (bool) $input->getOption('unique-entity');
+        $willVerifyEmail = (bool) $input->getOption('verify-email');
+        $verifyEmailAnonymously = (bool) $input->getOption('verify-anonymously');
+        $idGetter = $emailGetter = $fromEmailAddress = $fromEmailName = null;
+
+        if ($willVerifyEmail) {
+            $idGetter = $input->getOption('id-getter') ?: $securityHelper->findIdGetter($userClass);
+            $emailGetter = $input->getOption('email-getter') ?: $securityHelper->findEmailGetter($userClass, 'email');
+
+            if (!$idGetter) {
+                throw new RuntimeCommandException(\sprintf('"%s" has no "getId()" method, pass the getter with "--id-getter".', $userClass));
+            }
+
+            if (!$emailGetter) {
+                throw new RuntimeCommandException(\sprintf('"%s" has no "getEmail()" method, pass the getter with "--email-getter".', $userClass));
+            }
+
+            $fromEmailAddress = Validator::validateEmailAddress($input->getOption('from-email-address'));
+            $fromEmailName = Validator::notBlank($input->getOption('from-email-name'));
+        }
+
+        $autoLoginAuthenticator = $this->resolveAuthenticator($input, $io, $securityHelper, $securityData);
+        $redirectRouteName = $input->getOption('redirect-route');
+
         $userClassNameDetails = $generator->createClassNameDetails(
-            '\\'.$this->userClass,
+            '\\'.$userClass,
             'Entity\\'
         );
 
@@ -243,16 +359,16 @@ final class MakeRegistrationForm extends AbstractMaker
             'Security\\'
         );
 
-        $verifyEmailVars = ['will_verify_email' => $this->willVerifyEmail];
+        $verifyEmailVars = ['will_verify_email' => $willVerifyEmail];
 
-        if ($this->willVerifyEmail) {
+        if ($willVerifyEmail) {
             $verifyEmailVars = [
-                'will_verify_email' => $this->willVerifyEmail,
+                'will_verify_email' => $willVerifyEmail,
                 'email_verifier_class_details' => $verifyEmailServiceClassNameDetails,
-                'verify_email_anonymously' => $this->verifyEmailAnonymously,
-                'from_email' => $this->fromEmailAddress,
-                'from_email_name' => addslashes($this->fromEmailName),
-                'email_getter' => $this->emailGetter,
+                'verify_email_anonymously' => $verifyEmailAnonymously,
+                'from_email' => $fromEmailAddress,
+                'from_email_name' => addslashes($fromEmailName),
+                'email_getter' => $emailGetter,
             ];
 
             $useStatements = new UseStatementGenerator([
@@ -271,9 +387,9 @@ final class MakeRegistrationForm extends AbstractMaker
                 'verifyEmail/EmailVerifier.tpl.php',
                 array_merge([
                     'use_statements' => $useStatements,
-                    'id_getter' => $this->idGetter,
-                    'email_getter' => $this->emailGetter,
-                    'verify_email_anonymously' => $this->verifyEmailAnonymously,
+                    'id_getter' => $idGetter,
+                    'email_getter' => $emailGetter,
+                    'verify_email_anonymously' => $verifyEmailAnonymously,
                     'user_class_name' => $userClassNameDetails->getShortName(),
                 ],
                     $userRepoVars
@@ -287,7 +403,6 @@ final class MakeRegistrationForm extends AbstractMaker
         }
 
         // 1) Generate the form class
-        $usernameField = $this->usernameField;
         $formClassDetails = $this->generateFormClass(
             $userClassNameDetails,
             $generator,
@@ -311,7 +426,7 @@ final class MakeRegistrationForm extends AbstractMaker
             EntityManagerInterface::class,
         ]);
 
-        if ($this->willVerifyEmail) {
+        if ($willVerifyEmail) {
             $useStatements->addUseStatement([
                 $verifyEmailServiceClassNameDetails->getFullName(),
                 TemplatedEmail::class,
@@ -319,26 +434,26 @@ final class MakeRegistrationForm extends AbstractMaker
                 VerifyEmailExceptionInterface::class,
             ]);
 
-            if ($this->verifyEmailAnonymously) {
+            if ($verifyEmailAnonymously) {
                 $useStatements->addUseStatement($userRepoVars['repository_full_class_name']);
             }
         }
 
         $autoLoginVars = [
-            'login_after_registration' => null !== $this->autoLoginAuthenticator,
+            'login_after_registration' => null !== $autoLoginAuthenticator,
         ];
 
-        if (null !== $this->autoLoginAuthenticator) {
+        if (null !== $autoLoginAuthenticator) {
             $useStatements->addUseStatement([
                 Security::class,
             ]);
 
-            $autoLoginVars['firewall'] = $this->autoLoginAuthenticator->firewallName;
-            $autoLoginVars['authenticator'] = \sprintf('\'%s\'', $this->autoLoginAuthenticator->type->value);
+            $autoLoginVars['firewall'] = $autoLoginAuthenticator->firewallName;
+            $autoLoginVars['authenticator'] = \sprintf('\'%s\'', $autoLoginAuthenticator->type->value);
 
-            if (AuthenticatorType::CUSTOM === $this->autoLoginAuthenticator->type) {
-                $useStatements->addUseStatement($this->autoLoginAuthenticator->authenticatorClass);
-                $autoLoginVars['authenticator'] = \sprintf('%s::class', Str::getShortClassName($this->autoLoginAuthenticator->authenticatorClass));
+            if (AuthenticatorType::CUSTOM === $autoLoginAuthenticator->type) {
+                $useStatements->addUseStatement($autoLoginAuthenticator->authenticatorClass);
+                $autoLoginVars['authenticator'] = \sprintf('%s::class', Str::getShortClassName($autoLoginAuthenticator->authenticatorClass));
             }
         }
 
@@ -355,8 +470,8 @@ final class MakeRegistrationForm extends AbstractMaker
                 'route_name' => 'app_register',
                 'form_class_name' => $formClassDetails->getShortName(),
                 'user_class_name' => $userClassNameDetails->getShortName(),
-                'password_field' => $this->passwordField,
-                'redirect_route_name' => $this->redirectRouteName ?? null,
+                'password_field' => $passwordField,
+                'redirect_route_name' => $redirectRouteName ?? null,
                 'translator_available' => $isTranslatorAvailable,
             ],
                 $userRepoVars,
@@ -371,13 +486,13 @@ final class MakeRegistrationForm extends AbstractMaker
             'registration/twig_template.tpl.php',
             [
                 'username_field' => $usernameField,
-                'will_verify_email' => $this->willVerifyEmail,
+                'will_verify_email' => $willVerifyEmail,
             ]
         );
 
         // 4) Update the User class if necessary
-        if ($this->addUniqueEntityConstraint) {
-            $classDetails = new ClassDetails($this->userClass);
+        if ($addUniqueEntityConstraint) {
+            $classDetails = new ClassDetails($userClass);
             $userManipulator = new ClassSourceManipulator(
                 sourceCode: file_get_contents($classDetails->getPath())
             );
@@ -393,8 +508,8 @@ final class MakeRegistrationForm extends AbstractMaker
             $this->fileManager->dumpFile($classDetails->getPath(), $userManipulator->getSourceCode());
         }
 
-        if ($this->willVerifyEmail) {
-            $classDetails = new ClassDetails($this->userClass);
+        if ($willVerifyEmail) {
+            $classDetails = new ClassDetails($userClass);
             $userManipulator = new ClassSourceManipulator(
                 sourceCode: file_get_contents($classDetails->getPath()),
                 overwrite: false,
@@ -430,10 +545,10 @@ final class MakeRegistrationForm extends AbstractMaker
 
             $generator->generateFile(
                 targetPath: \sprintf('tests/%s.php', $testClassDetails->getShortName()),
-                templateName: $this->willVerifyEmail ? 'registration/Test.WithVerify.tpl.php' : 'registration/Test.WithoutVerify.tpl.php',
+                templateName: $willVerifyEmail ? 'registration/Test.WithVerify.tpl.php' : 'registration/Test.WithoutVerify.tpl.php',
                 variables: array_merge([
                     'use_statements' => $useStatements,
-                    'from_email' => $this->fromEmailAddress ?? null,
+                    'from_email' => $fromEmailAddress ?? null,
                 ], $userRepoVars)
             );
 
@@ -445,7 +560,7 @@ final class MakeRegistrationForm extends AbstractMaker
         $generator->writeChanges();
 
         $this->writeSuccessMessage($io);
-        $this->successMessage($io, $this->willVerifyEmail, $userClassNameDetails->getShortName());
+        $this->successMessage($io, $willVerifyEmail, $userClassNameDetails->getShortName());
     }
 
     private function successMessage(ConsoleStyle $io, bool $emailVerification, string $userClass): void

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -40,6 +40,7 @@ use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -89,14 +90,7 @@ class MakeResetPassword extends AbstractMaker
     use CanGenerateTestsTrait;
     use UidTrait;
 
-    private string $fromEmailAddress;
-    private string $fromEmailName;
-    private string $controllerResetSuccessRedirect;
     private ?RouteObject $controllerResetSuccessRoute = null;
-    private string $userClass;
-    private string $emailPropertyName;
-    private string $emailGetterMethodName;
-    private string $passwordSetterMethodName;
 
     public function __construct(
         private FileManager $fileManager,
@@ -120,6 +114,16 @@ class MakeResetPassword extends AbstractMaker
     {
         $command
             ->setHelp($this->getHelpFileContents('MakeResetPassword.txt'))
+        ;
+
+        $command
+            ->addOption('user-class', null, InputOption::VALUE_REQUIRED, 'The User class the feature is built for (e.g. <fg=yellow>App\\Entity\\User</>)')
+            ->addOption('email-field', null, InputOption::VALUE_REQUIRED, 'The property holding the email address (e.g. <fg=yellow>email</>)')
+            ->addOption('email-getter', null, InputOption::VALUE_REQUIRED, 'The method returning the email address (e.g. <fg=yellow>getEmail</>)')
+            ->addOption('password-setter', null, InputOption::VALUE_REQUIRED, 'The method setting the hashed password (e.g. <fg=yellow>setPassword</>)')
+            ->addOption('success-redirect-route', null, InputOption::VALUE_REQUIRED, 'The route to redirect to after a successful reset (e.g. <fg=yellow>app_home</>)')
+            ->addOption('from-email-address', null, InputOption::VALUE_REQUIRED, 'The address reset confirmations are sent from (e.g. <fg=yellow>mailer@your-domain.com</>)')
+            ->addOption('from-email-name', null, InputOption::VALUE_REQUIRED, 'The name associated with that address (e.g. <fg=yellow>Acme Mail Bot</>)')
         ;
 
         $this->addWithUuidOption($command);
@@ -152,63 +156,117 @@ class MakeResetPassword extends AbstractMaker
         $this->checkIsUsingUid($input);
 
         $interactiveSecurityHelper = new InteractiveSecurityHelper();
+        $providersData = $this->readSecurityProviders();
 
-        if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
-            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. PHP & XML configuration formats are currently not supported.');
+        if (!$input->getOption('user-class')) {
+            $input->setOption('user-class', $interactiveSecurityHelper->guessUserClass(
+                $io,
+                $providersData,
+                'What is the User entity that should be used with the "forgotten password" feature? (e.g. <fg=yellow>App\\Entity\\User</>)'
+            ));
         }
 
-        $manipulator = new YamlSourceManipulator($this->fileManager->getFileContents($path));
-        $securityData = $manipulator->getData();
-        $providersData = $securityData['security']['providers'] ?? [];
+        $userClass = $input->getOption('user-class');
 
-        $this->userClass = $interactiveSecurityHelper->guessUserClass(
-            $io,
-            $providersData,
-            'What is the User entity that should be used with the "forgotten password" feature? (e.g. <fg=yellow>App\\Entity\\User</>)'
-        );
+        if (!$input->getOption('email-field')) {
+            $input->setOption('email-field', $interactiveSecurityHelper->guessEmailField($io, $userClass));
+        }
 
-        $this->emailPropertyName = $interactiveSecurityHelper->guessEmailField($io, $this->userClass);
-        $this->emailGetterMethodName = $interactiveSecurityHelper->guessEmailGetter($io, $this->userClass, $this->emailPropertyName);
-        $this->passwordSetterMethodName = $interactiveSecurityHelper->guessPasswordSetter($io, $this->userClass);
+        if (!$input->getOption('email-getter')) {
+            $input->setOption('email-getter', $interactiveSecurityHelper->guessEmailGetter($io, $userClass, $input->getOption('email-field')));
+        }
 
-        $io->text(\sprintf('Implementing reset password for <info>%s</info>', $this->userClass));
+        if (!$input->getOption('password-setter')) {
+            $input->setOption('password-setter', $interactiveSecurityHelper->guessPasswordSetter($io, $userClass));
+        }
+
+        $io->text(\sprintf('Implementing reset password for <info>%s</info>', $userClass));
 
         $io->section('- ResetPasswordController -');
         $io->text('A named route is used for redirecting after a successful reset. Even a route that does not exist yet can be used here.');
 
-        $this->controllerResetSuccessRedirect = $io->ask(
-            'What route should users be redirected to after their password has been successfully reset?',
-            'app_home',
-            Validator::notBlank(...)
-        );
-
-        if ($this->router instanceof RouterInterface) {
-            $this->controllerResetSuccessRoute = $this->router->getRouteCollection()->get($this->controllerResetSuccessRedirect);
+        if (!$input->getOption('success-redirect-route')) {
+            $input->setOption('success-redirect-route', $io->ask(
+                'What route should users be redirected to after their password has been successfully reset?',
+                'app_home',
+                Validator::notBlank(...)
+            ));
         }
 
         $io->section('- Email -');
         $emailText[] = 'These are used to generate the email code. Don\'t worry, you can change them in the code later!';
         $io->text($emailText);
 
-        $this->fromEmailAddress = $io->ask(
-            'What email address will be used to send reset confirmations? e.g. mailer@your-domain.com',
-            null,
-            Validator::validateEmailAddress(...)
-        );
+        if (!$input->getOption('from-email-address')) {
+            $input->setOption('from-email-address', $io->ask(
+                'What email address will be used to send reset confirmations? e.g. mailer@your-domain.com',
+                null,
+                Validator::validateEmailAddress(...)
+            ));
+        }
 
-        $this->fromEmailName = $io->ask(
-            'What "name" should be associated with that email address? e.g. "Acme Mail Bot"',
-            null,
-            Validator::notBlank(...)
-        );
+        if (!$input->getOption('from-email-name')) {
+            $input->setOption('from-email-name', $io->ask(
+                'What "name" should be associated with that email address? e.g. "Acme Mail Bot"',
+                null,
+                Validator::notBlank(...)
+            ));
+        }
 
         $this->interactSetGenerateTests($input, $io);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    private function readSecurityProviders(): array
+    {
+        if (!$this->fileManager->fileExists($path = 'config/packages/security.yaml')) {
+            throw new RuntimeCommandException('The file "config/packages/security.yaml" does not exist. PHP & XML configuration formats are currently not supported.');
+        }
+
+        return (new YamlSourceManipulator($this->fileManager->getFileContents($path)))->getData()['security']['providers'] ?? [];
+    }
+
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        $securityHelper = new InteractiveSecurityHelper();
+        $providersData = $this->readSecurityProviders();
+
+        $userClass = $input->getOption('user-class') ?: $securityHelper->findUserClass($providersData);
+
+        if (!$userClass) {
+            throw new RuntimeCommandException('The User class cannot be guessed from "security.yaml", pass it with "--user-class".');
+        }
+
+        $emailPropertyName = $input->getOption('email-field') ?: $securityHelper->findEmailField($userClass);
+
+        if (!$emailPropertyName) {
+            throw new RuntimeCommandException(\sprintf('The email property of "%s" cannot be guessed, pass it with "--email-field".', $userClass));
+        }
+
+        $emailGetterMethodName = $input->getOption('email-getter') ?: $securityHelper->findEmailGetter($userClass, $emailPropertyName);
+
+        if (!$emailGetterMethodName) {
+            throw new RuntimeCommandException(\sprintf('"%s" has no "get%s()" method, pass the getter with "--email-getter".', $userClass, ucfirst($emailPropertyName)));
+        }
+
+        $passwordSetterMethodName = $input->getOption('password-setter') ?: $securityHelper->findPasswordSetter($userClass);
+
+        if (!$passwordSetterMethodName) {
+            throw new RuntimeCommandException(\sprintf('"%s" has no "setPassword()" method, pass the setter with "--password-setter".', $userClass));
+        }
+
+        $controllerResetSuccessRedirect = $input->getOption('success-redirect-route') ?: 'app_home';
+        $fromEmailAddress = Validator::validateEmailAddress($input->getOption('from-email-address'));
+        $fromEmailName = Validator::notBlank($input->getOption('from-email-name'));
+
+        if ($this->router instanceof RouterInterface) {
+            $this->controllerResetSuccessRoute = $this->router->getRouteCollection()->get($controllerResetSuccessRedirect);
+        }
+
         $userClassNameDetails = $generator->createClassNameDetails(
-            '\\'.$this->userClass,
+            '\\'.$userClass,
             'Entity\\'
         );
 
@@ -276,19 +334,19 @@ class MakeResetPassword extends AbstractMaker
                 'user_class_name' => $userClassNameDetails->getShortName(),
                 'request_form_type_class_name' => $requestFormTypeClassNameDetails->getShortName(),
                 'reset_form_type_class_name' => $changePasswordFormTypeClassNameDetails->getShortName(),
-                'password_setter' => $this->passwordSetterMethodName,
-                'success_redirect_route' => $this->controllerResetSuccessRedirect,
-                'from_email' => $this->fromEmailAddress,
-                'from_email_name' => $this->fromEmailName,
-                'email_getter' => $this->emailGetterMethodName,
-                'email_field' => $this->emailPropertyName,
+                'password_setter' => $passwordSetterMethodName,
+                'success_redirect_route' => $controllerResetSuccessRedirect,
+                'from_email' => $fromEmailAddress,
+                'from_email_name' => $fromEmailName,
+                'email_getter' => $emailGetterMethodName,
+                'email_field' => $emailPropertyName,
                 'problem_validate_message_or_constant' => $problemValidateMessageOrConstant,
                 'problem_handle_message_or_constant' => $problemHandleMessageOrConstant,
                 'translator_available' => $isTranslatorAvailable,
             ]
         );
 
-        $this->generateRequestEntity($generator, $requestClassNameDetails, $repositoryClassNameDetails, $userClassNameDetails);
+        $this->generateRequestEntity($generator, $requestClassNameDetails, $repositoryClassNameDetails, $userClassNameDetails, $userClass);
 
         $this->setBundleConfig($io, $generator, $repositoryClassNameDetails->getFullName());
 
@@ -305,7 +363,7 @@ class MakeResetPassword extends AbstractMaker
             'resetPassword/ResetPasswordRequestFormType.tpl.php',
             [
                 'use_statements' => $useStatements,
-                'email_field' => $this->emailPropertyName,
+                'email_field' => $emailPropertyName,
             ]
         );
 
@@ -341,7 +399,7 @@ class MakeResetPassword extends AbstractMaker
             'reset_password/request.html.twig',
             'resetPassword/twig_request.tpl.php',
             [
-                'email_field' => $this->emailPropertyName,
+                'email_field' => $emailPropertyName,
             ]
         );
 
@@ -380,7 +438,7 @@ class MakeResetPassword extends AbstractMaker
                     'user_short_name' => $userClassNameDetails->getShortName(),
                     'user_repo_short_name' => $userRepositoryDetails->getShortName(),
                     'success_route_path' => null !== $this->controllerResetSuccessRoute ? $this->controllerResetSuccessRoute->getPath() : '/',
-                    'from_email' => $this->fromEmailAddress,
+                    'from_email' => $fromEmailAddress,
                 ],
             );
 
@@ -460,7 +518,7 @@ class MakeResetPassword extends AbstractMaker
         $io->newLine();
     }
 
-    private function generateRequestEntity(Generator $generator, ClassNameDetails $requestClassNameDetails, ClassNameDetails $repositoryClassNameDetails, ClassNameDetails $userClassDetails): void
+    private function generateRequestEntity(Generator $generator, ClassNameDetails $requestClassNameDetails, ClassNameDetails $repositoryClassNameDetails, ClassNameDetails $userClassDetails, string $userClass): void
     {
         // Generate ResetPasswordRequest Entity
         $requestEntityPath = $this->entityClassGenerator->generateEntityClass(
@@ -498,7 +556,7 @@ class MakeResetPassword extends AbstractMaker
 
         $manipulator->addManyToOneRelation(new RelationManyToOne(
             propertyName: 'user',
-            targetClassName: $this->userClass,
+            targetClassName: $userClass,
             mapInverseRelation: false,
             avoidSetter: true,
             isCustomReturnTypeNullable: false,

--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -147,8 +147,8 @@ final class InteractiveSecurityHelper
 
     public function guessEmailField(SymfonyStyle $io, string $userClass): string
     {
-        if (property_exists($userClass, 'email')) {
-            return 'email';
+        if (null !== $emailField = $this->findEmailField($userClass)) {
+            return $emailField;
         }
 
         $classProperties = [];
@@ -163,10 +163,18 @@ final class InteractiveSecurityHelper
         );
     }
 
+    /**
+     * The email property when the class has the obvious one, null when a person has to pick.
+     */
+    public function findEmailField(string $userClass): ?string
+    {
+        return property_exists($userClass, 'email') ? 'email' : null;
+    }
+
     public function guessPasswordField(SymfonyStyle $io, string $userClass): string
     {
-        if (property_exists($userClass, 'password')) {
-            return 'password';
+        if (null !== $passwordField = $this->findPasswordField($userClass)) {
+            return $passwordField;
         }
 
         $classProperties = [];
@@ -181,11 +189,21 @@ final class InteractiveSecurityHelper
         );
     }
 
+    /**
+     * The password property when the class has the obvious one, null when a person has to pick.
+     */
+    public function findPasswordField(string $userClass): ?string
+    {
+        return property_exists($userClass, 'password') ? 'password' : null;
+    }
+
     public function guessPasswordSetter(SymfonyStyle $io, string $userClass): string
     {
-        if (null === ($methodChoices = $this->methodNameGuesser($userClass, 'setPassword'))) {
-            return 'setPassword';
+        if (null !== $passwordSetter = $this->findPasswordSetter($userClass)) {
+            return $passwordSetter;
         }
+
+        $methodChoices = $this->methodNameGuesser($userClass, 'setPassword');
 
         return $io->choice(
             \sprintf('Which method on your <fg=yellow>%s</> class can be used to set the encoded password (e.g. setPassword())?', $userClass),
@@ -193,13 +211,21 @@ final class InteractiveSecurityHelper
         );
     }
 
+    /**
+     * The password setter when the class has the obvious one, null when a person has to pick.
+     */
+    public function findPasswordSetter(string $userClass): ?string
+    {
+        return null === $this->methodNameGuesser($userClass, 'setPassword') ? 'setPassword' : null;
+    }
+
     public function guessEmailGetter(SymfonyStyle $io, string $userClass, string $emailPropertyName): string
     {
-        $supposedEmailMethodName = \sprintf('get%s', Str::asCamelCase($emailPropertyName));
-
-        if (null === ($methodChoices = $this->methodNameGuesser($userClass, $supposedEmailMethodName))) {
-            return $supposedEmailMethodName;
+        if (null !== $emailGetter = $this->findEmailGetter($userClass, $emailPropertyName)) {
+            return $emailGetter;
         }
+
+        $methodChoices = $this->methodNameGuesser($userClass, \sprintf('get%s', Str::asCamelCase($emailPropertyName)));
 
         return $io->choice(
             \sprintf('Which method on your <fg=yellow>%s</> class can be used to get the email address (e.g. getEmail())?', $userClass),
@@ -207,11 +233,23 @@ final class InteractiveSecurityHelper
         );
     }
 
+    /**
+     * The email getter when the class has the obvious one, null when a person has to pick.
+     */
+    public function findEmailGetter(string $userClass, string $emailPropertyName): ?string
+    {
+        $supposedEmailMethodName = \sprintf('get%s', Str::asCamelCase($emailPropertyName));
+
+        return null === $this->methodNameGuesser($userClass, $supposedEmailMethodName) ? $supposedEmailMethodName : null;
+    }
+
     public function guessIdGetter(SymfonyStyle $io, string $userClass): string
     {
-        if (null === ($methodChoices = $this->methodNameGuesser($userClass, 'getId'))) {
-            return 'getId';
+        if (null !== $idGetter = $this->findIdGetter($userClass)) {
+            return $idGetter;
         }
+
+        $methodChoices = $this->methodNameGuesser($userClass, 'getId');
 
         return $io->choice(
             \sprintf('Which method on your <fg=yellow>%s</> class can be used to get the unique user identifier (e.g. getId())?', $userClass),
@@ -307,6 +345,14 @@ final class InteractiveSecurityHelper
         }
 
         return $authenticators;
+    }
+
+    /**
+     * The id getter when the class has the obvious one, null when a person has to pick.
+     */
+    public function findIdGetter(string $userClass): ?string
+    {
+        return null === $this->methodNameGuesser($userClass, 'getId') ? 'getId' : null;
     }
 
     private function methodNameGuesser(string $className, string $suspectedMethodName): ?array

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -38,6 +38,112 @@ class MakeRegistrationFormTest extends MakerTestCase
 
     public static function getTestDetails(): \Generator
     {
+        yield 'it_generates_registration_form_non_interactively' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $output = $runner->runMaker([], '--no-interaction --redirect-route=app_anonymous');
+
+                self::assertStringContainsString('Success', $output);
+
+                // the user class, the login field and the password field are all derived from
+                // security.yaml and the class itself, exactly as the prompt derives them
+                $controller = file_get_contents($runner->getPath('src/Controller/RegistrationController.php'));
+                self::assertStringContainsString('app_anonymous', $controller);
+                // the three confirmations are opt-in here, where the prompt offers yes
+                self::assertStringNotContainsString('EmailVerifier', $controller);
+                self::assertStringNotContainsString('UniqueEntity', file_get_contents($runner->getPath('src/Entity/User.php')));
+            }),
+        ];
+
+        yield 'it_generates_registration_form_non_interactively_with_verification' => [self::createRegistrationFormTest()
+            ->addExtraDependencies('symfonycasts/verify-email-bundle')
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $runner->runMaker(
+                    [],
+                    '--no-interaction --redirect-route=app_anonymous --unique-entity --verify-email'
+                    .' --from-email-address=jr@rushlow.dev --from-email-name="Jesse Rushlow"'
+                );
+
+                $controller = file_get_contents($runner->getPath('src/Controller/RegistrationController.php'));
+                self::assertStringContainsString('EmailVerifier', $controller);
+                self::assertStringContainsString('jr@rushlow.dev', $controller);
+                self::assertStringContainsString('UniqueEntity', file_get_contents($runner->getPath('src/Entity/User.php')));
+            }),
+        ];
+
+        yield 'it_rejects_missing_options_non_interactively' => [self::createRegistrationFormTest()
+            ->addExtraDependencies('symfonycasts/verify-email-bundle')
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $invalid = [
+                    '--no-interaction --verify-email --redirect-route=app_anonymous' => 'is not a valid email address',
+                    '--no-interaction --redirect-route=app_anonymous --authenticator=nope' => 'No authenticator named "nope"',
+                ];
+
+                foreach ($invalid as $arguments => $expectedError) {
+                    $output = $runner->runMaker([], $arguments, allowedToFail: true);
+
+                    self::assertStringContainsString($expectedError, $output, \sprintf('"%s" was not rejected.', $arguments));
+                    self::assertFileDoesNotExist($runner->getPath('src/Controller/RegistrationController.php'));
+                }
+            }),
+        ];
+
+        yield 'it_generates_registration_form_non_interactively_with_auto_login' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $runner->modifyYamlFile('config/packages/security.yaml', static function (array $data) {
+                    $data['security']['firewalls']['main']['form_login'] = [];
+
+                    return $data;
+                });
+
+                $runner->runMaker([], '--no-interaction --auto-login');
+
+                $fixturePath = \dirname(__DIR__, 1).'/fixtures/make-registration-form/expected';
+
+                // --auto-login alone resolves the single configured authenticator,
+                // exactly as the prompt does when there is only one to choose from
+                self::assertFileEquals($fixturePath.'/RegistrationControllerFormLogin.php', $runner->getPath('src/Controller/RegistrationController.php'));
+            }),
+        ];
+
+        yield 'it_rejects_ambiguous_auto_login_non_interactively' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $runner->modifyYamlFile('config/packages/security.yaml', static function (array $data) {
+                    $data['security']['firewalls']['main']['form_login'] = [];
+                    $data['security']['firewalls']['main']['custom_authenticator'] = 'App\\Security\\StubAuthenticator';
+
+                    return $data;
+                });
+
+                $output = $runner->runMaker([], '--no-interaction --auto-login', allowedToFail: true);
+
+                self::assertStringContainsString('Multiple authenticators are configured', $output);
+                self::assertFileDoesNotExist($runner->getPath('src/Controller/RegistrationController.php'));
+            }),
+        ];
+
+        yield 'it_notes_missing_authenticator_for_auto_login_non_interactively' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $output = $runner->runMaker([], '--no-interaction --auto-login --redirect-route=app_anonymous');
+
+                // no authenticator is configured, so --auto-login has nothing to resolve;
+                // the command still succeeds, matching the interactive note rather than the prompt's error path
+                self::assertStringContainsString('No authenticators found', $output);
+                self::assertFileExists($runner->getPath('src/Controller/RegistrationController.php'));
+            }),
+        ];
+
         yield 'it_generates_registration_with_entity_and_form_login_with_no_login' => [self::createRegistrationFormTest()
             ->run(static function (MakerTestRunner $runner) {
                 self::makeUser($runner);

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -339,6 +339,49 @@ class MakeResetPasswordTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_non_interactively' => [self::buildMakerTest()
+            // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
+            ->setSkippedPhpVersions(80100, 80109)
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $output = $runner->runMaker(
+                    [],
+                    '--no-interaction --from-email-address=jr@rushlow.dev --from-email-name="Jesse Rushlow"'
+                );
+
+                self::assertStringContainsString('Success', $output);
+
+                // the user class, the email field, the getter and the setter are all derived
+                // from security.yaml and the class itself, exactly as the prompt derives them
+                $controller = file_get_contents($runner->getPath('src/Controller/ResetPasswordController.php'));
+                self::assertStringContainsString('getEmail()', $controller);
+                self::assertStringContainsString('setPassword(', $controller);
+                self::assertStringContainsString('app_home', $controller);
+                self::assertStringContainsString('jr@rushlow.dev', $controller);
+            }),
+        ];
+
+        yield 'it_rejects_missing_options_non_interactively' => [self::buildMakerTest()
+            // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
+            ->setSkippedPhpVersions(80100, 80109)
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $invalid = [
+                    '--no-interaction' => 'is not a valid email address',
+                    '--no-interaction --from-email-address=jr@rushlow.dev' => 'This value cannot be blank',
+                ];
+
+                foreach ($invalid as $arguments => $expectedError) {
+                    $output = $runner->runMaker([], $arguments, allowedToFail: true);
+
+                    self::assertStringContainsString($expectedError, $output, \sprintf('"%s" was not rejected.', $arguments));
+                    self::assertFileDoesNotExist($runner->getPath('src/Controller/ResetPasswordController.php'));
+                }
+            }),
+        ];
+
         yield 'it_generates_with_custom_user' => [self::buildMakerTest()
             // @legacy - drop skipped versions when PHP 8.1 is no longer supported.
             ->setSkippedPhpVersions(80100, 80109)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

> [!NOTE]
> Built on #1818 and #1819, which extract the silent halves of the security guesses this one also needs. Those commits appear in the diff until they are merged. This is the largest of the series and the last of it.

```console
$ php bin/console make:registration-form --no-interaction
Typed property Symfony\Bundle\MakerBundle\Maker\MakeRegistrationForm::$userClass must not
be accessed before initialization
```

### Cause

Eight answers were kept on the maker across twelve decision points, and the command exposed only `--with-tests`. `Command::run()` skips `interact()` under `--no-interaction`, so nothing was assigned and the first read in `generate()` threw.

### Fix

Thirteen options carry them: `--user-class`, `--username-field`, `--password-field`, `--unique-entity`, `--verify-email`, `--verify-anonymously`, `--id-getter`, `--email-getter`, `--from-email-address`, `--from-email-name`, `--auto-login`, `--authenticator` and `--redirect-route`.

`interact()` asks only for what was not passed and writes each answer into its option, `generate()` resolves them, and the properties are gone. The same questions are asked in the same order with the same defaults, except that passing an option skips its question.

### Three deliberate differences

`--unique-entity`, `--verify-email` and `--auto-login` are opt-in, where the prompts offer **yes** as their default.

This is worth arguing rather than assuming. Inheriting those defaults would mean a scripted run silently pulls in `symfonycasts/verify-email-bundle` and `symfony/mailer`, adds an `isVerified` property to the User entity, writes a `#[UniqueEntity]` attribute onto it and wires up authentication after registration. None of that is something a caller who passed no flags asked for. A flag that has to be spelled out is worth more here than matching which answer a prompt preselects, the same trade-off taken in #1813.

### The guesses

`guessUserClass()`, `guessUserNameField()`, `guessPasswordField()`, `guessIdGetter()` and `guessEmailGetter()` return silently when the config and the class are unambiguous and prompt otherwise, and the prompting branch cannot be reached without a terminal. `generate()` uses their silent halves on `InteractiveSecurityHelper` and fails with a message naming the option when a person would have to answer. `findPasswordField()` and `findIdGetter()` are added there for this.

The two email values and the redirect route have nothing to derive from and are required when the feature that needs them is switched on.

### Auto-login

`--auto-login` had the same gap. The single-authenticator match lived only in the interactive question, so `generate()` read `--authenticator` but never resolved it on its own. `resolveAuthenticator()` now does what the question did: picks the one configured authenticator when there is exactly one, fails naming `--authenticator` when there is more than one, and prints the same note the prompt shows when there is none.

### Why

Part of a series making the makers usable by coding agents, which cannot answer prompts. Same framing as #1814 and #1815.
