### PR TITLE
Validate maker options before generating code

### DIFF
--- a/src/Maker/MakeAuthenticator.php
+++ b/src/Maker/MakeAuthenticator.php
@@ -227,6 +227,14 @@ final class MakeAuthenticator extends AbstractMaker
         $supportRememberMe = $input->hasArgument('support-remember-me') ? $input->getArgument('support-remember-me') : false;
         $alwaysRememberMe = $input->hasArgument('always-remember-me') && self::REMEMBER_ME_TYPE_ALWAYS === $input->getArgument('always-remember-me');
 
+        if (null !== $input->getArgument('authenticator-class')) {
+            $input->setArgument('authenticator-class', Validator::validateClassName($input->getArgument('authenticator-class')));
+        }
+
+        if ($input->hasArgument('username-field') && null !== $input->getArgument('username-field')) {
+            $input->setArgument('username-field', Validator::validatePhpStringLiteral($input->getArgument('username-field'), \sprintf('The username field "%s" cannot contain quotes or backslashes.', $input->getArgument('username-field'))));
+        }
+
         $this->generateAuthenticatorClass(
             $securityData,
             $input->getArgument('authenticator-type'),

--- a/src/Maker/MakeCommand.php
+++ b/src/Maker/MakeCommand.php
@@ -107,6 +107,9 @@ final class MakeCommand extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $commandName = trim($input->getArgument('name'));
+
+        $commandName = Validator::validatePhpStringLiteral($commandName, \sprintf('The command name "%s" cannot contain quotes or backslashes.', $commandName));
+
         $commandNameHasAppPrefix = str_starts_with($commandName, 'app:');
 
         $commandClassNameDetails = $generator->createClassNameDetails(

--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\MakerBundle\Maker\Common\CanGenerateTestsTrait;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
 use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -82,6 +83,9 @@ final class MakeController extends AbstractMaker
         $isInvokable = (bool) $input->getOption('invokable');
 
         $controllerClass = $input->getArgument('controller-class');
+
+        Validator::validateClassName($controllerClass, \sprintf('The controller class "%s" is not a valid class name.', $controllerClass));
+
         $controllerClassName = \sprintf('Controller\%s', $controllerClass);
 
         // If the class name provided is absolute, we do not assume it will live in src/Controller

--- a/src/Maker/MakeDecorator.php
+++ b/src/Maker/MakeDecorator.php
@@ -132,6 +132,10 @@ final class MakeDecorator extends AbstractMaker
     {
         $id = $input->getArgument('id');
 
+        if (!class_exists($id)) {
+            $id = Validator::validatePhpStringLiteral($id, \sprintf('The service id "%s" cannot contain quotes or backslashes.', $id));
+        }
+
         $classNameDetails = $generator->createClassNameDetails(
             Validator::validateClassName(Validator::classDoesNotExist($input->getArgument('decorator-class'))),
             '',

--- a/src/Maker/MakeListener.php
+++ b/src/Maker/MakeListener.php
@@ -157,7 +157,7 @@ final class MakeListener extends AbstractMaker
             $event = $eventFullClassName;
         }
 
-        $eventName = class_exists($event) ? \sprintf('%s::class', $eventClassName) : \sprintf('\'%s\'', $event);
+        $eventName = class_exists($event) ? \sprintf('%s::class', $eventClassName) : \sprintf('\'%s\'', Validator::validatePhpStringLiteral($event, \sprintf('The event "%s" cannot contain quotes or backslashes.', $event)));
 
         if (null !== $eventFullClassName) {
             $useStatements->addUseStatement($eventFullClassName);

--- a/src/Maker/MakeMessage.php
+++ b/src/Maker/MakeMessage.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
 use Symfony\Bundle\MakerBundle\Util\YamlSourceManipulator;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -88,6 +89,10 @@ final class MakeMessage extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $chosenTransport = $input->getArgument('chosen-transport');
+
+        if (null !== $chosenTransport) {
+            $chosenTransport = Validator::validatePhpStringLiteral($chosenTransport, \sprintf('The transport "%s" cannot contain quotes or backslashes.', $chosenTransport));
+        }
 
         $messageClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -299,11 +299,15 @@ final class MakeRegistrationForm extends AbstractMaker
             throw new RuntimeCommandException(\sprintf('The login field of "%s" cannot be guessed, pass it with "--username-field".', $userClass));
         }
 
+        $usernameField = Validator::validatePropertyName($usernameField, \sprintf('The "--username-field" value "%s" is not a valid PHP property name.', $usernameField));
+
         $passwordField = $input->getOption('password-field') ?: $securityHelper->findPasswordField($userClass);
 
         if (!$passwordField) {
             throw new RuntimeCommandException(\sprintf('The password property of "%s" cannot be guessed, pass it with "--password-field".', $userClass));
         }
+
+        $passwordField = Validator::validatePropertyName($passwordField, \sprintf('The "--password-field" value "%s" is not a valid PHP property name.', $passwordField));
 
         $addUniqueEntityConstraint = (bool) $input->getOption('unique-entity');
         $willVerifyEmail = (bool) $input->getOption('verify-email');
@@ -318,9 +322,13 @@ final class MakeRegistrationForm extends AbstractMaker
                 throw new RuntimeCommandException(\sprintf('"%s" has no "getId()" method, pass the getter with "--id-getter".', $userClass));
             }
 
+            $idGetter = Validator::validatePropertyName($idGetter, \sprintf('The "--id-getter" value "%s" is not a valid PHP method name.', $idGetter));
+
             if (!$emailGetter) {
                 throw new RuntimeCommandException(\sprintf('"%s" has no "getEmail()" method, pass the getter with "--email-getter".', $userClass));
             }
+
+            $emailGetter = Validator::validatePropertyName($emailGetter, \sprintf('The "--email-getter" value "%s" is not a valid PHP method name.', $emailGetter));
 
             $fromEmailAddress = Validator::validateEmailAddress($input->getOption('from-email-address'));
             $fromEmailName = Validator::notBlank($input->getOption('from-email-name'));
@@ -328,6 +336,14 @@ final class MakeRegistrationForm extends AbstractMaker
 
         $autoLoginAuthenticator = $this->resolveAuthenticator($input, $io, $securityHelper, $securityData);
         $redirectRouteName = $input->getOption('redirect-route');
+
+        if ($redirectRouteName) {
+            $redirectRouteName = Validator::validatePhpStringLiteral($redirectRouteName, \sprintf('The "--redirect-route" value "%s" cannot contain quotes or backslashes.', $redirectRouteName));
+
+            if ($this->router instanceof RouterInterface && !\in_array($redirectRouteName, array_keys($this->router->getRouteCollection()->all()), true)) {
+                throw new RuntimeCommandException(\sprintf('The "--redirect-route" value "%s" does not match any existing route. Pass the name of an existing route.', $redirectRouteName));
+            }
+        }
 
         $userClassNameDetails = $generator->createClassNameDetails(
             '\\'.$userClass,
@@ -367,7 +383,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 'email_verifier_class_details' => $verifyEmailServiceClassNameDetails,
                 'verify_email_anonymously' => $verifyEmailAnonymously,
                 'from_email' => $fromEmailAddress,
-                'from_email_name' => addslashes($fromEmailName),
+                'from_email_name' => $fromEmailName,
                 'email_getter' => $emailGetter,
             ];
 

--- a/src/Maker/MakeResetPassword.php
+++ b/src/Maker/MakeResetPassword.php
@@ -245,11 +245,15 @@ class MakeResetPassword extends AbstractMaker
             throw new RuntimeCommandException(\sprintf('The email property of "%s" cannot be guessed, pass it with "--email-field".', $userClass));
         }
 
+        $emailPropertyName = Validator::validatePropertyName($emailPropertyName, \sprintf('The "--email-field" value "%s" is not a valid PHP property name.', $emailPropertyName));
+
         $emailGetterMethodName = $input->getOption('email-getter') ?: $securityHelper->findEmailGetter($userClass, $emailPropertyName);
 
         if (!$emailGetterMethodName) {
             throw new RuntimeCommandException(\sprintf('"%s" has no "get%s()" method, pass the getter with "--email-getter".', $userClass, ucfirst($emailPropertyName)));
         }
+
+        $emailGetterMethodName = Validator::validatePropertyName($emailGetterMethodName, \sprintf('The "--email-getter" value "%s" is not a valid PHP method name.', $emailGetterMethodName));
 
         $passwordSetterMethodName = $input->getOption('password-setter') ?: $securityHelper->findPasswordSetter($userClass);
 
@@ -257,7 +261,10 @@ class MakeResetPassword extends AbstractMaker
             throw new RuntimeCommandException(\sprintf('"%s" has no "setPassword()" method, pass the setter with "--password-setter".', $userClass));
         }
 
