### PR TITLE
[make:command] Ask for the arguments and the options

### DIFF
--- a/config/help/MakeCommand.txt
+++ b/config/help/MakeCommand.txt
@@ -3,3 +3,22 @@ The <info>%command.name%</info> command generates a new command:
 <info>php %command.full_name% app:do-something</info>
 
 If the argument is missing, the command will ask for the command name interactively.
+
+The command then asks for the arguments and the options to declare, and generates the
+<info>__invoke()</info> method with the matching <info>#[Argument]</info> and <info>#[Option]</info> parameters.
+
+They can be passed on the command line instead of being asked for, which is what you
+want in a script or when the terminal is not interactive:
+
+<info>php %command.full_name% app:send-report --argument=recipient --argument=cc?:array --option=dry-run --option=format:Format</info>
+
+The format is <comment>name[:type]</comment>, where the type is one of <comment>string</comment>, <comment>bool</comment>, <comment>int</comment>, <comment>float</comment>,
+<comment>array</comment> or a backed enum. It defaults to <comment>string</comment> for an argument and to <comment>bool</comment> for an option.
+The name is written the way it reads on the command line: <comment>dry-run</comment> becomes <comment>$dryRun</comment>.
+
+The short name of an enum is enough as long as it is unique within <comment>src/</comment>, which saves
+escaping backslashes in your shell.
+
+An argument is required unless its name ends with <comment>?</comment>, as an optional key of a PHP array
+shape: <comment>cc?:array</comment>. Note that this differs from the interactive mode, whose default
+answer is <comment>no</comment>.

