### PR TITLE
[make:*] Fix crash when PHPUnit is not installed

### DIFF
--- a/src/Maker/MakeController.php
+++ b/src/Maker/MakeController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MakerBundle\Maker;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
@@ -143,7 +144,7 @@ final class MakeController extends AbstractMaker
                 'route_path' => Str::asRoutePath($controllerClassData->getClassName(relative: true, withoutSuffix: true)),
             ]);
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/MakeCrud.php
+++ b/src/Maker/MakeCrud.php
@@ -16,6 +16,7 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -284,7 +285,7 @@ final class MakeCrud extends AbstractMaker
                 ]
             );
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/MakeRegistrationForm.php
+++ b/src/Maker/MakeRegistrationForm.php
@@ -15,6 +15,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -552,7 +553,7 @@ final class MakeRegistrationForm extends AbstractMaker
                 ], $userRepoVars)
             );
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/src/Maker/Security/MakeFormLogin.php
+++ b/src/Maker/Security/MakeFormLogin.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MakerBundle\Maker\Security;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -236,7 +237,7 @@ final class MakeFormLogin extends AbstractMaker
                 ],
             );
 
-            if (!class_exists(WebTestCase::class)) {
+            if (!class_exists(TestCase::class)) {
                 $io->caution('You\'ll need to install the `symfony/test-pack` to execute the tests for your new controller.');
             }
         }

--- a/tests/Maker/MakeCrudTest.php
+++ b/tests/Maker/MakeCrudTest.php
@@ -125,6 +125,33 @@ class MakeCrudTest extends MakerTestCase
             }),
         ];
 
+        yield 'it_generates_crud_with_tests_when_phpunit_is_not_installed' => [self::buildMakerTest()
+            ->run(static function (MakerTestRunner $runner) {
+                $runner->copy(
+                    'make-crud/SweetFood.php',
+                    'src/Entity/SweetFood.php'
+                );
+
+                // Simulate a project without PHPUnit installed: generating tests must not crash.
+                $runner->writeFile(
+                    'remove_phpunit.php',
+                    '<?php $config = json_decode(file_get_contents("composer.json"), true); unset($config["require-dev"]["phpunit/phpunit"]); file_put_contents("composer.json", json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));',
+                );
+                $runner->runProcess('php remove_phpunit.php && composer update --no-interaction && rm remove_phpunit.php');
+
+                $output = $runner->runMaker([
+                    'SweetFood', // Entity Class Name
+                    '',          // Default Controller,
+                    'y',         // Generate Tests
+                ]);
+
+                self::assertStringContainsString('src/Controller/SweetFoodController.php', $output);
+                self::assertStringContainsString('src/Form/SweetFoodType.php', $output);
+                self::assertStringContainsString('tests/Controller/SweetFoodControllerTest.php', $output);
+                self::assertStringContainsString('symfony/test-pack', $output);
+            }),
+        ];
+
         yield 'it_generates_correct_class_methods' => [self::buildMakerTest()
             ->addExtraDependencies('symfony/test-pack')
             ->run(static function (MakerTestRunner $runner) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Fixed tickets | #1830
| License       | MIT

Running `make:crud` with `--with-tests` in a project without PHPUnit installed crashed with:

    Class "PHPUnit\Framework\TestCase" not found

### Cause

`MakeCrud`, `MakeController`, `MakeRegistrationForm` and `MakeFormLogin` checked the availability of the test runner with `class_exists(WebTestCase::class)`. `WebTestCase` belongs to `symfony/framework-bundle` and is always autoloadable, but loading it requires its parent class `PHPUnit\Framework\TestCase`, which is absent when PHPUnit is not installed. The `class_exists` call then throws.

### Fix

The check now targets `PHPUnit\Framework\TestCase`, which returns `false` cleanly when PHPUnit is absent. The makers no longer crash and simply display the caution telling the user to install `symfony/test-pack` to run the generated tests.