+        $passwordSetterMethodName = Validator::validatePropertyName($passwordSetterMethodName, \sprintf('The "--password-setter" value "%s" is not a valid PHP method name.', $passwordSetterMethodName));
+
         $controllerResetSuccessRedirect = $input->getOption('success-redirect-route') ?: 'app_home';
+        $controllerResetSuccessRedirect = Validator::validatePhpStringLiteral($controllerResetSuccessRedirect, \sprintf('The "--success-redirect-route" value "%s" cannot contain quotes or backslashes.', $controllerResetSuccessRedirect));
         $fromEmailAddress = Validator::validateEmailAddress($input->getOption('from-email-address'));
         $fromEmailName = Validator::notBlank($input->getOption('from-email-name'));
 

--- a/src/Maker/MakeSchedule.php
+++ b/src/Maker/MakeSchedule.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -123,6 +124,10 @@ final class MakeSchedule extends AbstractMaker
 
         $scheduleName = $input->getOption('schedule-name') ?: self::getDefaultScheduleName($message);
         $transportName = $input->getOption('transport-name') ?: null;
+
+        if (null !== $transportName) {
+            $transportName = Validator::validatePhpStringLiteral($transportName, \sprintf('The "--transport-name" value "%s" cannot contain quotes or backslashes.', $transportName));
+        }
 
         $scheduleClassDetails = $generator->createClassNameDetails(
             $scheduleName,

--- a/src/Maker/MakeSerializerEncoder.php
+++ b/src/Maker/MakeSerializerEncoder.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Util\UseStatementGenerator;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -55,6 +56,10 @@ final class MakeSerializerEncoder extends AbstractMaker
             'Encoder'
         );
         $format = $input->getArgument('format');