--- a/config/makers.php
+++ b/config/makers.php
@@ -54,6 +54,7 @@ return static function (ContainerConfigurator $container) {
         ->tag('maker.command');
 
     $services->set('maker.maker.make_command', MakeCommand::class)
+        ->arg('$fileManager', service('maker.file_manager'))
         ->tag('maker.command');
 
     $services->set('maker.maker.make_twig_component', MakeTwigComponent::class)

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -13,17 +13,23 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
+use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\EnumHelper;
 use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -32,8 +38,30 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class MakeCommand extends AbstractMaker
 {
-    public function __construct(?PhpCompatUtil $phpCompatUtil = null)
-    {
+    private const PARAMETER_TYPES = ['string', 'bool', 'int', 'float', 'array'];
+
+    private const EMPTY_VALUES = [
+        'string' => "''",
+        'bool' => 'false',
+        'int' => '0',
+        'float' => '0.0',
+        'array' => '[]',
+    ];
+
+    /**
+     * @var list<array{name: string, type: string, description: string, required: bool}>
+     */
+    private array $arguments = [];
+
+    /**
+     * @var list<array{name: string, type: string, description: string, required: bool}>
+     */
+    private array $options = [];
+
+    public function __construct(
+        ?PhpCompatUtil $phpCompatUtil = null,
+        private ?FileManager $fileManager = null,
+    ) {
         if (null !== $phpCompatUtil) {
             @trigger_deprecation(
                 'symfony/maker-bundle',
@@ -57,8 +85,23 @@ final class MakeCommand extends AbstractMaker
     {
         $command
             ->addArgument('name', InputArgument::OPTIONAL, \sprintf('Choose a command name (e.g. <fg=yellow>app:%s</>)', Str::asCommand(Str::getRandomTerm())))
+            ->addOption('argument', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add an argument without being asked for it: <fg=yellow>name[?][:type]</> (e.g. <fg=yellow>recipient:string</>). Repeat the option for each argument')
+            ->addOption('option', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add an option without being asked for it: <fg=yellow>name[:type]</> (e.g. <fg=yellow>dry-run:bool</>). Repeat it for each option')
             ->setHelp($this->getHelpFileContents('MakeCommand.txt'))
         ;
+    }
+
+    public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        // they were passed on the command line, asking for more would mix both ways of declaring them
+        if ($input->getOption('argument') || $input->getOption('option')) {
+            return;
+        }
+
+        $io->text('The command is generated with an <fg=yellow>__invoke()</> method, whose parameters are the arguments and options of the command.');
+
+        $this->arguments = $this->askForParameters($io, 'argument');
+        $this->options = $this->askForParameters($io, 'option', $this->arguments);
     }
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
@@ -73,13 +116,43 @@ final class MakeCommand extends AbstractMaker
             \sprintf('The "%s" command name is not valid because it would be implemented by "%s" class, which is not valid as a PHP class name (it must start with a letter or underscore, followed by any number of letters, numbers, or underscores).', $commandName, Str::asClassName($commandName, 'Command'))
         );
 
+        $argumentDefinitions = $input->getOption('argument');
+        $optionDefinitions = $input->getOption('option');
+
+        if ($argumentDefinitions || $optionDefinitions) {
+            [$arguments, $options] = self::parseDefinitions($argumentDefinitions, $optionDefinitions, $generator);
+        } else {
+            $arguments = $this->arguments;
+            $options = $this->options;
+        }
+
+        if (!$arguments && !$options) {
+            // Nothing was asked, either because of --no-interaction or because the user went straight
+            // through the questions. The sample parameters are kept: they show both attributes at work.
+            $arguments = [['name' => 'arg', 'type' => 'string', 'description' => 'Argument description', 'required' => false]];
+            $options = [['name' => 'enable', 'type' => 'bool', 'description' => 'Option description', 'required' => false]];
+        }
+
         $useStatements = new UseStatementGenerator([
             Command::class,
             SymfonyStyle::class,
             AsCommand::class,
-            Argument::class,
-            Option::class,
         ]);
+
+        if ($arguments) {
+            $useStatements->addUseStatement(Argument::class);
+        }
+
+        if ($options) {
+            $useStatements->addUseStatement(Option::class);
+        }
+
+        foreach ([...$arguments, ...$options] as $parameter) {
+            // an enum named like one of the imports above, "Option" say, is imported under an alias
+            if (!\in_array($parameter['type'], self::PARAMETER_TYPES, true) && !$useStatements->hasUseStatement($parameter['type'])) {
+                $useStatements->addUseStatement($parameter['type'], 'Enum');
+            }
+        }
 
         $generator->generateClass(
             $commandClassNameDetails->getFullName(),
@@ -87,6 +160,11 @@ final class MakeCommand extends AbstractMaker
             [
                 'use_statements' => $useStatements,
                 'command_name' => $commandName,
+                'command_parameters' => [
+                    ...array_map(static fn (array $argument): string => self::buildParameter('Argument', $argument, $useStatements), $arguments),
+                    ...array_map(static fn (array $option): string => self::buildParameter('Option', $option, $useStatements), $options),
+                ],
+                'command_notes' => array_map(self::buildNote(...), [...$arguments, ...$options]),
             ]
         );
 
@@ -97,6 +175,229 @@ final class MakeCommand extends AbstractMaker
             'Next: open your new command class and customize it!',
             'Find the documentation at <fg=yellow>https://symfony.com/doc/current/console.html</>',
         ]);
+    }
+
+    /**
+     * @param list<array{name: string, type: string, description: string, required: bool}> $declared their names are taken
+     *
+     * @return list<array{name: string, type: string, description: string, required: bool}>
+     */
+    private function askForParameters(ConsoleStyle $io, string $kind, array $declared = []): array
+    {
+        $parameters = [];
+
+        while (true) {
+            $io->writeln('');
+            $name = $io->ask(\sprintf('New %s name (press <return> to stop adding %ss)', $kind, $kind));
+
+            if (null === $name || '' === trim($name)) {
+                return $parameters;
+            }
+
+            $name = self::normalizeName($name);
+
+            if (null !== $error = self::validateName($name, [...$declared, ...$parameters])) {
+                $io->error($error);
+
+                continue;
+            }
+
+            $type = $io->choice('Type', [...self::PARAMETER_TYPES, 'enum'], 'option' === $kind ? 'bool' : 'string');
+
+            if ('enum' === $type) {
+                $type = $io->askQuestion($this->createEnumQuestion());
+            }
+
+            $parameters[] = [
+                'name' => $name,
+                'type' => $type,
+                'description' => $io->ask('Description', Str::asHumanWords($name)),
+                // An option is never required: not passing it is what its default value stands for.
+                // Neither is an argument that follows an optional one, which PHP and the console
+                // component both refuse, so the question is only worth asking while none was added.
+                'required' => 'argument' === $kind
+                    && !\in_array(false, array_column($parameters, 'required'), true)
+                    && $io->confirm('Is it required?', false),
+            ];
+
+            if ('argument' === $kind && 'array' === $type) {
+                // the console component refuses any argument after it
+                $io->text('An array argument takes every remaining value, so it has to be the last one.');
+
+                return $parameters;
+            }
+        }
+    }
+
+    private function createEnumQuestion(): Question
+    {
+        $question = new Question('Backed enum class');
+        $question->setValidator(Validator::classIsBackedEnum(...));
+
+        if ($this->fileManager) {
+            $question->setAutocompleterValues((new EnumHelper($this->fileManager->getRootDirectory().'/src', 'App'))->getAllEnums());
+        }
+
+        return $question;
+    }
+
+    /**
+     * @param string[] $argumentDefinitions
+     * @param string[] $optionDefinitions
+     *
+     * @return array{list<array{name: string, type: string, description: string, required: bool}>, list<array{name: string, type: string, description: string, required: bool}>}
+     */
+    private static function parseDefinitions(array $argumentDefinitions, array $optionDefinitions, Generator $generator): array
+    {
+        $arguments = [];
+
+        foreach ($argumentDefinitions as $definition) {
+            $arguments[] = self::parseDefinition('argument', $definition, $arguments, $generator);
+        }
+
+        $options = [];
+
+        foreach ($optionDefinitions as $definition) {
+            $options[] = self::parseDefinition('option', $definition, [...$arguments, ...$options], $generator);
+        }
+
+        return [$arguments, $options];
+    }
+
+    /**
+     * Parses <name>[?][:<type>], where "?" makes an argument optional the way it does a key of a PHP array shape.
+     *
+     * @param list<array{name: string, type: string, description: string, required: bool}> $declared parsed so far, arguments first
+     *
+     * @return array{name: string, type: string, description: string, required: bool}
+     */
+    private static function parseDefinition(string $kind, string $definition, array $declared, Generator $generator): array
+    {
+        $parts = explode(':', trim($definition), 2);
+        $name = $parts[0];
+
+        if ($optional = str_ends_with($name, '?')) {
+            $name = substr($name, 0, -1);
+        }
+
+        $name = self::normalizeName($name);
+        $type = ($parts[1] ?? '') ?: ('option' === $kind ? 'bool' : 'string');
+
+        if ('' === $name) {
+            throw new RuntimeCommandException(\sprintf('The definition "%s" is missing a name.', $definition));
+        }
+
+        if (null !== $error = self::validateName($name, $declared)) {
+            throw new RuntimeCommandException($error);
+        }
+
+        $type = self::resolveType($type, $definition, $generator);
+
+        if ('option' === $kind && $optional) {
+            throw new RuntimeCommandException(\sprintf('The option "%s" cannot have a "?", an option is always optional.', $definition));
+        }
+
+        if ('argument' === $kind) {
+            // the console component refuses both, and would only say so once the generated command runs
+            foreach ($declared as $argument) {
+                if ('array' === $argument['type']) {
+                    throw new RuntimeCommandException(\sprintf('No argument can follow the array argument "%s", which takes every remaining value.', $argument['name']));
+                }
+
+                if (!$optional && !$argument['required']) {
+                    throw new RuntimeCommandException(\sprintf('The argument "%s" cannot be required after the optional "%s", add a "?" to its name.', $definition, $argument['name']));
+                }
+            }
+        }
+
+        return [
+            'name' => $name,
+            'type' => $type,
+            'description' => Str::asHumanWords($name),
+            'required' => 'argument' === $kind && !$optional,
+        ];
+    }
+
+    /**
+     * @return string one of the parameter types, or the class of a backed enum
+     */
+    private static function resolveType(string $type, string $definition, Generator $generator): string
+    {
+        if (\in_array($type, self::PARAMETER_TYPES, true)) {
+            return $type;
+        }
+
+        if (str_contains($type, '\\')) {
+            $enums = enum_exists($type) ? [ltrim($type, '\\')] : [];
+        } else {
+            // a short name spares the caller from escaping backslashes in the shell
+            $enumHelper = new EnumHelper($generator->getRootDirectory().'/src', rtrim($generator->getRootNamespace(), '\\'));
+            $enums = array_values(array_filter($enumHelper->getAllEnums(), static fn (string $enum): bool => Str::getShortClassName($enum) === $type));
+        }
+
+        if (!$enums) {
+            throw new RuntimeCommandException(\sprintf('Invalid type "%s" in "%s", use one of "%s" or the name of a backed enum.', $type, $definition, implode('", "', self::PARAMETER_TYPES)));
+        }
+
+        if (1 < \count($enums)) {
+            throw new RuntimeCommandException(\sprintf('The enum "%s" in "%s" is ambiguous, use its full class name: "%s".', $type, $definition, implode('", "', $enums)));
+        }
+
+        if (!is_subclass_of($enums[0], \BackedEnum::class)) {
+            throw new RuntimeCommandException(\sprintf('The enum "%s" in "%s" is not backed, which the console component needs to read it from the input.', $enums[0], $definition));
+        }
+
+        return $enums[0];
+    }
+
+    private static function normalizeName(string $name): string
+    {
+        // the name is typed the way it reads on the command line, but it becomes a parameter
+        return Str::asLowerCamelCase(str_replace('-', '_', trim($name)));
+    }
+
+    /**
+     * @param list<array{name: string, type: string, description: string, required: bool}> $declared
+     */
+    private static function validateName(string $name, array $declared): ?string
+    {
+        if (!Str::isValidPhpVariableName($name)) {
+            return \sprintf('"%s" is not a valid PHP variable name.', $name);
+        }
+
+        // $io is the first parameter of the generated method
+        if ('io' === $name || \in_array($name, array_column($declared, 'name'), true)) {
+            return \sprintf('__invoke() already has a "$%s" parameter.', $name);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array{name: string, type: string, description: string, required: bool} $parameter
+     */
+    private static function buildParameter(string $attribute, array $parameter, UseStatementGenerator $useStatements): string
+    {
+        $isEnum = !\in_array($parameter['type'], self::PARAMETER_TYPES, true);
+
+        return \sprintf(
+            '#[%s(\'%s\')] %s%s $%s%s',
+            $attribute,
+            addcslashes($parameter['description'], "'\\"),
+            // an optional enum has no empty case to default to
+            $isEnum && !$parameter['required'] ? '?' : '',
+            $isEnum ? $useStatements->getShortName($parameter['type']) : $parameter['type'],
+            $parameter['name'],
+            $parameter['required'] ? '' : ' = '.(self::EMPTY_VALUES[$parameter['type']] ?? 'null'),
+        );
+    }
+
+    /**
+     * @param array{name: string, type: string, description: string, required: bool} $parameter
+     */
+    private static function buildNote(array $parameter): string
+    {
+        return \sprintf('$io->note(sprintf(\'The value of $%1$s is: %%s\', var_export($%1$s, true)));', $parameter['name']);
     }
 
     public function configureDependencies(DependencyBuilder $dependencies): void

--- a/templates/command/Command.tpl.php
+++ b/templates/command/Command.tpl.php
@@ -12,11 +12,13 @@ class <?= $class_name; ?>
 {
     public function __invoke(
         SymfonyStyle $io,
-        #[Argument('Argument description')] string $arg = '',
-        #[Option('Option description')] bool $enable = false,
+<?php foreach ($command_parameters as $parameter) { ?>
+        <?= $parameter; ?>,
+<?php } ?>
     ): int {
-        $io->note(sprintf('The value of $arg is: %s', $arg));
-        $io->note(sprintf('The value of $enable is: %s', $enable ? 'true' : 'false'));
+<?php foreach ($command_notes as $note) { ?>
+        <?= $note."\n"; ?>
+<?php } ?>
 
         $io->success('You have a new command! Now make it your own! Pass --help to see your options.');
 

--- a/tests/Maker/MakeCommandTest.php
+++ b/tests/Maker/MakeCommandTest.php
@@ -30,6 +30,10 @@ class MakeCommandTest extends MakerTestCase
                 $runner->runMaker([
                     // command name
                     'app:foo',
+                    // no argument
+                    '',
+                    // no option
+                    '',
                 ]);
 
                 self::runCommandTest($runner, 'it_makes_a_command.php');
@@ -41,6 +45,10 @@ class MakeCommandTest extends MakerTestCase
                 $runner->runMaker([
                     // command name
                     'app:foo',
+                    // no argument
+                    '',
+                    // no option
+                    '',
                 ]);
 
                 self::runCommandTest($runner, 'it_makes_a_command.php');
@@ -63,11 +71,157 @@ class MakeCommandTest extends MakerTestCase
                 $runner->runMaker([
                     // command name
                     'app:foo',
+                    // no argument
+                    '',
+                    // no option
+                    '',
                 ]);
 
                 self::runCommandTest($runner, 'it_makes_a_command_in_custom_namespace.php');
             }),
         ];
+
+        yield 'it_makes_a_command_non_interactively' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([], 'app:foo --no-interaction');
+
+                self::assertStringContainsString('Success', $output);
+
+                $commandFileContents = file_get_contents($runner->getPath('src/Command/FooCommand.php'));
+
+                // interact() does not run without a terminal, so no parameter is collected and the
+                // sample ones are generated, exactly as before this was interactive
+                self::assertStringContainsString("#[Argument('Argument description')] string \$arg = '',", $commandFileContents);
+                self::assertStringContainsString("#[Option('Option description')] bool \$enable = false,", $commandFileContents);
+            }),
+        ];
+
+        yield 'it_makes_a_command_with_arguments_and_options' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::writeEnums($runner);
+
+                $runner->runMaker([
+                    // command name
+                    'app:foo',
+                    // $io is the first parameter of __invoke(), so the name is asked again
+                    'io',
+                    // argument name, type, description, required
+                    'recipient', 'string', 'Who to greet', 'y',
+                    // argument name, type, description, required
+                    'times', 'int', 'How many times', '',
+                    // argument name, type, description: no "required" question here, an argument
+                    // following an optional one can only be optional; and no more arguments are
+                    // asked for after an array one, which takes every remaining value
+                    'tags', 'array', 'Tags to add',
+                    // taken by an argument, so the name is asked again
+                    'times',
+                    // option name, type, description
+                    'dry-run', 'bool', 'Do not send anything',
+                    // option name, type, enum class, description
+                    'format', 'enum', 'App\\Enum\\Format', 'Output format',
+                    // no more options
+                    '',
+                ]);
+
+                self::runCommandTest($runner, 'it_makes_a_command_with_arguments_and_options.php');
+
+                $commandFileContents = file_get_contents($runner->getPath('src/Command/FooCommand.php'));
+
+                self::assertStringContainsString("#[Argument('Who to greet')] string \$recipient,", $commandFileContents);
+                self::assertStringContainsString("#[Argument('How many times')] int \$times = 0,", $commandFileContents);
+                self::assertStringContainsString("#[Argument('Tags to add')] array \$tags = [],", $commandFileContents);
+                self::assertStringContainsString("#[Option('Do not send anything')] bool \$dryRun = false,", $commandFileContents);
+                self::assertStringContainsString('use App\Enum\Format;', $commandFileContents);
+                self::assertStringContainsString("#[Option('Output format')] ?Format \$format = null,", $commandFileContents);
+                self::assertSame(1, substr_count($commandFileContents, '$times = '));
+                self::assertStringNotContainsString('$arg', $commandFileContents);
+            }),
+        ];
+
+        yield 'it_makes_a_command_from_the_command_line' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::writeEnums($runner);
+
+                // no answer is given: passing any of them on the command line skips the questions
+                $runner->runMaker([], 'app:foo --argument=recipient --argument=times?:int --argument=tags?:array --option=dry-run --option=retries:int --option=format:Format --option=mode:Option');
+
+                self::runCommandTest($runner, 'it_makes_a_command_with_arguments_and_options.php');
+
+                $commandFileContents = file_get_contents($runner->getPath('src/Command/FooCommand.php'));
+
+                self::assertStringContainsString("#[Argument('Recipient')] string \$recipient,", $commandFileContents);
+                self::assertStringContainsString("#[Argument('Times')] int \$times = 0,", $commandFileContents);
+                self::assertStringContainsString("#[Argument('Tags')] array \$tags = [],", $commandFileContents);
+                self::assertStringContainsString("#[Option('Dry Run')] bool \$dryRun = false,", $commandFileContents);
+                self::assertStringContainsString("#[Option('Retries')] int \$retries = 0,", $commandFileContents);
+                // the short name of the enum is resolved within src/
+                self::assertStringContainsString('use App\Enum\Format;', $commandFileContents);
+                self::assertStringContainsString("#[Option('Format')] ?Format \$format = null,", $commandFileContents);
+                // "Option" is taken by the attribute
+                self::assertStringContainsString('use App\Enum\Option as EnumOption;', $commandFileContents);
+                self::assertStringContainsString("#[Option('Mode')] ?EnumOption \$mode = null,", $commandFileContents);
+                self::assertStringNotContainsString('$arg', $commandFileContents);
+            }),
+        ];
+
+        yield 'it_rejects_invalid_definitions' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $invalidDefinitions = [
+                    '--argument=:string' => 'is missing a name',
+                    '--argument=1st' => '"1st" is not a valid PHP variable name',
+                    '--argument=name:nope' => 'Invalid type "nope"',
+                    // the "?" belongs to the name, as in a PHP array shape
+                    '--argument=count:int?' => 'Invalid type "int?"',
+                    // $io is the first parameter of __invoke()
+                    '--argument=io' => 'already has a "$io" parameter',
+                    '--argument=name --option=name' => 'already has a "$name" parameter',
+                    // the console component would only refuse these once the generated command runs
+                    '--argument=name? --argument=other' => 'The argument "other" cannot be required',
+                    '--argument=names:array --argument=other?' => 'No argument can follow the array argument "names"',
+                    '--option=force?' => 'The option "force?" cannot have a "?"',
+                ];
+
+                foreach ($invalidDefinitions as $definitions => $expectedError) {
+                    $output = $runner->runMaker(
+                        [],
+                        \sprintf('--no-interaction app:foo %s', $definitions),
+                        allowedToFail: true
+                    );
+
+                    self::assertStringContainsString($expectedError, $output, \sprintf('"%s" was not rejected.', $definitions));
+                    // nothing is written before every definition has been parsed
+                    self::assertFileDoesNotExist($runner->getPath('src/Command/FooCommand.php'));
+                }
+            }),
+        ];
+    }
+
+    private static function writeEnums(MakerTestRunner $runner): void
+    {
+        $runner->writeFile('src/Enum/Format.php', <<<'PHP'
+            <?php
+
+            namespace App\Enum;
+
+            enum Format: string
+            {
+                case Json = 'json';
+                case Xml = 'xml';
+            }
+            PHP);
+
+        // named like the attribute the generated command imports
+        $runner->writeFile('src/Enum/Option.php', <<<'PHP'
+            <?php
+
+            namespace App\Enum;
+
+            enum Option: int
+            {
+                case On = 1;
+                case Off = 0;
+            }
+            PHP);
     }
 
     private static function runCommandTest(MakerTestRunner $runner, string $filename): void

