### PR TITLE
[make:schedule] Fix the crash under --no-interaction

### DIFF
--- a/src/Maker/MakeSchedule.php
+++ b/src/Maker/MakeSchedule.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker;
 
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Exception\RuntimeCommandException;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
@@ -20,6 +21,7 @@ use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
@@ -37,9 +39,8 @@ use Symfony\Contracts\Cache\CacheInterface;
  */
 final class MakeSchedule extends AbstractMaker
 {
-    private string $scheduleName;
-    private ?string $message = null;
-    private ?string $transportName = null;
+    /** @var string[]|null */
+    private ?array $availableMessages = null;
 
     public function __construct(
         private FileManager $fileManager,
@@ -60,11 +61,42 @@ final class MakeSchedule extends AbstractMaker
     public function configureCommand(Command $command, InputConfiguration $inputConfig): void
     {
         $command
+            ->addOption('transport-name', mode: InputOption::VALUE_OPTIONAL, description: 'What should we call the new transport? (To be used for the attribute #[AsSchedule(name)])')
+            ->addOption('message', mode: InputOption::VALUE_OPTIONAL, description: 'Which message in src/Message should the schedule use? Omit for an empty schedule.')
+            ->addOption('schedule-name', mode: InputOption::VALUE_OPTIONAL, description: 'What should we call the new schedule?')
             ->setHelp($this->getHelpFileContents('MakeScheduler.txt'))
         ;
     }
 
     public function interact(InputInterface $input, ConsoleStyle $io, Command $command): void
+    {
+        if (!$input->getOption('transport-name')) {
+            $input->setOption('transport-name', $io->ask('What should we call the new transport? (To be used for the attribute #[AsSchedule(name)])'));
+        }
+
+        if (!$input->getOption('message')) {
+            // Loop over existing src/Message/* and ask which message the user would like to schedule
+            $availableMessages = ['Empty Schedule', ...$this->findAvailableMessages()];
+
+            // If the count is 1, no other messages were found - don't ask to create a message
+            if (1 !== \count($availableMessages)) {
+                $selectedMessage = $io->choice('Select which message', $availableMessages);
+
+                if ('Empty Schedule' !== $selectedMessage) {
+                    $input->setOption('message', $selectedMessage);
+                }
+            }
+        }
+
+        if (!$input->getOption('schedule-name')) {
+            $input->setOption('schedule-name', $io->ask(
+                question: 'What should we call the new schedule?',
+                default: self::getDefaultScheduleName($input->getOption('message'))
+            ));
+        }
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         trigger_deprecation('symfony/maker-bundle', 'v1.63.0', '"make:schedule" is deprecated, install the symfony/scheduler recipe instead.');
 
@@ -75,42 +107,25 @@ final class MakeSchedule extends AbstractMaker
             $io->writeln('Scheduler successfully installed!');
         }
 
-        // Loop over existing src/Message/* and ask which message the user would like to schedule
-        $availableMessages = ['Empty Schedule'];
-        $messageDir = $this->fileManager->getRootDirectory().'/src/Message';
+        $message = $input->getOption('message');
 
-        if ($this->fileManager->fileExists($messageDir)) {
-            $finder = $this->finder->in($this->fileManager->getRootDirectory().'/src/Message');
+        if (null !== $message) {
+            $availableMessages = $this->findAvailableMessages();
 
-            foreach ($finder->files() as $file) {
-                $availableMessages[] = $file->getFilenameWithoutExtension();
+            if (!\in_array($message, $availableMessages, true)) {
+                $errorMessage = $availableMessages
+                    ? \sprintf('The message "%s" was not found in "src/Message". Available: "%s".', $message, implode('", "', $availableMessages))
+                    : \sprintf('The message "%s" was not found in "src/Message".', $message);
+
+                throw new RuntimeCommandException($errorMessage);
             }
         }
 
-        $this->transportName = $io->ask('What should we call the new transport? (To be used for the attribute #[AsSchedule(name)])');
+        $scheduleName = $input->getOption('schedule-name') ?: self::getDefaultScheduleName($message);
+        $transportName = $input->getOption('transport-name') ?: null;
 
-        $scheduleNameHint = 'MainSchedule';
-
-        // If the count is 1, no other messages were found - don't ask to create a message
-        if (1 !== \count($availableMessages)) {
-            $selectedMessage = $io->choice('Select which message', $availableMessages);
-
-            if ('Empty Schedule' !== $selectedMessage) {
-                $this->message = $selectedMessage;
-
-                // We don't want SomeMessageSchedule, so remove the "Message" suffix to give us SomeSchedule
-                $scheduleNameHint = \sprintf('%sSchedule', Str::removeSuffix($selectedMessage, 'Message'));
-            }
-        }
-
-        // Ask the name of the new schedule
-        $this->scheduleName = $io->ask(question: 'What should we call the new schedule?', default: $scheduleNameHint);
-    }
-
-    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
-    {
         $scheduleClassDetails = $generator->createClassNameDetails(
-            $this->scheduleName,
+            $scheduleName,
             'Scheduler\\',
         );
 
@@ -122,8 +137,8 @@ final class MakeSchedule extends AbstractMaker
             CacheInterface::class,
         ]);
 
-        if (null !== $this->message) {
-            $useStatements->addUseStatement('App\\Message\\'.$this->message);
+        if (null !== $message) {
+            $useStatements->addUseStatement('App\\Message\\'.$message);
         }
 
         $generator->generateClass(
@@ -131,10 +146,10 @@ final class MakeSchedule extends AbstractMaker
             'scheduler/Schedule.tpl.php',
             [
                 'use_statements' => $useStatements,
-                'has_custom_message' => null !== $this->message,
-                'message_class_name' => $this->message,
-                'has_transport_name' => null !== $this->transportName,
-                'transport_name' => $this->transportName,
+                'has_custom_message' => null !== $message,
+                'message_class_name' => $message,
+                'has_transport_name' => null !== $transportName,
+                'transport_name' => $transportName,
             ],
         );
 
@@ -145,5 +160,36 @@ final class MakeSchedule extends AbstractMaker
 
     public function configureDependencies(DependencyBuilder $dependencies): void
     {
+    }
+
+    /**
+     * @return string[]
+     */
+    private function findAvailableMessages(): array
+    {
+        if (null !== $this->availableMessages) {
+            return $this->availableMessages;
+        }
+
+        $messages = [];
+        $messageDir = $this->fileManager->getRootDirectory().'/src/Message';
+
+        if ($this->fileManager->fileExists($messageDir)) {
+            foreach ($this->finder->in($messageDir)->files() as $file) {
+                $messages[] = $file->getFilenameWithoutExtension();
+            }
+        }
+
+        return $this->availableMessages = $messages;
+    }
+
+    private static function getDefaultScheduleName(?string $message): string
+    {
+        if (null === $message) {
+            return 'MainSchedule';
+        }
+
+        // We don't want SomeMessageSchedule, so remove the "Message" suffix to give us SomeSchedule
+        return \sprintf('%sSchedule', Str::removeSuffix($message, 'Message'));
     }
 }

--- a/tests/Maker/MakeScheduleTest.php
+++ b/tests/Maker/MakeScheduleTest.php
@@ -106,5 +106,65 @@ class MakeScheduleTest extends MakerTestCase
                 );
             }),
         ];
