### PR TITLE
[make:crud] Fix crash when the entity class name is left blank

### DIFF
--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -86,11 +86,10 @@ final class MakeCrud extends AbstractMaker
             $entities = $this->doctrineHelper->getEntitiesForAutocomplete();
 
             $question = new Question($argument->getDescription());
+            $question->setValidator(static fn ($answer) => Validator::entityExists($answer, $entities));
             $question->setAutocompleterValues($entities);
 
-            $value = $io->askQuestion($question);
-
-            $input->setArgument('entity-class', $value);
+            $input->setArgument('entity-class', $io->askQuestion($question));
         }
 
         if (null === $input->getOption('controller-class')) {

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -45,6 +45,28 @@ class MakeCrudTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_asks_again_when_entity_class_is_blank' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-crud/SweetFood.php',
+                    'src/Entity/SweetFood.php'
+                );
+
+                // a blank entity class name triggers a validation error, then re-asks the question
+                $output = $runner->runMaker([
+                    '',          // blank entity class name,
+                    'SweetFood', // entity class name
+                    '',          // default controller,
+                    'n',         // Generate Tests
+                ]);
+
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
+
+                self::runCrudTest($runner, 'it_generates_basic_crud.php');
+            }),
+        ];
+
         yield 'it_generates_crud_with_custom_controller' => [self::buildMakerTest()
             ->run(static function (MakerTestRunner $runner) {
                 $runner->copy(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Running `make:crud` interactively and pressing Enter without typing an entity class name crashed with a TypeError:

    Symfony\Bundle\MakerBundle\Maker\MakeCrud::getDefaultControllerClass(): Argument #1 ($entityClass) must be of type string, null given

### Cause

The interactive question for the entity class name returned `null` when left blank, and `MakeCrud::interact()` passed that value to `getDefaultControllerClass()`, whose parameter is typed `string`.

### Fix

The question now validates the answer with `Validator::entityExists()`, the pattern already used in `MakeForm`. A blank or unknown entity class name is rejected with a clear message and the question is asked again until a valid entity is provided.