--- a/tests/fixtures/make-command/tests/it_makes_a_command_with_arguments_and_options.php
+++ b/tests/fixtures/make-command/tests/it_makes_a_command_with_arguments_and_options.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class GeneratedCommandTest extends KernelTestCase
+{
+    public function testCommand()
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+
+        $command = $application->find('app:foo');
+
+        $tester = new CommandTester($command);
+        $tester->execute(['recipient' => 'world']);
+
+        $this->assertStringContainsString('You have a new command', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
Closes #1699.

The first half of that issue landed with #1746: `make:command` generates an `__invoke()` method. This is the second half, asking for the arguments and the options so the signature comes out ready rather than as a sample to edit.

```
$ php bin/console make:command app:send-report

 New argument name (press <return> to stop adding arguments):
 > recipient
 Type [string]:
 Description [Recipient]: Who to send the report to
 Is it required? (yes/no) [no]: yes

 New argument name (press <return> to stop adding arguments):
 >

 New option name (press <return> to stop adding options):
 > dry-run
 Type [bool]:
 Description [Dry Run]: Do not send anything
```

```php
public function __invoke(
    SymfonyStyle $io,
    #[Argument('Who to send the report to')] string $recipient,
    #[Option('Do not send anything')] bool $dryRun = false,
): int {
```

The name is typed the way it reads on the command line, so `dry-run` becomes `$dryRun`. Besides the scalar types and `array`, the type can be a backed enum.

They can also be passed on the command line (thanks @GromNaN). The type defaults to `string` for an argument and `bool` for an option, the short name of an enum is enough when it is unique within `src/`, a `?` after the name makes an argument optional as in a PHP array shape, and passing any of them skips the questions:

```
$ php bin/console make:command app:send-report --argument=recipient --argument=cc?:array --option=dry-run --option=format:Format
```

A few decisions worth flagging:

* **Answering nothing keeps the sample argument and option**, so `--no-interaction`, where `interact()` never runs, and the person who just presses return through the questions still get a command that shows both attributes at work.
* **What the console component would refuse is refused up front.** A required argument after an optional one, any argument after an array one, a parameter named `io` (taken by `SymfonyStyle $io`), an argument and an option sharing a name, and an enum that is not backed all produce a command that fails to load. The questions skip or ask again, and the command line gets an error before anything is written.
* **An enum named like an import is aliased**: an `App\Enum\Option` comes in as `EnumOption`, since `Option` is the attribute.
* **The notes use `var_export()`**, so every type, enums included, is shown the same way.

I saw the run of `--no-interaction` fixes that just landed (#1816, #1817, #1818), and this maker does collect state in `interact()` and read it in `generate()`, which is the shape those removed. The properties are initialised, so there is nothing to crash on, but `it_makes_a_command_non_interactively` pins that down rather than leaving it to reading.

#### Testing

Seven functional tests, up from three: the questions, the command line (enums included), and the definitions it rejects. `MakeCommandTest` green, PHPStan green with the CI tooling.
