### PR TITLE
[Security] Recognize "custom_authenticators" in InteractiveSecurityHelper

### DIFF
--- a/src/Security/InteractiveSecurityHelper.php
+++ b/src/Security/InteractiveSecurityHelper.php
@@ -289,7 +289,7 @@ final class InteractiveSecurityHelper
      *      pattern: ^/path
      *      form_login:
      *          login_path: app_login
-     *      custom_authenticator:
+     *      custom_authenticators:
      *          - App\Security\MyAuthenticator
      *
      * @param array<string, mixed> $firewallConfig
@@ -301,34 +301,27 @@ final class InteractiveSecurityHelper
         $authenticators = [];
 
         foreach ($firewallConfig as $potentialAuthenticator => $configData) {
-            // Check if $potentialAuthenticator is a supported authenticator or if its some other key.
+            // custom_authenticators (make:security:custom) and custom_authenticator (the
+            // deprecated make:auth) are both real keys found in the wild for the same thing.
+            if (\in_array($potentialAuthenticator, ['custom_authenticator', 'custom_authenticators'], true)) {
+                $authenticators = [...$authenticators, ...$this->getCustomAuthenticators($configData, $firewallName)];
+
+                continue;
+            }
+
             if (null === ($authenticator = AuthenticatorType::tryFrom($potentialAuthenticator))) {
                 // $potentialAuthenticator is probably something like "pattern" or "lazy", not an authenticator
                 continue;
             }
 
-            // $potentialAuthenticator is a supported authenticator. Check if it's a custom_authenticator.
-            if (AuthenticatorType::CUSTOM !== $authenticator) {
-                // We found a "built in" authenticator - "form_login", "json_login", etc...
-                $authenticators[] = new Authenticator($authenticator, $firewallName);
-
-                continue;
-            }
-
-            /*
-             * $potentialAuthenticator = custom_authenticator.
-             * $configData is either [App\MyAuthenticator] or (string) App\MyAuthenticator
-             */
-            $customAuthenticators = $this->getCustomAuthenticators($configData, $firewallName);
-
-            $authenticators = [...$authenticators, ...$customAuthenticators];
+            $authenticators[] = new Authenticator($authenticator, $firewallName);
         }
 
         return $authenticators;
     }
 
     /**
-     * @param string|array<string> $customAuthenticators A single entry from custom_authenticators or an array of authenticators
+     * @param string|array<string> $customAuthenticators A single entry from custom_authenticator(s) or an array of authenticators
      *
      * @return Authenticator[]
      */

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -131,6 +131,28 @@ class MakeRegistrationFormTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_resolves_auto_login_with_plural_custom_authenticators_key_non_interactively' => [self::createRegistrationFormTest()
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                // make:security:custom writes "custom_authenticators" (plural), not the
+                // "custom_authenticator" key the deprecated make:auth writes
+                $runner->modifyYamlFile('config/packages/security.yaml', static function (array $data) {
+                    $data['security']['firewalls']['main']['custom_authenticators'] = ['App\\Security\\StubAuthenticator'];
+
+                    return $data;
+                });
+
+                $output = $runner->runMaker([], '--no-interaction --auto-login --redirect-route=app_anonymous');
+
+                self::assertStringContainsString('Success', $output);
+
+                $fixturePath = \dirname(__DIR__, 1).'/fixtures/make-registration-form/expected';
+
+                self::assertFileEquals($fixturePath.'/RegistrationControllerCustomAuthenticator.php', $runner->getPath('src/Controller/RegistrationController.php'));
+            }),
+        ];
+
         yield 'it_notes_missing_authenticator_for_auto_login_non_interactively' => [self::createRegistrationFormTest()
             ->run(static function (MakerTestRunner $runner) {
                 self::makeUser($runner);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Found while testing the `--no-interaction` fixes from #1810–#1826 for real: a
custom authenticator generated by `make:security:custom` is invisible to
`InteractiveSecurityHelper`, so `--auto-login` and `--logout` never notice it
exists.

```php
$helper->getAuthenticatorsFromConfig([
    'main' => ['custom_authenticators' => ['App\Security\CustomAuthenticator']],
]);
// => [] (should contain one Authenticator)
```

### Cause

`make:security:custom` writes `custom_authenticators` (plural) to
`security.yaml`. `AuthenticatorType::CUSTOM` only maps the singular
`custom_authenticator`, the key the deprecated `make:auth` writes. The one
existing test for this path used the singular key, so it passed without ever
exercising the shape `make:security:custom` actually produces.

### Fix

Recognize both keys when scanning a firewall's config. Kept the singular
one, since projects and code generated by `make:auth` still use it.

### Why

Part of the series making the makers usable by coding agents (#1810–#1826).
This one is not about `--no-interaction`, but it was hiding behind the same
testing gap: a fixture that matched the code instead of what the maker
actually produces.