+
+        if (null !== $format) {
+            $format = Validator::validatePhpStringLiteral($format, \sprintf('The format "%s" cannot contain quotes or backslashes.', $format));
+        }
 
         $useStatements = new UseStatementGenerator([
             DecoderInterface::class,

--- a/src/Maker/MakeSubscriber.php
+++ b/src/Maker/MakeSubscriber.php
@@ -97,7 +97,7 @@ final class MakeSubscriber extends AbstractMaker
             $useStatements->addUseStatement(KernelEvents::class);
             $eventName = $eventConstant;
         } else {
-            $eventName = class_exists($event) ? \sprintf('%s::class', $eventClassName) : \sprintf('\'%s\'', $event);
+            $eventName = class_exists($event) ? \sprintf('%s::class', $eventClassName) : \sprintf('\'%s\'', Validator::validatePhpStringLiteral($event, \sprintf('The event "%s" cannot contain quotes or backslashes.', $event)));
         }
 
         if (null !== $eventFullClassName) {

--- a/src/Maker/MakeTwigExtension.php
+++ b/src/Maker/MakeTwigExtension.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,8 +49,14 @@ final class MakeTwigExtension extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        $twigExtensionName = $input->getArgument('name');
+
+        if (null !== $twigExtensionName) {
+            Validator::validateClassName($twigExtensionName, \sprintf('The Twig extension name "%s" is not a valid class name.', $twigExtensionName));
+        }
+
         $extensionClassData = ClassData::create(
-            class: \sprintf('Twig\%s', $input->getArgument('name')),
+            class: \sprintf('Twig\%s', $twigExtensionName),
             suffix: 'Extension',
             useStatements: [
                 AsTwigFilter::class,

--- a/src/Maker/MakeUser.php
+++ b/src/Maker/MakeUser.php
@@ -122,6 +122,10 @@ final class MakeUser extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        if (null !== ($identityPropertyName = $input->getOption('identity-property-name'))) {
+            $input->setOption('identity-property-name', Validator::validatePropertyName($identityPropertyName, \sprintf('The "--identity-property-name" value "%s" is not a valid PHP property name.', $identityPropertyName)));
+        }
+
         $userClassConfiguration = new UserClassConfiguration(
             $input->getOption('is-entity'),
             $input->getOption('identity-property-name'),

--- a/src/Maker/MakeValidator.php
+++ b/src/Maker/MakeValidator.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -52,8 +53,14 @@ final class MakeValidator extends AbstractMaker
     /** @return void */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator)
     {
+        $validatorName = $input->getArgument('name');
+
+        if (null !== $validatorName) {
+            Validator::validateClassName($validatorName, \sprintf('The validator name "%s" is not a valid class name.', $validatorName));
+        }
+
         $validatorClassData = ClassData::create(
-            class: \sprintf('Validator\\%s', $input->getArgument('name')),
+            class: \sprintf('Validator\\%s', $validatorName),
             suffix: 'Validator',
             extendsClass: ConstraintValidator::class,
             useStatements: [

--- a/src/Maker/MakeVoter.php
+++ b/src/Maker/MakeVoter.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -50,8 +51,14 @@ final class MakeVoter extends AbstractMaker
 
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
+        $voterName = $input->getArgument('name');
+
+        if (null !== $voterName) {
+            Validator::validateClassName($voterName, \sprintf('The voter name "%s" is not a valid class name.', $voterName));
+        }
+
         $voterClassData = ClassData::create(
-            class: \sprintf('Security\Voter\%s', $input->getArgument('name')),
+            class: \sprintf('Security\Voter\%s', $voterName),
             suffix: 'Voter',
             extendsClass: Voter::class,
             useStatements: [

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -145,14 +145,24 @@ final class Validator
         return $valueAsBool;
     }
 
-    public static function validatePropertyName(string $name): string
+    public static function validatePropertyName(string $name, string $errorMessage = ''): string
     {
         // check for valid PHP variable name
         if (!Str::isValidPhpVariableName($name)) {
-            throw new \InvalidArgumentException(\sprintf('"%s" is not a valid PHP property name.', $name));
+            throw new RuntimeCommandException($errorMessage ?: \sprintf('"%s" is not a valid PHP property name.', $name));
         }
 
         return $name;
+    }
+
+    public static function validatePhpStringLiteral(string $value, string $errorMessage = ''): string
+    {
+        // a quote, a backslash or a control character would break the generated code
+        if (preg_match('/[\'\\\\\x00-\x1f\x7f]/', $value)) {
+            throw new RuntimeCommandException($errorMessage ?: \sprintf('"%s" cannot be used as it contains a quote, a backslash, or a control character.', $value));
+        }
+
+        return $value;
     }
 
     public static function validateDoctrineFieldName(string $name, ManagerRegistry $registry): string

--- a/templates/registration/RegistrationController.tpl.php
+++ b/templates/registration/RegistrationController.tpl.php
@@ -33,7 +33,7 @@ class <?= $class_name; ?> extends AbstractController
             // generate a signed url and email it to the user
             $this->emailVerifier->sendEmailConfirmation('app_verify_email', $user,
                 (new TemplatedEmail())
-                    ->from(new Address('<?= $from_email ?>', '<?= $from_email_name ?>'))
+                    ->from(new Address('<?= $from_email ?>', '<?= addslashes($from_email_name) ?>'))
                     ->to((string) $user-><?= $email_getter ?>())
                     ->subject('Please Confirm your Email')
                     ->htmlTemplate('registration/confirmation_email.html.twig')

--- a/templates/resetPassword/ResetPasswordController.tpl.php
+++ b/templates/resetPassword/ResetPasswordController.tpl.php
@@ -139,7 +139,7 @@ class <?= $class_name ?> extends AbstractController
         }
 
         $email = (new TemplatedEmail())
-            ->from(new Address('<?= $from_email ?>', '<?= $from_email_name ?>'))
+            ->from(new Address('<?= $from_email ?>', '<?= addslashes($from_email_name) ?>'))
             ->to((string) $user-><?= $email_getter ?>())
             ->subject('Your password reset request')
             ->htmlTemplate('reset_password/email.html.twig')

--- a/tests/Maker/MakeRegistrationFormTest.php
+++ b/tests/Maker/MakeRegistrationFormTest.php
@@ -93,6 +93,45 @@ class MakeRegistrationFormTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_rejects_invalid_identifier_options_non_interactively' => [self::createRegistrationFormTest()
+            ->addExtraDependencies('symfonycasts/verify-email-bundle')
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $invalid = [
+                    '--no-interaction --redirect-route=app_anonymous --username-field="user-email"' => 'The "--username-field" value "user-email" is not a valid PHP property name',
+                    '--no-interaction --redirect-route=app_anonymous --password-field="pass word"' => 'The "--password-field" value "pass word" is not a valid PHP property name',
+                    '--no-interaction --redirect-route=app_anonymous --verify-email --from-email-address=jr@rushlow.dev --from-email-name=SymfonyCasts --id-getter="get;Id"' => 'The "--id-getter" value "get;Id" is not a valid PHP method name',
+                    '--no-interaction --redirect-route=app_anonymous --verify-email --from-email-address=jr@rushlow.dev --from-email-name=SymfonyCasts --email-getter="get@Email"' => 'The "--email-getter" value "get@Email" is not a valid PHP method name',
+                    '--no-interaction --redirect-route=this_route_does_not_exist' => 'does not match any existing route',
+                ];
+
+                foreach ($invalid as $arguments => $expectedError) {
+                    $output = $runner->runMaker([], $arguments, allowedToFail: true);
+
+                    // the error box wraps long messages, normalize the whitespace before comparing
+                    self::assertStringContainsString($expectedError, preg_replace('/\s+/', ' ', $output), \sprintf('"%s" was not rejected.', $arguments));
+                    self::assertFileDoesNotExist($runner->getPath('src/Controller/RegistrationController.php'));
+                }
+            }),
+        ];
+
+        yield 'it_escapes_from_email_name_non_interactively' => [self::createRegistrationFormTest()
+            ->addExtraDependencies('symfonycasts/verify-email-bundle')
+            ->run(static function (MakerTestRunner $runner) {
+                self::makeUser($runner);
+
+                $runner->runMaker(
+                    [],
+                    '--no-interaction --redirect-route=app_anonymous --unique-entity --verify-email'
+                    .' --from-email-address=jr@rushlow.dev --from-email-name="O\'Brien"'
+                );
+
+                $controller = file_get_contents($runner->getPath('src/Controller/RegistrationController.php'));
+                self::assertStringContainsString("->from(new Address('jr@rushlow.dev', 'O\\'Brien'))", $controller);
+            }),
+        ];
+
         yield 'it_generates_registration_form_non_interactively_with_auto_login' => [self::createRegistrationFormTest()
             ->run(static function (MakerTestRunner $runner) {
                 self::makeUser($runner);

--- a/tests/Maker/MakeResetPasswordTest.php
+++ b/tests/Maker/MakeResetPasswordTest.php
@@ -33,7 +33,6 @@ class MakeResetPasswordTest extends MakerTestCase
                 self::makeUser($runner);
 
                 $output = $runner->runMaker([
-                    'App\Entity\User',
                     'app_home',
                     'jr@rushlow.dev',
                     'SymfonyCasts',
@@ -149,7 +148,6 @@ class MakeResetPasswordTest extends MakerTestCase
                 self::makeUser($runner);
 
                 $output = $runner->runMaker([
-                    'App\Entity\User',
                     'app_home',
                     'jr@rushlow.dev',
                     'SymfonyCasts',
@@ -209,7 +207,6 @@ class MakeResetPasswordTest extends MakerTestCase
                 self::makeUser($runner);
 
                 $output = $runner->runMaker([
-                    'App\Entity\User',
                     'app_home',
                     'jr@rushlow.dev',
                     'SymfonyCasts',
@@ -270,7 +267,6 @@ class MakeResetPasswordTest extends MakerTestCase
                 self::makeUser($runner);
 
                 $output = $runner->runMaker([
-                    'App\Entity\User',
                     'app_home',
                     'victor@symfonycasts.com',
                     'SymfonyCasts',
@@ -295,7 +291,6 @@ class MakeResetPasswordTest extends MakerTestCase
                 self::makeUser($runner);
 
                 $output = $runner->runMaker([
-                    'App\Entity\User',
                     'app_home',
                     'jr@rushlow.dev',
                     'SymfonyCasts',
@@ -324,7 +319,6 @@ class MakeResetPasswordTest extends MakerTestCase
                 self::makeUser($runner);
 
                 $output = $runner->runMaker([
-                    'App\Entity\User',
                     'app_home',
                     'jr@rushlow.dev',
                     'SymfonyCasts',


### PR DESCRIPTION
The makers reject invalid values instead of dumping invalid values in the templates.

MakeRegistrationForm and MakeResetPassword validate the field and getter options as PHP identifiers, and the route options as strings without quotes or backslashes. The `from-email-name` is escaped in the generated controllers so a display name such as "O'Brien" is preserved.

The same checks apply to the other makers that inject raw user input into the generated PHP: class names are checked with `validateClassName`, and values embedded in single-quoted literals with `validatePhpStringLiteral`. This covers MakeAuthenticator, MakeCommand, MakeController, MakeDecorator, MakeListener, MakeMessage, MakeSchedule, MakeSerializerEncoder, MakeSubscriber, MakeTwigExtension, MakeUser, MakeValidator and MakeVoter.

`validateClassName` and `validatePropertyName` now throw a `RuntimeCommandException`, consistent with the rest of the Validator class.

The `reset-password` interactive tests passed the user class as the redirect route answer because the class is guessed from `security.yaml`. The fixtures now provide the route directly.