+
+        yield 'it_generates_a_schedule_non_interactively' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([], '--no-interaction');
+
+                self::assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-schedule/expected/DefaultScheduleEmpty.php',
+                    $runner->getPath('src/Scheduler/MainSchedule.php')
+                );
+            }),
+        ];
+
+        yield 'it_generates_a_schedule_with_transport_name_non_interactively' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([], '--no-interaction --transport-name=dummy');
+
+                self::assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-schedule/expected/DefaultScheduleWithTransportName.php',
+                    $runner->getPath('src/Scheduler/MainSchedule.php')
+                );
+            }),
+        ];
+
+        yield 'it_generates_a_schedule_with_message_non_interactively' => [self::buildMakerTest()
+            ->preRun(static function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-schedule/standard_setup',
+                    ''
+                );
+            })
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([], '--no-interaction --message=MessageFixture');
+
+                self::assertStringContainsString('Success', $output);
+
+                self::assertFileEquals(
+                    \dirname(__DIR__).'/fixtures/make-schedule/expected/MyScheduleWithMessage.php',
+                    $runner->getPath('src/Scheduler/MessageFixtureSchedule.php')
+                );
+            }),
+        ];
+
+        yield 'it_rejects_unknown_message_non_interactively' => [self::buildMakerTest()
+            ->preRun(static function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-schedule/standard_setup',
+                    ''
+                );
+            })
+            ->run(static function (MakerTestRunner $runner) {
+                $output = $runner->runMaker([], '--no-interaction --message=DoesNotExist', allowedToFail: true);
+
+                self::assertStringContainsString('was not found', $output);
+                self::assertFileDoesNotExist($runner->getPath('src/Scheduler/DoesNotExistSchedule.php'));
+            }),
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

`make:schedule --no-interaction` crashes:

```
In MakeSchedule.php line 113:

  [Error]
  Typed property Symfony\Bundle\MakerBundle\Maker\MakeSchedule::$scheduleName
   must not be accessed before initialization
```

### Cause

`Command::run()` skips `interact()` entirely under `--no-interaction`.
`$scheduleName`, `$message` and `$transportName` were only ever set there,
and `generate()` reads them unconditionally.

### Fix

Same pattern as the rest of this series: the three answers move onto the
input, as `--schedule-name`, `--message` and `--transport-name`. `interact()`
asks only when an option is missing, same questions, same order, same
defaults. `generate()` reads the options and no longer touches a property.

A `--message` value is checked against the files in `src/Message` and
rejected by name when it does not match one, the same guarantee the
interactive choice list gives.

The `composer require symfony/scheduler` call moves from `interact()` to
`generate()`, since `interact()` never runs under `--no-interaction` and the
package still needs to be there.

### Tests

Added non-interactive cases: the default empty schedule, `--transport-name`,
an existing `--message`, and a rejection case for an unknown `--message`
name. The existing interactive cases are unchanged and still pass.

### Why

Part of the series making the makers usable by coding agents, which cannot
answer prompts. Last remaining crash in the maker list.
